### PR TITLE
feat: localStorageからHttpOnly Cookie認証に変更してXSS攻撃を防止

### DIFF
--- a/backend/app/auth/urls.py
+++ b/backend/app/auth/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import LoginView, MeView, RefreshView, UserSignupView
+from .views import LoginView, LogoutView, MeView, RefreshView, UserSignupView
 
 urlpatterns = [
     path("signup/", UserSignupView.as_view(), name="signup"),
     path("login/", LoginView.as_view(), name="auth-login"),
+    path("logout/", LogoutView.as_view(), name="auth-logout"),
     path("refresh/", RefreshView.as_view(), name="auth-refresh"),
-    path("me", MeView.as_view(), name="auth-me"),
+    path("me/", MeView.as_view(), name="auth-me"),
 ]

--- a/backend/app/auth/views.py
+++ b/backend/app/auth/views.py
@@ -62,6 +62,20 @@ class LoginView(PublicAPIView):
         return response
 
 
+class LogoutView(AuthenticatedAPIView):
+    """ログアウトビュー"""
+
+    def post(self, request):
+        """HttpOnly Cookieを削除してログアウト"""
+        response = Response({"message": "ログアウトしました"})
+        
+        # HttpOnly Cookieを削除
+        response.delete_cookie("access_token")
+        response.delete_cookie("refresh_token")
+        
+        return response
+
+
 class RefreshView(PublicAPIView):
     """トークンリフレッシュビュー"""
 

--- a/backend/app/authentication.py
+++ b/backend/app/authentication.py
@@ -1,0 +1,44 @@
+"""
+認証関連のクラス定義
+"""
+
+from rest_framework.request import Request
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken
+
+
+class CookieJWTAuthentication(JWTAuthentication):
+    """
+    Cookie または Authorization ヘッダーから JWT トークンを取得する認証クラス
+
+    優先順位:
+    1. Authorization ヘッダー (API リクエスト用)
+    2. HttpOnly Cookie (動画ストリーミング用)
+    """
+
+    def authenticate(self, request: Request):
+        print(f"🍪 CookieJWTAuthentication: Received cookies: {request.COOKIES}")
+        
+        # まず Authorization ヘッダーから認証を試みる
+        header_auth = super().authenticate(request)
+        if header_auth is not None:
+            print("🍪 CookieJWTAuthentication: Header auth successful")
+            return header_auth
+
+        # Cookie から access_token を取得
+        raw_token = request.COOKIES.get("access_token")
+        print(f"🍪 CookieJWTAuthentication: Raw token from cookie: {raw_token[:20] if raw_token else None}...")
+        
+        if raw_token is None:
+            print("🍪 CookieJWTAuthentication: No access_token cookie found")
+            return None
+
+        try:
+            validated_token = self.get_validated_token(raw_token)
+            user = self.get_user(validated_token)
+            print(f"🍪 CookieJWTAuthentication: Cookie auth successful for user: {user.username}")
+            return user, validated_token
+        except InvalidToken as e:
+            print(f"🍪 CookieJWTAuthentication: Invalid token error: {e}")
+            return None
+

--- a/backend/app/chat/views.py
+++ b/backend/app/chat/views.py
@@ -3,7 +3,7 @@ from app.utils.encryption import decrypt_api_key
 from app.utils.responses import create_error_response
 from app.utils.vector_manager import PGVectorManager
 from app.views import ShareTokenAuthentication, IsAuthenticatedOrSharedAccess
-from rest_framework_simplejwt.authentication import JWTAuthentication
+from app.authentication import CookieJWTAuthentication
 from langchain_community.vectorstores import PGVector
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_openai import OpenAIEmbeddings
@@ -19,7 +19,7 @@ from .langchain_utils import get_langchain_llm, handle_langchain_exception
 class ChatView(generics.CreateAPIView):
     """チャットビュー（LangChain使用・共有トークン対応）"""
 
-    authentication_classes = [JWTAuthentication, ShareTokenAuthentication]
+    authentication_classes = [CookieJWTAuthentication, ShareTokenAuthentication]
     permission_classes = [IsAuthenticatedOrSharedAccess]
 
     def post(self, request):

--- a/backend/app/utils/mixins.py
+++ b/backend/app/utils/mixins.py
@@ -1,14 +1,14 @@
 """共通のミックスイン（DRY原則）"""
 
 from rest_framework.permissions import AllowAny, IsAuthenticated
-from rest_framework_simplejwt.authentication import JWTAuthentication
+from app.authentication import CookieJWTAuthentication
 
 
 class AuthenticatedViewMixin:
     """認証必須の共通ミックスイン（DRY原則）"""
 
     permission_classes = [IsAuthenticated]
-    authentication_classes = [JWTAuthentication]
+    authentication_classes = [CookieJWTAuthentication]
 
     def get_serializer_context(self):
         """シリアライザーにリクエストコンテキストを渡す（DRY原則）"""

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -8,35 +8,9 @@ from rest_framework.authentication import BaseAuthentication
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.views import APIView
-from rest_framework_simplejwt.authentication import JWTAuthentication
-from rest_framework_simplejwt.exceptions import InvalidToken
 
-
-class CookieJWTAuthentication(JWTAuthentication):
-    """
-    Cookie または Authorization ヘッダーから JWT トークンを取得する認証クラス
-
-    優先順位:
-    1. Authorization ヘッダー (API リクエスト用)
-    2. HttpOnly Cookie (動画ストリーミング用)
-    """
-
-    def authenticate(self, request: Request):
-        # まず Authorization ヘッダーから認証を試みる
-        header_auth = super().authenticate(request)
-        if header_auth is not None:
-            return header_auth
-
-        # Cookie から access_token を取得
-        raw_token = request.COOKIES.get("access_token")
-        if raw_token is None:
-            return None
-
-        try:
-            validated_token = self.get_validated_token(raw_token)
-            return self.get_user(validated_token), validated_token
-        except InvalidToken:
-            return None
+# CookieJWTAuthenticationは app.authentication からインポート
+from app.authentication import CookieJWTAuthentication
 
 
 class ShareTokenAuthentication(BaseAuthentication):

--- a/backend/ask_video/settings.py
+++ b/backend/ask_video/settings.py
@@ -158,7 +158,7 @@ AUTH_USER_MODEL = "app.User"
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "app.authentication.CookieJWTAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -27,7 +27,9 @@ export function useAuth(options: UseAuthOptions = {}): UseAuthReturn {
   onAuthErrorRef.current = onAuthError;
 
   const checkAuth = useCallback(async () => {
-    if (!apiClient.isAuthenticated()) {
+    // HttpOnly Cookieベースの認証では、非同期で認証状態をチェック
+    const isAuth = await apiClient.isAuthenticated();
+    if (!isAuth) {
       if (redirectToLogin) {
         router.push('/login');
       }
@@ -40,7 +42,7 @@ export function useAuth(options: UseAuthOptions = {}): UseAuthReturn {
       setUser(userData);
     } catch (error) {
       console.error('Failed to fetch user:', error);
-      apiClient.logout();
+      await apiClient.logout();
       if (redirectToLogin) {
         router.push('/login');
       }


### PR DESCRIPTION
- フロントエンド: localStorage使用を廃止しHttpOnly Cookieベースに変更
- バックエンド: CookieJWTAuthenticationクラスを実装
- 認証クラスをapp.authenticationモジュールに分離
- すべてのビューでCookieJWTAuthenticationを使用
- ログアウトエンドポイントを追加
- XSS攻撃対策: JavaScriptからアクセスできないHttpOnly Cookieを使用