### PR TITLE
feat: 使用状況統計機能の追加

### DIFF
--- a/backend/app/auth/serializers.py
+++ b/backend/app/auth/serializers.py
@@ -200,3 +200,14 @@ class RefreshResponseSerializer(serializers.Serializer):
 
 class MessageResponseSerializer(serializers.Serializer):
     detail = serializers.CharField(help_text="Response message")
+
+
+class UsageItemSerializer(serializers.Serializer):
+    used = serializers.FloatField(help_text="Current usage")
+    limit = serializers.FloatField(help_text="Maximum limit")
+
+
+class UsageStatsResponseSerializer(serializers.Serializer):
+    videos = UsageItemSerializer(help_text="Video count usage")
+    whisper_minutes = UsageItemSerializer(help_text="Whisper processing time in minutes")
+    chats = UsageItemSerializer(help_text="Chat count usage")

--- a/backend/app/auth/tests/test_views.py
+++ b/backend/app/auth/tests/test_views.py
@@ -347,7 +347,7 @@ class UsageStatsViewTests(APITestCase):
 
     def test_get_usage_stats_with_shared_origin_chat(self):
         """Test getting usage statistics including shared origin chats"""
-        from app.models import ChatLog, VideoGroup
+        from app.models import ChatLog
 
         # Create another user who will access via share
         other_user = User.objects.create_user(
@@ -403,7 +403,7 @@ class UsageStatsViewTests(APITestCase):
         )
 
         # Create data for other user
