### PR TITLE
Reverse RAG search results to improve accuracy

### DIFF
--- a/backend/app/chat/services/rag_chat.py
+++ b/backend/app/chat/services/rag_chat.py
@@ -59,11 +59,12 @@ class RagChatService:
         """RAGを使用してチャットを実行する"""
         # 1. 元のクエリでドキュメントを検索
         docs = retriever.get_relevant_documents(query_text)
+        reversed_docs = docs[::-1]
 
         # 2. 検索結果を元にLLMの応答を生成
         system_prompt = build_system_prompt(
             locale=locale,
-            references=self._build_reference_entries(docs),
+            references=self._build_reference_entries(reversed_docs),
         )
         prompt_input = {"system_prompt": system_prompt, "query_text": query_text}
         llm_response = (self.prompt | self.llm).invoke(prompt_input)


### PR DESCRIPTION
# Improve Response Accuracy by Reversing RAG Search Results

## Overview
This modification rearranges the order of reference information presented to LLMs by reversing the sequence of search results from RAG (Retrieval-Augmented Generation), thereby enhancing response accuracy.

## Changes Implemented
- Modified the `_run_rag_chat` method in `backend/app/chat/services/rag_chat.py`
- Stored the search results in reverse order (`docs[::-1]`) as `reversed_docs`
- Updated the reference information passed to the `_build_reference_entries` method to use `reversed_docs` instead of `docs`

## Rationale for Changes
While vector search typically returns results in descending order of relevance, presenting reference information in reverse order when generating prompts for LLMs may improve response accuracy. This modification aims to generate more appropriate responses by reversing the search result sequence before passing it to the LLM.

## Impact Areas
- Only affects the order of reference information when using the RAG chat functionality
- No impact on existing API interfaces or data structures
- The re-searching of related videos (`_research_related_videos`) continues to use the original `docs`, so no changes are applied to that functionality