### PR TITLE
Change language and timezone to Django defaults

### DIFF
--- a/backend/ask_video/settings.py
+++ b/backend/ask_video/settings.py
@@ -148,9 +148,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
-LANGUAGE_CODE = "ja"
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "Asia/Tokyo"
+TIME_ZONE = "America/Chicago"
 
 USE_I18N = True
 
@@ -215,7 +215,7 @@ CELERY_RESULT_BACKEND = os.environ.get(
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
-CELERY_TIMEZONE = "Asia/Tokyo"
+CELERY_TIMEZONE = "America/Chicago"
 CELERY_TASK_TRACK_STARTED = True
 CELERY_TASK_TIME_LIMIT = 30 * 60  # 30 minutes
 CELERY_TASK_SOFT_TIME_LIMIT = 25 * 60  # 25 minutes


### PR DESCRIPTION
# Change language and timezone to Django defaults

## Summary
Updated Django's language and timezone settings to their default values.

## Changes Made
- `LANGUAGE_CODE`: `"ja"` → `"en-us"`
- `TIME_ZONE`: `"Asia/Tokyo"` → `"America/Chicago"`
- `CELERY_TIMEZONE`: `"Asia/Tokyo"` → `"America/Chicago"`

## Reasoning
- To standardize error messages in English
- To align with Django's default configuration settings

## Impact
- Error messages will now display in English
- All timezone-related operations will execute using the default timezone (America/Chicago)

## Testing
- [x] Verify that error messages display in English
- [x] Confirm that timezone-related operations function correctly