### PR TITLE
fix: 動画詳細ページでloadVideo関数を呼び出すように修正

### DIFF
--- a/frontend/app/videos/[id]/page.tsx
+++ b/frontend/app/videos/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter, useParams } from 'next/navigation';
+import { useEffect } from 'react';
 import { useVideo } from '@/hooks/useVideos';
 import { useAsyncState } from '@/hooks/useAsyncState';
 import { apiClient } from '@/lib/api';
@@ -18,7 +19,13 @@ export default function VideoDetailPage() {
   const router = useRouter();
   const videoId = params?.id ? parseInt(params.id as string) : null;
 
-  const { video, isLoading, error } = useVideo(videoId);
+  const { video, isLoading, error, loadVideo } = useVideo(videoId);
+
+  useEffect(() => {
+    if (videoId) {
+      loadVideo();
+    }
+  }, [videoId, loadVideo]);
   
   const { isLoading: isDeleting, error: deleteError, mutate: handleDelete } = useAsyncState({
     onSuccess: () => router.push('/videos'),


### PR DESCRIPTION
- useVideoフックからloadVideo関数を取得
- useEffectでvideoIdが存在する場合にloadVideo()を呼び出し
- 動画詳細ページでデータが正しく読み込まれるように修正

Fixes: http://localhost:3000/videos/3で動画が見つかりませんと表示される問題