### PR TITLE
feat: nginxのclient_max_body_sizeを300Mに設定

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -6,6 +6,8 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    client_max_body_size 300M;
+
     upstream backend {
         server 192.168.113.107:8000;
     }


### PR DESCRIPTION
大きなファイルのアップロードに対応するため、nginxのclient_max_body_sizeを300Mに設定しました。