### PR TITLE
fix: パスワードリセットページで認証チェックをスキップするように修正

### DIFF
--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -53,7 +53,16 @@ export function useAuth(options: UseAuthOptions = {}): UseAuthReturn {
   }, [redirectToLogin, router]);
 
   useEffect(() => {
-    const authRequired = !['/login', '/signup', '/share'].some(path => pathname.startsWith(path));
+    const publicPaths = [
+      '/login',
+      '/signup',
+      '/signup/check-email',
+      '/forgot-password',
+      '/reset-password',
+      '/verify-email',
+      '/share',
+    ];
+    const authRequired = !publicPaths.some((path) => pathname.startsWith(path));
 
     if (authRequired) {
       checkAuth();


### PR DESCRIPTION
パスワードをお忘れですか？リンクをクリックした際に、すぐにログイン画面に戻される問題を修正。
useAuthフックの公開ページリストに以下を追加:
- /forgot-password
- /reset-password
- /signup/check-email
- /verify-email

これにより、未ログイン状態でもパスワードリセット関連のページにアクセス可能になりました。