### PR TITLE
動画アップロードでタイトルをファイル名にデフォルト設定

### DIFF
--- a/frontend/components/video/VideoUpload.tsx
+++ b/frontend/components/video/VideoUpload.tsx
@@ -11,6 +11,7 @@ interface VideoUploadProps {
 
 export function VideoUpload({ onUploadSuccess }: VideoUploadProps) {
   const {
+    file,
     title,
     description,
     isUploading,
@@ -49,6 +50,7 @@ export function VideoUpload({ onUploadSuccess }: VideoUploadProps) {
             setTitle={setTitle}
             setDescription={setDescription}
             handleFileChange={handleFileChange}
+            file={file}
           />
         </form>
       </CardContent>

--- a/frontend/components/video/VideoUploadFormFields.tsx
+++ b/frontend/components/video/VideoUploadFormFields.tsx
@@ -15,6 +15,7 @@ interface VideoUploadFormFieldsProps {
   setTitle: (title: string) => void;
   setDescription: (description: string) => void;
   handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  file?: File | null;
   showCancelButton?: boolean;
   onCancel?: () => void;
   cancelButtonClassName?: string;
@@ -31,12 +32,22 @@ export function VideoUploadFormFields({
   setTitle,
   setDescription,
   handleFileChange,
+  file,
   showCancelButton = false,
   onCancel,
   cancelButtonClassName,
   hideButtons = false,
   renderButtons,
 }: VideoUploadFormFieldsProps) {
+  // プレースホルダーを動的に生成
+  const getTitlePlaceholder = () => {
+    if (file) {
+      const fileNameWithoutExt = file.name.replace(/\.[^/.]+$/, '');
+      return `${fileNameWithoutExt}（デフォルト）`;
+    }
+    return '動画のタイトルを入力';
+  };
+
   return (
     <>
       <div className="space-y-2">
@@ -58,7 +69,7 @@ export function VideoUploadFormFields({
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          placeholder="動画のタイトルを入力"
+          placeholder={getTitlePlaceholder()}
           disabled={isUploading}
           required
         />

--- a/frontend/components/video/VideoUploadModal.tsx
+++ b/frontend/components/video/VideoUploadModal.tsx
@@ -15,6 +15,7 @@ interface VideoUploadModalProps {
 
 export function VideoUploadModal({ isOpen, onClose, onUploadSuccess }: VideoUploadModalProps) {
   const {
+    file,
     title,
     description,
     isUploading,
@@ -68,6 +69,7 @@ export function VideoUploadModal({ isOpen, onClose, onUploadSuccess }: VideoUplo
             setTitle={setTitle}
             setDescription={setDescription}
             handleFileChange={handleFileChange}
+            file={file}
             hideButtons={true}
           />
           <DialogFooter>

--- a/frontend/hooks/useVideoUpload.ts
+++ b/frontend/hooks/useVideoUpload.ts
@@ -28,7 +28,9 @@ function validateVideoUpload(file: File | null, title: string): ValidationResult
   if (!file) {
     return { isValid: false, error: 'ファイルを選択してください' };
   }
-  if (!title.trim()) {
+  // タイトルが空の場合はファイル名を使用するので、ファイルがあればOK
+  const finalTitle = title.trim() || file.name.replace(/\.[^/.]+$/, '');
+  if (!finalTitle) {
     return { isValid: false, error: 'タイトルを入力してください' };
   }
   return { isValid: true };
@@ -48,9 +50,13 @@ export function useVideoUpload(): UseVideoUploadReturn {
 
   const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
-      setFile(e.target.files[0]);
+      const selectedFile = e.target.files[0];
+      setFile(selectedFile);
+      // ファイル名（拡張子を除く）をタイトルに自動設定
+      const fileNameWithoutExt = selectedFile.name.replace(/\.[^/.]+$/, '');
+      setTitle(fileNameWithoutExt);
     }
-  }, []);
+  }, [setTitle]);
 
   const reset = useCallback(() => {
     setFile(null);
@@ -70,9 +76,12 @@ export function useVideoUpload(): UseVideoUploadReturn {
     }
 
     await uploadVideo(async () => {
+      // タイトルが空の場合はファイル名（拡張子を除く）を使用
+      const finalTitle = title.trim() || (file ? file.name.replace(/\.[^/.]+$/, '') : '');
+      
       const request: VideoUploadRequest = {
         file: file!,
-        title: title.trim(),
+        title: finalTitle,
         description: description.trim() || undefined,
       };
 


### PR DESCRIPTION
- ファイル選択時にタイトルをファイル名（拡張子なし）に自動設定
- プレースホルダーに「ファイル名（デフォルト）」を表示
- タイトルが空の場合は送信時にファイル名を使用