### PR TITLE
feat: Accept-Languageヘッダーに対応した多言語プロンプト機能を追加

### DIFF
--- a/backend/app/chat/prompts/__init__.py
+++ b/backend/app/chat/prompts/__init__.py
@@ -1,0 +1,5 @@
+"""プロンプト管理モジュール."""
+
+from .loader import get_system_context_parts, get_system_prompt
+
+__all__ = ["get_system_context_parts", "get_system_prompt"]

--- a/backend/app/chat/prompts/loader.py
+++ b/backend/app/chat/prompts/loader.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+DEFAULT_LOCALE = "default"
+PROMPTS_ROOT_KEY = "rag"
+PROMPTS_PATH = Path(__file__).with_name("prompts.json")
+
+
+class PromptConfigurationError(RuntimeError):
+    """プロンプト設定に問題がある場合の例外."""
+
+
+@lru_cache(maxsize=1)
+def _load_prompt_config() -> Dict[str, Any]:
+    if not PROMPTS_PATH.exists():
+        raise PromptConfigurationError(
+            f"Prompt configuration file not found: {PROMPTS_PATH}"
+        )
+
+    with PROMPTS_PATH.open("r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def _iter_locale_candidates(locale: Optional[str]) -> Iterable[str]:
+    if locale:
+        yield locale
+        if "-" in locale:
+            yield locale.split("-", 1)[0]
+    yield DEFAULT_LOCALE
+
+
+def _get_locale_config(locale: Optional[str]) -> Dict[str, Any]:
+    config = _load_prompt_config().get(PROMPTS_ROOT_KEY, {})
+
+    for candidate in _iter_locale_candidates(locale):
+        locale_config = config.get(candidate)
+        if locale_config:
+            return locale_config
+
+    raise PromptConfigurationError(
+        f"Prompt configuration missing '{DEFAULT_LOCALE}' locale for key '{PROMPTS_ROOT_KEY}'."
+    )
+
+
+def get_system_prompt(locale: Optional[str] = None) -> str:
+    """ドキュメントが無い場合に利用するシステムプロンプトを取得."""
+    locale_config = _get_locale_config(locale)
+    prompt = locale_config.get("system_prompt")
+    if prompt:
+        return prompt
+
+    default_prompt = _get_locale_config(DEFAULT_LOCALE).get("system_prompt")
+    if default_prompt:
+        return default_prompt
+
+    raise PromptConfigurationError("System prompt is not configured.")
+
+
+def get_system_context_parts(locale: Optional[str] = None) -> Dict[str, str]:
+    """ドキュメントが存在する場合に利用するコンテキスト用の定型文を取得."""
+    locale_config = _get_locale_config(locale)
+    context_parts = locale_config.get("system_context")
+    if context_parts:
+        return {
+            "lead": context_parts.get("lead", ""),
+            "footer": context_parts.get("footer", ""),
+        }
+
+    default_context = _get_locale_config(DEFAULT_LOCALE).get("system_context", {})
+    if default_context:
+        return {
+            "lead": default_context.get("lead", ""),
+            "footer": default_context.get("footer", ""),
+        }
+
+    return {"lead": "", "footer": ""}

--- a/backend/app/chat/prompts/prompts.json
+++ b/backend/app/chat/prompts/prompts.json
@@ -1,0 +1,18 @@
+{
+  "rag": {
+    "default": {
+      "system_prompt": "You are an assistant who answers using scenes linked to the user's video group. If you are unsure, state that you do not know within 200 characters instead of speculating.",
+      "system_context": {
+        "lead": "Below are relevant scenes extracted from the user's video group. Always prioritize this context when answering.",
+        "footer": "If the answer is unclear, do not guess; say you are unsure within 200 characters."
+      }
+    },
+    "ja": {
+      "system_prompt": "あなたは動画グループに紐づくシーンの内容をもとに回答するアシスタントです。不明な点があれば無理に補完せず、わからない旨を200文字以内で伝えてください。",
+      "system_context": {
+        "lead": "以下はあなたの動画グループから抽出した関連シーンです。回答は必ずこの文脈を最優先してください。",
+        "footer": "不明な場合は推測せず、その旨を200文字以内で伝えてください。"
+      }
+    }
+  }
+}

--- a/backend/app/chat/views.py
+++ b/backend/app/chat/views.py
@@ -114,9 +114,17 @@ class ChatView(generics.CreateAPIView):
                     )
 
             service = RagChatService(user=user, llm=llm)
+            accept_language = request.headers.get("Accept-Language", "")
+            request_locale = (
+                accept_language.split(",")[0].split(";")[0].strip()
+                if accept_language
+                else ""
+            ) or None
+
             result = service.run(
                 messages=messages,
                 group=group if group_id is not None else None,
+                locale=request_locale,
             )
 
             response_data = {


### PR DESCRIPTION
- Accept-Languageヘッダーからロケールを抽出してプロンプトに反映
- プロンプト管理モジュールを追加（prompts.json、loader.py）
- 日本語と英語のプロンプトをサポート
- RagChatServiceにlocaleパラメータを追加