### PR TITLE
fix: 動画グループで動画選択時にプレイヤーが切り替わらない問題を修正

### DIFF
--- a/frontend/app/videos/groups/[id]/page.tsx
+++ b/frontend/app/videos/groups/[id]/page.tsx
@@ -338,8 +338,12 @@ export default function VideoGroupDetailPage() {
               <CardContent className="flex-1 flex items-center justify-center">
                 {selectedVideo ? (
                   selectedVideo.file ? (
-                    <video controls className="w-full max-h-[500px] rounded">
-                      <source src={selectedVideo.file} type="video/mp4" />
+                    <video
+                      key={selectedVideo.id}
+                      controls
+                      className="w-full max-h-[500px] rounded"
+                      src={selectedVideo.file}
+                    >
                       お使いのブラウザは動画タグをサポートしていません。
                     </video>
                   ) : (


### PR DESCRIPTION
- video要素にkey属性を追加して、動画選択時に要素を再マウントするように修正
- sourceタグではなくsrc属性を使用してブラウザの再読み込みを確実にする