### PR TITLE
fix: 動画削除時にグループからも削除されるように修正

### DIFF
--- a/backend/app/video/views.py
+++ b/backend/app/video/views.py
@@ -141,6 +141,10 @@ class VideoDetailView(
         except Exception as e:
             logger.warning(f"Failed to delete vectors for video {video_id}: {e}")
 
+        # Delete VideoGroupMember relationships (remove video from all groups)
+        # This is necessary because we use soft delete, so CASCADE won't trigger
+        VideoGroupMember.objects.filter(video=instance).delete()
+
         # Soft delete: set deleted_at and clear file field
         # This preserves the record for monthly usage tracking while removing file reference
         from django.utils import timezone


### PR DESCRIPTION
- VideoDetailViewのdestroyメソッドで、動画削除時にVideoGroupMemberも削除する処理を追加
- ソフトデリートを使用しているため、CASCADEが発動しないため手動で削除が必要
- テストケースを追加して動作を確認