### PR TITLE
feat: 月次使用量集計後に古い削除済み動画レコードを自動削除する機能を追加

### DIFF
--- a/backend/app/management/__init__.py
+++ b/backend/app/management/__init__.py
@@ -1,0 +1,2 @@
+# Django management commands package
+

--- a/backend/app/management/commands/__init__.py
+++ b/backend/app/management/commands/__init__.py
@@ -1,0 +1,2 @@
+# Django management commands
+

--- a/backend/app/management/commands/cleanup_old_deleted_videos.py
+++ b/backend/app/management/commands/cleanup_old_deleted_videos.py
@@ -1,0 +1,118 @@
+"""
+Django management command to cleanup old soft-deleted video records.
+
+This command deletes video records that were soft-deleted before the current month.
+This is safe to run after monthly usage tracking is complete, as deleted videos
+from previous months are no longer needed for usage calculations.
+
+Usage:
+    python manage.py cleanup_old_deleted_videos
+    python manage.py cleanup_old_deleted_videos --dry-run  # Preview what would be deleted
+"""
+
+import logging
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from app.models import Video
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Delete video records that were soft-deleted before the current month"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview what would be deleted without actually deleting",
+        )
+        parser.add_argument(
+            "--months",
+            type=int,
+            default=1,
+            help="Number of months to keep deleted records (default: 1, meaning delete records from before current month)",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        months_to_keep = options["months"]
+
+        # Calculate cutoff date: records deleted before this date will be removed
+        now = timezone.now()
+        first_day_of_current_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        
+        # Subtract months_to_keep months to get the cutoff date
+        # For months_to_keep=1, we delete records deleted before the current month
+        if months_to_keep == 1:
+            cutoff_date = first_day_of_current_month
+        else:
+            # Calculate the cutoff date by subtracting months
+            cutoff_date = first_day_of_current_month
+            for _ in range(months_to_keep - 1):
+                # Go back one month
+                if cutoff_date.month == 1:
+                    cutoff_date = cutoff_date.replace(year=cutoff_date.year - 1, month=12)
+                else:
+                    cutoff_date = cutoff_date.replace(month=cutoff_date.month - 1)
+
+        # Find videos that were soft-deleted before the cutoff date
+        old_deleted_videos = Video.objects.filter(
+            deleted_at__isnull=False,  # Only soft-deleted videos
+            deleted_at__lt=cutoff_date,  # Deleted before cutoff date
+        )
+
+        count = old_deleted_videos.count()
+
+        if count == 0:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"No old deleted videos found (cutoff date: {cutoff_date.strftime('%Y-%m-%d')})"
+                )
+            )
+            return
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"DRY RUN: Would delete {count} video record(s) deleted before {cutoff_date.strftime('%Y-%m-%d %H:%M:%S')}"
+                )
+            )
+            # Show some examples
+            sample_videos = old_deleted_videos[:5]
+            for video in sample_videos:
+                self.stdout.write(
+                    f"  - Video ID {video.id}: '{video.title}' (deleted at {video.deleted_at})"
+                )
+            if count > 5:
+                self.stdout.write(f"  ... and {count - 5} more")
+            return
+
+        # Actually delete the records
+        self.stdout.write(
+            f"Deleting {count} video record(s) deleted before {cutoff_date.strftime('%Y-%m-%d %H:%M:%S')}..."
+        )
+
+        deleted_count = 0
+        for video in old_deleted_videos.iterator(chunk_size=100):
+            try:
+                video_id = video.id
+                video.delete()  # This will trigger post_delete signal and delete vectors
+                deleted_count += 1
+                if deleted_count % 100 == 0:
+                    self.stdout.write(f"  Deleted {deleted_count}/{count} records...")
+            except Exception as e:
+                logger.error(f"Failed to delete video {video.id}: {e}", exc_info=True)
+                self.stdout.write(
+                    self.style.ERROR(f"  Failed to delete video {video.id}: {e}")
+                )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully deleted {deleted_count} old deleted video record(s)"
+            )
+        )
+

--- a/backend/app/management/commands/tests/__init__.py
+++ b/backend/app/management/commands/tests/__init__.py
@@ -1,0 +1,2 @@
+# Tests for management commands
+

