### PR TITLE
Add video duration limit validation (max 120 minutes)

### DIFF
--- a/backend/app/utils/video_validator.py
+++ b/backend/app/utils/video_validator.py
@@ -1,0 +1,114 @@
+"""
+Video validation utilities
+"""
+
+import json
+import logging
+import os
+import subprocess
+import tempfile
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def get_video_duration(video_file):
+    """
+    Get video duration in seconds using ffprobe
+
+    Args:
+        video_file: Django FileField or file-like object
+
+    Returns:
+        float: Duration in seconds, or None if unable to determine
+    """
+    try:
+        # Get file path
+        is_temp_file = False
+        try:
+            # Local filesystem case
+            video_path = video_file.path
+        except (NotImplementedError, AttributeError):
+            # Remote storage like S3 case - download temporarily
+            is_temp_file = True
+            temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+            temp_path = temp_file.name
+            temp_file.close()
+
+            try:
+                # Download file from remote storage
+                with video_file.open("rb") as remote_file:
+                    with open(temp_path, "wb") as local_file:
+                        local_file.write(remote_file.read())
+
+                video_path = temp_path
+            except Exception as e:
+                logger.error(f"Failed to download video file for validation: {e}")
+                return None
+
+        # Get video duration using ffprobe
+        probe_result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_format",
+                video_path,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        probe = json.loads(probe_result.stdout)
+        duration = float(probe["format"]["duration"])
+
+        # Clean up temporary file if created
+        if is_temp_file:
+            try:
+                os.unlink(video_path)
+            except Exception as e:
+                logger.warning(f"Failed to delete temporary file {video_path}: {e}")
+
+        return duration
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Error running ffprobe: {e.stderr}")
+        return None
+    except (KeyError, ValueError, json.JSONDecodeError) as e:
+        logger.error(f"Error parsing ffprobe output: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Error getting video duration: {e}")
+        return None
+
+
+def validate_video_duration(video_file):
+    """
+    Validate that video duration does not exceed the maximum allowed duration
+
+    Args:
+        video_file: Django FileField or file-like object
+
+    Returns:
+        tuple: (is_valid: bool, error_message: str or None)
+    """
+    duration = get_video_duration(video_file)
+
+    if duration is None:
+        # If we can't determine duration, allow upload (will fail later in processing)
+        logger.warning("Could not determine video duration, skipping duration validation")
+        return True, None
+
+    max_duration = getattr(settings, "MAX_VIDEO_DURATION_SECONDS", 7200)  # Default 120 minutes
+
+    if duration > max_duration:
+        max_minutes = max_duration / 60
+        duration_minutes = duration / 60
+        return False, f"Video duration exceeds the limit. Maximum {max_minutes:.0f} minutes allowed, but this video is {duration_minutes:.1f} minutes."
+
+    return True, None
+

--- a/backend/app/video/serializers.py
+++ b/backend/app/video/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from app.models import Video, VideoGroup
 from app.tasks import transcribe_video
+from app.utils.video_validator import validate_video_duration
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,13 @@ class VideoCreateSerializer(UserOwnedSerializerMixin, serializers.ModelSerialize
     class Meta:
         model = Video
         fields = ["file", "title", "description"]
+
+    def validate_file(self, value):
+        """Validate video file duration"""
+        is_valid, error_message = validate_video_duration(value)
+        if not is_valid:
+            raise serializers.ValidationError(error_message)
+        return value
 
     def create(self, validated_data):
         """Start transcription task when Video is created"""

--- a/backend/ask_video/settings.py
+++ b/backend/ask_video/settings.py
@@ -43,6 +43,9 @@ class DefaultSettings:
     # Storage
     USE_S3_STORAGE = False
 
+    # Video settings
+    MAX_VIDEO_DURATION_MINUTES = 120  # Maximum video duration in minutes
+
     # Email
     FRONTEND_URL = "http://localhost:3000"
     DEFAULT_FROM_EMAIL = "noreply@askvideo.local"
@@ -236,6 +239,14 @@ CELERY_TASK_SOFT_TIME_LIMIT = 25 * 60  # 25 minutes
 
 # Feature flags
 ENABLE_SIGNUP = os.environ.get("ENABLE_SIGNUP", "true").lower() == "true"
+
+# Video settings
+MAX_VIDEO_DURATION_MINUTES = int(
+    os.environ.get(
+        "MAX_VIDEO_DURATION_MINUTES", DefaultSettings.MAX_VIDEO_DURATION_MINUTES
+    )
+)
+MAX_VIDEO_DURATION_SECONDS = MAX_VIDEO_DURATION_MINUTES * 60
 
 # Storage configuration
 USE_S3_STORAGE = (

--- a/frontend/i18n/locales/en/translation.json
+++ b/frontend/i18n/locales/en/translation.json
@@ -159,7 +159,8 @@
       "validation": {
         "noFile": "Please select a file",
         "noTitle": "Please enter a title",
-        "generic": "Validation error"
+        "generic": "Validation error",
+        "maxDurationExceeded": "Video duration exceeds the limit. Maximum {{max}} minutes allowed, but this video is {{actual}} minutes."
       }
     },
     "detail": {

--- a/frontend/i18n/locales/ja/translation.json
+++ b/frontend/i18n/locales/ja/translation.json
@@ -159,7 +159,8 @@
       "validation": {
         "noFile": "ファイルを選択してください",
         "noTitle": "タイトルを入力してください",
-        "generic": "バリデーションエラー"
+        "generic": "バリデーションエラー",
+        "maxDurationExceeded": "動画の長さが上限を超えています。最大 {{max}} 分までアップロードできますが、この動画は {{actual}} 分です。"
       }
     },
     "detail": {


### PR DESCRIPTION
- Add MAX_VIDEO_DURATION_MINUTES setting (default: 120 minutes)
- Add video_validator utility to check video duration using ffprobe
- Add frontend validation using HTML5 video element
- Add validation in VideoCreateSerializer
- Add error messages in English and Japanese translations