### PR TITLE
Fix CI cache error: add continue-on-error to setup-uv steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "backend/**/pyproject.toml"
+        continue-on-error: true
+        id: setup-uv
       - name: Install dependencies
         working-directory: backend
         run: uv sync --frozen
@@ -96,6 +98,8 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "backend/**/pyproject.toml"
+        continue-on-error: true
+        id: setup-uv
       - name: Install dependencies
         working-directory: backend
         run: uv sync --frozen
@@ -138,6 +142,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v3
+        continue-on-error: true
+        id: setup-uv
       - name: Install dependencies
         working-directory: backend
         run: uv sync --frozen


### PR DESCRIPTION
- Add continue-on-error: true to all astral-sh/setup-uv@v3 steps
- This allows CI to continue even if cache service is temporarily unavailable
- Cache failures will not block the build process