--- a/backend/app/management/commands/tests/test_cleanup_old_deleted_videos.py
+++ b/backend/app/management/commands/tests/test_cleanup_old_deleted_videos.py
@@ -1,0 +1,155 @@
+"""
+Tests for cleanup_old_deleted_videos management command
+"""
+
+from datetime import timedelta
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from app.models import User, Video
+
+
+class CleanupOldDeletedVideosCommandTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass123"
+        )
+
+    def test_cleanup_no_deleted_videos(self):
+        """Test cleanup when there are no deleted videos"""
+        out = StringIO()
+        call_command("cleanup_old_deleted_videos", stdout=out)
+        self.assertIn("No old deleted videos found", out.getvalue())
+
+    def test_cleanup_current_month_deleted_videos_not_deleted(self):
+        """Test that videos deleted in current month are not deleted"""
+        # Create a video deleted this month
+        video = Video.objects.create(
+            user=self.user,
+            title="Current Month Video",
+            description="Test",
+            deleted_at=timezone.now(),
+        )
+
+        out = StringIO()
+        call_command("cleanup_old_deleted_videos", stdout=out)
+        self.assertIn("No old deleted videos found", out.getvalue())
+        # Video should still exist
+        self.assertTrue(Video.objects.filter(pk=video.pk).exists())
+
+    def test_cleanup_old_deleted_videos(self):
+        """Test that videos deleted before current month are deleted"""
+        # Create a video deleted last month
+        last_month = timezone.now() - timedelta(days=35)
+        old_video = Video.objects.create(
+            user=self.user,
+            title="Old Video",
+            description="Test",
+            deleted_at=last_month,
+        )
+
+        out = StringIO()
+        call_command("cleanup_old_deleted_videos", stdout=out)
+        self.assertIn("Successfully deleted", out.getvalue())
+        # Video should be deleted
+        self.assertFalse(Video.objects.filter(pk=old_video.pk).exists())
+
+    def test_cleanup_dry_run(self):
+        """Test dry-run mode doesn't actually delete"""
+        # Create a video deleted last month
+        last_month = timezone.now() - timedelta(days=35)
+        old_video = Video.objects.create(
+            user=self.user,
+            title="Old Video",
+            description="Test",
+            deleted_at=last_month,
+        )
+
+        out = StringIO()
+        call_command("cleanup_old_deleted_videos", "--dry-run", stdout=out)
+        self.assertIn("DRY RUN", out.getvalue())
+        self.assertIn("Would delete", out.getvalue())
+        # Video should still exist
+        self.assertTrue(Video.objects.filter(pk=old_video.pk).exists())
+
+    def test_cleanup_only_soft_deleted_videos(self):
+        """Test that non-deleted videos are not affected"""
+        # Create a non-deleted video
+        active_video = Video.objects.create(
+            user=self.user,
+            title="Active Video",
+            description="Test",
+            deleted_at=None,
+        )
+
+        # Create a video deleted last month
+        last_month = timezone.now() - timedelta(days=35)
+        old_video = Video.objects.create(
+            user=self.user,
+            title="Old Video",
+            description="Test",
+            deleted_at=last_month,
+        )
+
+        out = StringIO()
+        call_command("cleanup_old_deleted_videos", stdout=out)
+        self.assertIn("Successfully deleted", out.getvalue())
+        # Active video should still exist
+        self.assertTrue(Video.objects.filter(pk=active_video.pk).exists())
+        # Old deleted video should be deleted
+        self.assertFalse(Video.objects.filter(pk=old_video.pk).exists())
+
+    def test_cleanup_custom_months(self):
+        """Test cleanup with custom months parameter"""
+        # Create a video deleted 2 months ago
+        two_months_ago = timezone.now() - timedelta(days=65)
+        old_video = Video.objects.create(
+            user=self.user,
+            title="Very Old Video",
+            description="Test",
+            deleted_at=two_months_ago,
+        )
+
+        # With default months=1, it should be deleted
+        out = StringIO()
+        call_command("cleanup_old_deleted_videos", stdout=out)
+        self.assertIn("Successfully deleted", out.getvalue())
+        self.assertFalse(Video.objects.filter(pk=old_video.pk).exists())
+
+        # Recreate for next test
+        old_video = Video.objects.create(
+            user=self.user,
+            title="Very Old Video",
+            description="Test",
+            deleted_at=two_months_ago,
+        )
+
+        # With months=3, it should NOT be deleted (only 2 months old)
+        out = StringIO()
+        call_command("cleanup_old_deleted_videos", "--months", "3", stdout=out)
+        self.assertIn("No old deleted videos found", out.getvalue())
+        self.assertTrue(Video.objects.filter(pk=old_video.pk).exists())
+
+    @patch("app.models.delete_video_vectors")
+    def test_cleanup_deletes_vectors(self, mock_delete_vectors):
+        """Test that cleanup also deletes vectors via post_delete signal"""
+        # Create a video deleted last month
+        last_month = timezone.now() - timedelta(days=35)
+        old_video = Video.objects.create(
+            user=self.user,
+            title="Old Video",
+            description="Test",
+            deleted_at=last_month,
+        )
+
+        out = StringIO()
+        call_command("cleanup_old_deleted_videos", stdout=out)
+        # post_delete signal should be called, which calls delete_video_vectors
+        # Note: In actual implementation, the signal handler calls delete_video_vectors
+        # but since we're using soft delete, the signal only fires on hard delete
+        self.assertIn("Successfully deleted", out.getvalue())
+

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -561,3 +561,21 @@ def transcribe_video(self, video_id):
         except Exception as e:
             # Common error handling
             ErrorHandler.handle_task_error(e, video_id, self, max_retries=3)