-        other_video = Video.objects.create(
+        Video.objects.create(
             user=other_user,
             title="Other User Video",
             description="Test",
@@ -414,7 +414,7 @@ class UsageStatsViewTests(APITestCase):
             name="Other Group",
             description="Test",
         )
-        other_chat = ChatLog.objects.create(
+        ChatLog.objects.create(
             user=other_user,
             group=other_group,
             question="Other question",

--- a/backend/app/auth/urls.py
+++ b/backend/app/auth/urls.py
@@ -3,13 +3,14 @@ from django.urls import path
 
 from .views import (EmailVerificationView, LoginView, LogoutView, MeView,
                     PasswordResetConfirmView, PasswordResetRequestView,
-                    RefreshView, UserSignupView)
+                    RefreshView, UsageStatsView, UserSignupView)
 
 urlpatterns = [
     path("login/", LoginView.as_view(), name="auth-login"),
     path("logout/", LogoutView.as_view(), name="auth-logout"),
     path("refresh/", RefreshView.as_view(), name="auth-refresh"),
     path("me/", MeView.as_view(), name="auth-me"),
+    path("usage-stats/", UsageStatsView.as_view(), name="auth-usage-stats"),
     path("verify-email/", EmailVerificationView.as_view(), name="auth-verify-email"),
     path(
         "password-reset/",

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -24,18 +24,10 @@ export default function Settings() {
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
-              <div className="rounded-lg bg-blue-50 p-4">
-                <p className="text-sm text-blue-800">
-                  {t('settings.info')}
+              <div className="rounded-lg bg-gray-50 p-6 text-center">
+                <p className="text-gray-600">
+                  {t('settings.noSettings')}
                 </p>
-              </div>
-              <div className="space-y-2">
-                <h3 className="text-sm font-semibold">{t('settings.usageLimits.title')}</h3>
-                <ul className="list-disc list-inside space-y-1 text-sm text-gray-600">
-                  <li>{t('settings.usageLimits.videos')}</li>
-                  <li>{t('settings.usageLimits.whisper')}</li>
-                  <li>{t('settings.usageLimits.chat')}</li>
-                </ul>
               </div>
             </div>
           </CardContent>

--- a/frontend/i18n/locales/en/translation.json
+++ b/frontend/i18n/locales/en/translation.json
@@ -117,6 +117,21 @@
     "account": {
       "username": "Username",
       "serviceReady": "✓ Service Ready"
+    },
+    "usage": {
+      "title": "Usage Statistics",
+      "description": "Current usage and limits",
+      "loading": "Loading...",
+      "videos": {
+        "label": "Videos Stored (Total)"
+      },
+      "whisper": {
+        "label": "Transcription Time (This Month)",
+        "unit": "min"
+      },
+      "chats": {
+        "label": "Chat Count (This Month)"
+      }
     }
   },
   "videos": {
@@ -347,14 +362,8 @@
   },
   "settings": {
     "title": "Settings",
-    "description": "Service settings and usage limits",
-    "info": "OpenAI API key is managed by the system. You can use the service with confidence.",
-    "usageLimits": {
-      "title": "Usage Limits",
-      "videos": "Video storage: Maximum 50 videos",
-      "whisper": "Whisper processing time: 20 hours (1,200 minutes) per month",
-      "chat": "Chat messages: 3,000 messages per month"
-    }
+    "description": "Account settings",
+    "noSettings": "No configurable settings available at this time."
   },
   "chat": {
     "title": "Chat",

--- a/frontend/i18n/locales/ja/translation.json
+++ b/frontend/i18n/locales/ja/translation.json
@@ -117,6 +117,21 @@
     "account": {
       "username": "ユーザー名",
       "serviceReady": "✓ サービス利用可能"
+    },
+    "usage": {
+      "title": "使用状況",
+      "description": "現在の使用量と制限",
+      "loading": "読み込み中...",
+      "videos": {
+        "label": "動画保存数（全期間）"
+      },
+      "whisper": {
+        "label": "文字起こし時間（今月）",
+        "unit": "分"
+      },
+      "chats": {
+        "label": "チャット回数（今月）"
+      }
     }
   },
   "videos": {
@@ -347,14 +362,8 @@
   },
   "settings": {
     "title": "設定",
-    "description": "サービス設定と使用量制限",
-    "info": "OpenAI APIキーは運営側で管理されています。安心してお使いいただけます。",
-    "usageLimits": {
-      "title": "使用量制限",
-      "videos": "動画の保存数: 最大50本",
-      "whisper": "Whisper処理時間: 月間20時間（1,200分）",
-      "chat": "チャット回数: 月間3,000回"
-    }
+    "description": "アカウント設定",
+    "noSettings": "現在、変更可能な設定項目はありません。"
   },
   "chat": {
     "title": "チャット",

--- a/frontend/lib/__tests__/api.test.ts
+++ b/frontend/lib/__tests__/api.test.ts
@@ -187,6 +187,26 @@ describe('apiClient', () => {
     })
   })
 
+  describe('getUsageStats', () => {
+    it('should get usage statistics', async () => {
+      const mockUsageStats = {
+        videos: { used: 10, limit: 50 },
+        whisper_minutes: { used: 100.5, limit: 1200 },
+        chats: { used: 50, limit: 3000 },
+      }
+      ;(fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(mockUsageStats),
+        json: async () => mockUsageStats,
+        headers: new Headers({ 'content-type': 'application/json' }),
+      })
+
+      const result = await apiClient.getUsageStats()
+      expect(result).toEqual(mockUsageStats)
+    })
+  })
+
   describe('getVideos', () => {
     it('should get videos list', async () => {
       const mockVideos = [

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -20,6 +20,17 @@ export interface User {
   username: string;
 }
 
+export interface UsageItem {
+  used: number;
+  limit: number;
+}
+
+export interface UsageStats {
+  videos: UsageItem;
+  whisper_minutes: UsageItem;
+  chats: UsageItem;
+}
+
 export interface SignupRequest {
   username: string;
   email: string;
@@ -418,6 +429,10 @@ class ApiClient {
 
   async getMe(): Promise<User> {
     return this.request<User>('/auth/me');
+  }
+
+  async getUsageStats(): Promise<UsageStats> {
+    return this.request<UsageStats>('/auth/usage-stats/');
   }
 
   async chat(data: ChatRequest): Promise<ChatMessage> {


### PR DESCRIPTION
- バックエンドに使用状況統計APIエンドポイントを追加
- ホームページに使用状況表示を追加（動画数、Whisper処理時間、チャット回数）
- 設定ページを簡素化
- 多言語対応の翻訳を更新