### PR TITLE
fix: 動画一覧パネルの高さをチャットパネルと同じ600pxに固定

### DIFF
--- a/frontend/app/share/[token]/page.tsx
+++ b/frontend/app/share/[token]/page.tsx
@@ -177,8 +177,8 @@ export default function SharedGroupPage() {
           {/* 3カラムレイアウト */}
           <div className="grid grid-cols-12 gap-4 flex-1 min-h-0">
             {/* 左側：動画一覧 */}
-            <div className="col-span-3 h-full">
-              <Card className="h-full flex flex-col">
+            <div className="col-span-3">
+              <Card className="h-[600px] flex flex-col">
                 <CardHeader>
                   <CardTitle>動画一覧</CardTitle>
                 </CardHeader>

--- a/frontend/app/videos/groups/[id]/page.tsx
+++ b/frontend/app/videos/groups/[id]/page.tsx
@@ -673,8 +673,8 @@ export default function VideoGroupDetailPage() {
           {/* 3カラムレイアウト */}
           <div className="grid grid-cols-12 gap-4 flex-1 min-h-0">
           {/* 左側：動画一覧 */}
-          <div className="col-span-3 h-full">
-            <Card className="h-full flex flex-col">
+          <div className="col-span-3">
+            <Card className="h-[600px] flex flex-col">
               <CardHeader>
                 <CardTitle>動画一覧</CardTitle>
               </CardHeader>


### PR DESCRIPTION
動画を追加しても縦に伸びないように、動画一覧パネルの高さをh-fullからh-[600px]に変更しました。 これにより、チャットパネルと同じ高さで表示され、レイアウトが崩れなくなります。