+
+
+@shared_task(bind=True, ignore_result=True)
+def cleanup_old_deleted_videos_task(self):
+    """
+    Periodic task to cleanup old soft-deleted video records.
+    This task should be scheduled to run monthly (e.g., on the 1st of each month)
+    after monthly usage tracking is complete.
+    """
+    from django.core.management import call_command
+
+    logger.info("Starting cleanup of old deleted video records...")
+    try:
+        call_command("cleanup_old_deleted_videos")
+        logger.info("Successfully completed cleanup of old deleted video records")
+    except Exception as e:
+        logger.error(f"Failed to cleanup old deleted video records: {e}", exc_info=True)
+        raise

--- a/backend/app/tests/test_cleanup_task.py
+++ b/backend/app/tests/test_cleanup_task.py
@@ -1,0 +1,63 @@
+"""
+Tests for cleanup_old_deleted_videos_task Celery task
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from app.models import User, Video
+from app.tasks import cleanup_old_deleted_videos_task
+
+
+class CleanupOldDeletedVideosTaskTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass123"
+        )
+
+    @patch("app.tasks.call_command")
+    def test_cleanup_task_calls_command(self, mock_call_command):
+        """Test that the Celery task calls the management command"""
+        cleanup_old_deleted_videos_task()
+        mock_call_command.assert_called_once_with("cleanup_old_deleted_videos")
+
+    @patch("app.tasks.logger")
+    @patch("app.tasks.call_command")
+    def test_cleanup_task_logs_success(self, mock_call_command, mock_logger):
+        """Test that the task logs success"""
+        cleanup_old_deleted_videos_task()
+        mock_logger.info.assert_any_call("Starting cleanup of old deleted video records...")
+        mock_logger.info.assert_any_call(
+            "Successfully completed cleanup of old deleted video records"
+        )
+
+    @patch("app.tasks.logger")
+    @patch("app.tasks.call_command")
+    def test_cleanup_task_logs_error(self, mock_call_command, mock_logger):
+        """Test that the task logs errors"""
+        mock_call_command.side_effect = Exception("Test error")
+        with self.assertRaises(Exception):
+            cleanup_old_deleted_videos_task()
+        mock_logger.error.assert_called_once()
+        self.assertIn("Failed to cleanup", str(mock_logger.error.call_args))
+
+    def test_cleanup_task_actually_deletes(self):
+        """Test that the task actually deletes old videos"""
+        # Create a video deleted last month
+        last_month = timezone.now() - timedelta(days=35)
+        old_video = Video.objects.create(
+            user=self.user,
+            title="Old Video",
+            description="Test",
+            deleted_at=last_month,
+        )
+
+        # Run the task
+        cleanup_old_deleted_videos_task()
+
+        # Video should be deleted
+        self.assertFalse(Video.objects.filter(pk=old_video.pk).exists())
+

--- a/backend/talk_video/settings.py
+++ b/backend/talk_video/settings.py
@@ -234,6 +234,17 @@ CELERY_TASK_TRACK_STARTED = True
 CELERY_TASK_TIME_LIMIT = 30 * 60  # 30 minutes
 CELERY_TASK_SOFT_TIME_LIMIT = 25 * 60  # 25 minutes
 
+# Celery Beat Schedule (periodic tasks)
+from celery.schedules import crontab
+
+CELERY_BEAT_SCHEDULE = {
+    # Cleanup old deleted videos on the 1st of each month at 2:00 AM
+    "cleanup-old-deleted-videos": {
+        "task": "app.tasks.cleanup_old_deleted_videos_task",
+        "schedule": crontab(hour=2, minute=0, day_of_month=1),  # 1st of each month at 2 AM
+    },
+}
+
 # Feature flags
 ENABLE_SIGNUP = os.environ.get("ENABLE_SIGNUP", "true").lower() == "true"
 


### PR DESCRIPTION
- Django managementコマンド  を追加
  - 現在の月より前に削除されたレコードを物理削除
  - ドライラン機能と保持期間のカスタマイズに対応
- Celery periodic task  を追加
  - 毎月1日 2:00 AMに自動実行されるように設定
- テストを追加（managementコマンドとCeleryタスク）
- 月次使用量の集計後に古いレコードを削除することでDBの肥大化を防止