### PR TITLE
fix: N+1問題とDRY原則違反を解消

### DIFF
--- a/backend/app/auth/views.py
+++ b/backend/app/auth/views.py
@@ -1,14 +1,12 @@
 from app.utils.mixins import AuthenticatedViewMixin, PublicViewMixin
 from app.utils.plan_limits import (
     get_chat_limit,
-    get_first_day_of_month,
     get_monthly_chat_count,
     get_monthly_whisper_usage,
     get_video_limit,
     get_whisper_minutes_limit,
 )
 from django.contrib.auth import get_user_model
-from django.db.models import Q
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics, status
 from rest_framework.response import Response

--- a/backend/app/utils/plan_limits.py
+++ b/backend/app/utils/plan_limits.py
@@ -5,6 +5,8 @@ This module provides functions to get user-specific limits from the database
 and check monthly usage limits.
 """
 
+from typing import Optional
+
 from app.models import ChatLog, User, Video
 from django.db.models import Q, Sum
 from django.utils import timezone
@@ -60,7 +62,7 @@ def get_first_day_of_month():
     return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
 
-def get_monthly_chat_count(user: User, exclude_chat_log_id: int = None):
+def get_monthly_chat_count(user: User, exclude_chat_log_id: Optional[int] = None):
     """
     Get monthly chat count for a user (N+1 prevention).
 
@@ -87,7 +89,7 @@ def get_monthly_chat_count(user: User, exclude_chat_log_id: int = None):
     return queryset.count()
 
 
-def get_monthly_whisper_usage(user: User, exclude_video_id: int = None):
+def get_monthly_whisper_usage(user: User, exclude_video_id: Optional[int] = None):
     """
     Get monthly Whisper usage in minutes for a user (N+1 prevention).
 

--- a/backend/app/utils/task_helpers.py
+++ b/backend/app/utils/task_helpers.py
@@ -221,14 +221,16 @@ class ErrorHandler:
     @staticmethod
     def validate_required_fields(data: dict, required_fields: list) -> tuple[bool, str]:
         """
-        Validate required fields
+        Validate required fields (DRY: Uses ValidationHelper internally)
 
         Returns:
             (is_valid, error_message)
         """
-        missing_fields = [
-            field for field in required_fields if field not in data or not data[field]
-        ]
-        if missing_fields:
+        from app.utils.response_utils import ValidationHelper
+
+        is_valid, errors = ValidationHelper.validate_required_fields(data, required_fields)
+        if not is_valid and errors:
+            # Convert dict format to string format for backward compatibility
+            missing_fields = list(errors.keys())
             return False, f"Missing required fields: {', '.join(missing_fields)}"
         return True, ""


### PR DESCRIPTION
- 月次制限チェックのロジックを共通関数に抽出（plan_limits.py）
  - get_first_day_of_month(): 月初日の計算を共通化
  - get_monthly_chat_count(): 月次チャット数の取得（N+1対策: select_related適用）
  - get_monthly_whisper_usage(): 月次Whisper使用量の取得

- validate_required_fieldsの重複を解消
  - ErrorHandler.validate_required_fieldsがValidationHelperを使用するように変更

- 各ビュー・シリアライザーで共通関数を使用
  - chat/views.py: get_monthly_chat_count()を使用
  - video/serializers.py: get_monthly_whisper_usage()を使用
  - auth/views.py: 共通関数を使用してコード重複を削減

- N+1問題の対策
  - get_monthly_chat_count()でselect_related('group', 'group__user')を適用
  - 不要なインポートを削除