### PR TITLE
fix: protected_mediaの所有者チェックとセキュリティ強化

### DIFF
--- a/backend/ask_video/settings.py
+++ b/backend/ask_video/settings.py
@@ -163,6 +163,10 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
     ],
+    # セキュリティ: 本番環境ではBrowsable APIを無効化
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
+    ],
 }
 
 SIMPLE_JWT = {


### PR DESCRIPTION
- JWT認証ユーザーが他のユーザーの動画にアクセスできないように所有者チェックを追加
- REST FrameworkのBrowsable APIを無効化し、セキュリティを向上
- 共有トークンとJWT認証の両方で適切なアクセス制御を実装