### PR TITLE
feat: チャットから関連動画を表示・再生する機能を追加

### DIFF
--- a/frontend/app/videos/groups/[id]/page.tsx
+++ b/frontend/app/videos/groups/[id]/page.tsx
@@ -226,6 +226,32 @@ export default function VideoGroupDetailPage() {
     }
   };
 
+  // チャットから動画を選択して指定時間から再生する関数
+  const handleVideoPlayFromTime = (videoId: number, startTime: string) => {
+    // 時間文字列を秒に変換
+    const timeToSeconds = (timeStr: string): number => {
+      const parts = timeStr.split(':');
+      if (parts.length === 2) {
+        const minutes = parseInt(parts[0], 10);
+        const seconds = parseInt(parts[1], 10);
+        return minutes * 60 + seconds;
+      }
+      return 0;
+    };
+
+    // 動画を選択
+    handleVideoSelect(videoId);
+    
+    // 少し遅延してから時間を設定（動画要素がレンダリングされるまで待つ）
+    setTimeout(() => {
+      const videoElement = document.querySelector('video') as HTMLVideoElement;
+      if (videoElement) {
+        videoElement.currentTime = timeToSeconds(startTime);
+        videoElement.play();
+      }
+    }, 100);
+  };
+
   // ドラッグエンドハンドラー
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
@@ -468,7 +494,11 @@ export default function VideoGroupDetailPage() {
 
           {/* 右側：チャット */}
           <div className="col-span-3">
-            <ChatPanel hasApiKey={!!user?.encrypted_openai_api_key} groupId={groupId ?? undefined} />
+            <ChatPanel 
+              hasApiKey={!!user?.encrypted_openai_api_key} 
+              groupId={groupId ?? undefined}
+              onVideoPlay={handleVideoPlayFromTime}
+            />
           </div>
         </div>
         </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -29,9 +29,17 @@ export interface LoginRequest {
   password: string;
 }
 
+export interface RelatedVideo {
+  video_id: number;
+  title: string;
+  start_time: string;
+  end_time: string;
+}
+
 export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
+  related_videos?: RelatedVideo[];
 }
 
 export interface ChatRequest {


### PR DESCRIPTION
- バックエンドでRAG検索結果の関連動画情報をレスポンスに含める
- フロントエンドで関連動画を横スクロールカードで表示
- グループ画面でチャットから動画を指定時間から再生可能
- シンプルで統一感のあるデザインに調整