### PR TITLE
feat: shadcn/uiコンポーネントを使用したカスタム動画プレイヤーを実装

### DIFF
--- a/frontend/app/share/[token]/page.tsx
+++ b/frontend/app/share/[token]/page.tsx
@@ -9,6 +9,7 @@ import { MessageAlert } from '@/components/common/MessageAlert';
 import { ChatPanel } from '@/components/chat/ChatPanel';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+import { VideoPlayer, VideoPlayerHandle } from '@/components/video/VideoPlayer';
 import { getStatusBadgeClassName, getStatusLabel, timeStringToSeconds } from '@/lib/utils/video';
 import { convertVideoInGroupToSelectedVideo, SelectedVideo } from '@/lib/utils/videoConversion';
 import { useTranslation } from 'react-i18next';
@@ -55,7 +56,7 @@ export default function SharedGroupPage() {
   const [selectedVideo, setSelectedVideo] = useState<SelectedVideo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const videoRef = useRef<VideoPlayerHandle>(null);
   const pendingStartTimeRef = useRef<number | null>(null);
 
   // Mobile tab state
@@ -98,9 +99,9 @@ export default function SharedGroupPage() {
     }
   };
 
-  const handleVideoCanPlay = () => {
+  const handleVideoCanPlay = (event: React.SyntheticEvent<HTMLVideoElement>) => {
     if (pendingStartTimeRef.current !== null && videoRef.current) {
-      videoRef.current.currentTime = pendingStartTimeRef.current;
+      videoRef.current.setCurrentTime(pendingStartTimeRef.current);
       videoRef.current.play();
       pendingStartTimeRef.current = null;
     }
@@ -118,7 +119,7 @@ export default function SharedGroupPage() {
 
     // Set time immediately if same video is already selected
     if (selectedVideo?.id === videoId && videoRef.current) {
-      videoRef.current.currentTime = seconds;
+      videoRef.current.setCurrentTime(seconds);
       videoRef.current.play();
     } else {
       // Save start time when selecting different video
@@ -253,16 +254,13 @@ export default function SharedGroupPage() {
                 <CardContent className="flex-1 flex items-center justify-center overflow-hidden">
                   {selectedVideo ? (
                     selectedVideo.file ? (
-                      <video
+                      <VideoPlayer
                         ref={videoRef}
                         key={selectedVideo.id}
-                        controls
-                        className="w-full h-full max-h-[400px] lg:max-h-[500px] rounded object-contain"
                         src={apiClient.getSharedVideoUrl(selectedVideo.file, shareToken)}
                         onCanPlay={handleVideoCanPlay}
-                      >
-                        {t('common.messages.browserNoVideoSupport')}
-                      </video>
+                        className="w-full h-full max-h-[400px] lg:max-h-[500px]"
+                      />
                     ) : (
                       <p className="text-gray-500 text-sm">
                         {t('videos.shared.videoNoFile')}

--- a/frontend/app/videos/[id]/page.tsx
+++ b/frontend/app/videos/[id]/page.tsx
@@ -16,13 +16,14 @@ import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { MessageAlert } from '@/components/common/MessageAlert';
 import { InlineSpinner } from '@/components/common/InlineSpinner';
 import { getStatusBadgeClassName, getStatusLabel, formatDate } from '@/lib/utils/video';
+import { VideoPlayer, VideoPlayerHandle } from '@/components/video/VideoPlayer';
 
 export default function VideoDetailPage() {
   const params = useParams();
   const router = useRouter();
   const searchParams = useSearchParams();
   const videoId = params?.id ? parseInt(params.id as string) : null;
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const videoRef = useRef<VideoPlayerHandle>(null);
   const startTime = searchParams.get('t');
   const { t, i18n } = useTranslation();
 
@@ -40,11 +41,11 @@ export default function VideoDetailPage() {
   }, [videoId, loadVideo]);
 
   // Play from specified time when video is loaded
-  const handleVideoLoaded = () => {
+  const handleVideoLoaded = (event: React.SyntheticEvent<HTMLVideoElement>) => {
     if (videoRef.current && startTime) {
       const seconds = parseInt(startTime, 10);
       if (!isNaN(seconds)) {
-        videoRef.current.currentTime = seconds;
+        videoRef.current.setCurrentTime(seconds);
         videoRef.current.play();
       }
     }
@@ -241,15 +242,12 @@ export default function VideoDetailPage() {
             </CardHeader>
             <CardContent>
               {video.file ? (
-                <video
+                <VideoPlayer
                   ref={videoRef}
-                  controls
-                  className="w-full rounded"
                   src={video.file}
                   onLoadedMetadata={handleVideoLoaded}
-                >
-                  {t('common.messages.browserNoVideoSupport')}
-                </video>
+                  className="w-full rounded"
+                />
               ) : (
                 <p className="text-gray-500">{t('common.messages.videoFileMissing')}</p>
               )}

--- a/frontend/app/videos/groups/[id]/page.tsx
+++ b/frontend/app/videos/groups/[id]/page.tsx
@@ -21,6 +21,7 @@ import { ChatPanel } from '@/components/chat/ChatPanel';
 import { useAuth } from '@/hooks/useAuth';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+import { VideoPlayer, VideoPlayerHandle } from '@/components/video/VideoPlayer';
 import { handleAsyncError } from '@/lib/utils/errorHandling';
 import { useAsyncState } from '@/hooks/useAsyncState';
 import { useTranslation } from 'react-i18next';
@@ -156,7 +157,7 @@ export default function VideoGroupDetailPage() {
   const [shareLink, setShareLink] = useState<string | null>(null);
   const [isGeneratingLink, setIsGeneratingLink] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const videoRef = useRef<VideoPlayerHandle>(null);
   const pendingStartTimeRef = useRef<number | null>(null);
 
   // Edit mode state management
@@ -409,7 +410,7 @@ export default function VideoGroupDetailPage() {
 
     // Set time immediately if same video is already selected
     if (selectedVideo?.id === videoId && videoRef.current) {
-      videoRef.current.currentTime = seconds;
+      videoRef.current.setCurrentTime(seconds);
       videoRef.current.play();
     } else {
       // Save start time when selecting different video
@@ -420,10 +421,9 @@ export default function VideoGroupDetailPage() {
 
   // Play from specified time when video is loaded and ready
   const handleVideoCanPlay = (event: React.SyntheticEvent<HTMLVideoElement>) => {
-    if (pendingStartTimeRef.current !== null) {
-      const videoElement = event.currentTarget;
-      videoElement.currentTime = pendingStartTimeRef.current;
-      videoElement.play();
+    if (pendingStartTimeRef.current !== null && videoRef.current) {
+      videoRef.current.setCurrentTime(pendingStartTimeRef.current);
+      videoRef.current.play();
       pendingStartTimeRef.current = null;
     }
   };
@@ -913,16 +913,13 @@ export default function VideoGroupDetailPage() {
               <CardContent className="flex-1 flex items-center justify-center overflow-hidden">
                 {selectedVideo ? (
                   selectedVideo.file ? (
-                    <video
+                    <VideoPlayer
                       ref={videoRef}
                       key={selectedVideo.id}
-                      controls
-                      className="w-full h-full max-h-[400px] lg:max-h-[500px] rounded object-contain"
                       src={selectedVideo.file}
                       onCanPlay={handleVideoCanPlay}
-                    >
-                      {t('common.messages.browserNoVideoSupport')}
-                    </video>
+                      className="w-full h-full max-h-[400px] lg:max-h-[500px]"
+                    />
                   ) : (
                     <p className="text-gray-500 text-sm">
                       {t('videos.groupDetail.videoNoFile')}

--- a/frontend/components/ui/slider.tsx
+++ b/frontend/components/ui/slider.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+const Slider = React.forwardRef<
+  React.ComponentRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }
+

--- a/frontend/components/video/VideoPlayer.tsx
+++ b/frontend/components/video/VideoPlayer.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import React, { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { Play, Pause, Volume2, VolumeX, Maximize, Minimize } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface VideoPlayerProps {
+  src: string;
+  onCanPlay?: (event: React.SyntheticEvent<HTMLVideoElement>) => void;
+  onLoadedMetadata?: (event: React.SyntheticEvent<HTMLVideoElement>) => void;
+  className?: string;
+}
+
+export interface VideoPlayerHandle {
+  videoElement: HTMLVideoElement | null;
+  play: () => Promise<void>;
+  pause: () => void;
+  setCurrentTime: (time: number) => void;
+}
+
+const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
+  ({ src, onCanPlay, onLoadedMetadata, className }, ref) => {
+    const videoRef = useRef<HTMLVideoElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [currentTime, setCurrentTime] = useState(0);
+    const [duration, setDuration] = useState(0);
+    const [volume, setVolume] = useState(1);
+    const [isMuted, setIsMuted] = useState(false);
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const [showControls, setShowControls] = useState(true);
+    const [isHovering, setIsHovering] = useState(false);
+    const controlsTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+    // Expose methods via ref
+    useImperativeHandle(ref, () => ({
+      videoElement: videoRef.current,
+      play: async () => {
+        if (videoRef.current) {
+          await videoRef.current.play();
+          setIsPlaying(true);
+        }
+      },
+      pause: () => {
+        if (videoRef.current) {
+          videoRef.current.pause();
+          setIsPlaying(false);
+        }
+      },
+      setCurrentTime: (time: number) => {
+        if (videoRef.current) {
+          videoRef.current.currentTime = time;
+          setCurrentTime(time);
+        }
+      },
+    }));
+
+    // Format time helper
+    const formatTime = (seconds: number): string => {
+      if (isNaN(seconds)) return '0:00';
+      const hrs = Math.floor(seconds / 3600);
+      const mins = Math.floor((seconds % 3600) / 60);
+      const secs = Math.floor(seconds % 60);
+      
+      if (hrs > 0) {
+        return `${hrs}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+      }
+      return `${mins}:${secs.toString().padStart(2, '0')}`;
+    };
+
+    // Toggle play/pause
+    const togglePlayPause = () => {
+      if (videoRef.current) {
+        if (isPlaying) {
+          videoRef.current.pause();
+        } else {
+          videoRef.current.play();
+        }
+      }
+    };
+
+    // Handle time update
+    const handleTimeUpdate = () => {
+      if (videoRef.current) {
+        setCurrentTime(videoRef.current.currentTime);
+      }
+    };
+
+    // Handle progress change
+    const handleProgressChange = (value: number[]) => {
+      if (videoRef.current) {
+        const newTime = (value[0] / 100) * duration;
+        videoRef.current.currentTime = newTime;
+        setCurrentTime(newTime);
+      }
+    };
+
+    // Handle volume change
+    const handleVolumeChange = (value: number[]) => {
+      if (videoRef.current) {
+        const newVolume = value[0] / 100;
+        videoRef.current.volume = newVolume;
+        setVolume(newVolume);
+        setIsMuted(newVolume === 0);
+      }
+    };
+
+    // Toggle mute
+    const toggleMute = () => {
+      if (videoRef.current) {
+        if (isMuted) {
+          videoRef.current.volume = volume > 0 ? volume : 0.5;
+          setVolume(videoRef.current.volume);
+          setIsMuted(false);
+        } else {
+          videoRef.current.volume = 0;
+          setVolume(0);
+          setIsMuted(true);
+        }
+      }
+    };
+
+    // Toggle fullscreen
+    const toggleFullscreen = () => {
+      if (!containerRef.current) return;
+
+      if (!isFullscreen) {
+        if (containerRef.current.requestFullscreen) {
+          containerRef.current.requestFullscreen();
+        }
+      } else {
+        if (document.exitFullscreen) {
+          document.exitFullscreen();
+        }
+      }
+    };
+
+    // Handle loaded metadata
+    const handleLoadedMetadata = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+      if (videoRef.current) {
+        setDuration(videoRef.current.duration);
+      }
+      onLoadedMetadata?.(e);
+    };
+
+    // Handle can play
+    const handleCanPlay = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+      onCanPlay?.(e);
+    };
+
+    // Handle play/pause events
+    useEffect(() => {
+      const video = videoRef.current;
+      if (!video) return;
+
+      const handlePlay = () => setIsPlaying(true);
+      const handlePause = () => setIsPlaying(false);
+      const handleVolumeChange = () => {
+        if (video) {
+          setVolume(video.volume);
+          setIsMuted(video.muted || video.volume === 0);
+        }
+      };
+
+      video.addEventListener('play', handlePlay);
+      video.addEventListener('pause', handlePause);
+      video.addEventListener('volumechange', handleVolumeChange);
+      video.addEventListener('timeupdate', handleTimeUpdate);
+
+      return () => {
+        video.removeEventListener('play', handlePlay);
+        video.removeEventListener('pause', handlePause);
+        video.removeEventListener('volumechange', handleVolumeChange);
+        video.removeEventListener('timeupdate', handleTimeUpdate);
+      };
+    }, []);
+
+    // Handle fullscreen change
+    useEffect(() => {
+      const handleFullscreenChange = () => {
+        setIsFullscreen(!!document.fullscreenElement);
+      };
+
+      document.addEventListener('fullscreenchange', handleFullscreenChange);
+      return () => {
+        document.removeEventListener('fullscreenchange', handleFullscreenChange);
+      };
+    }, []);
+
+    // Handle controls visibility
+    useEffect(() => {
+      if (isHovering || !isPlaying) {
+        setShowControls(true);
+        if (controlsTimeoutRef.current) {
+          clearTimeout(controlsTimeoutRef.current);
+        }
+      } else if (isPlaying) {
+        controlsTimeoutRef.current = setTimeout(() => {
+          setShowControls(false);
+        }, 3000);
+      }
+
+      return () => {
+        if (controlsTimeoutRef.current) {
+          clearTimeout(controlsTimeoutRef.current);
+        }
+      };
+    }, [isHovering, isPlaying]);
+
+    const progressPercentage = duration > 0 ? (currentTime / duration) * 100 : 0;
+    const volumePercentage = volume * 100;
+
+    return (
+      <div
+        ref={containerRef}
+        className={cn('relative w-full h-full bg-black rounded overflow-hidden group', className)}
+        onMouseEnter={() => setIsHovering(true)}
+        onMouseLeave={() => setIsHovering(false)}
+        onMouseMove={() => setIsHovering(true)}
+      >
+        <video
+          ref={videoRef}
+          src={src}
+          className="w-full h-full object-contain"
+          onLoadedMetadata={handleLoadedMetadata}
+          onCanPlay={handleCanPlay}
+          onTimeUpdate={handleTimeUpdate}
+          playsInline
+        />
+
+        {/* Controls overlay */}
+        <div
+          className={cn(
+            'absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-opacity duration-300',
+            showControls ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          )}
+        >
+          {/* Bottom controls */}
+          <div className="absolute bottom-0 left-0 right-0 p-3 md:p-4 space-y-3">
+            {/* Progress bar */}
+            <div className="w-full">
+              <Slider
+                value={[progressPercentage]}
+                onValueChange={handleProgressChange}
+                max={100}
+                step={0.1}
+                className="w-full cursor-pointer"
+              />
+            </div>
+
+            {/* Control buttons */}
+            <div className="flex items-center justify-between gap-2 md:gap-4">
+              <div className="flex items-center gap-2 md:gap-3 flex-1 min-w-0">
+                {/* Play/Pause button */}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={togglePlayPause}
+                  className="text-white hover:bg-white/20 h-8 w-8 md:h-10 md:w-10"
+                >
+                  {isPlaying ? (
+                    <Pause className="h-4 w-4 md:h-5 md:w-5" />
+                  ) : (
+                    <Play className="h-4 w-4 md:h-5 md:w-5" />
+                  )}
+                </Button>
+
+                {/* Time display */}
+                <span className="text-white text-xs md:text-sm font-mono whitespace-nowrap">
+                  {formatTime(currentTime)} / {formatTime(duration)}
+                </span>
+
+                {/* Volume control */}
+                <div className="flex items-center gap-2 flex-1 min-w-0">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={toggleMute}
+                    className="text-white hover:bg-white/20 h-8 w-8 md:h-10 md:w-10"
+                  >
+                    {isMuted ? (
+                      <VolumeX className="h-4 w-4 md:h-5 md:w-5" />
+                    ) : (
+                      <Volume2 className="h-4 w-4 md:h-5 md:w-5" />
+                    )}
+                  </Button>
+                  <div className="hidden md:flex items-center gap-2 flex-1 min-w-0 max-w-[120px]">
+                    <Slider
+                      value={[volumePercentage]}
+                      onValueChange={handleVolumeChange}
+                      max={100}
+                      step={1}
+                      className="w-full cursor-pointer"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* Fullscreen button */}
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={toggleFullscreen}
+                className="text-white hover:bg-white/20 h-8 w-8 md:h-10 md:w-10"
+              >
+                {isFullscreen ? (
+                  <Minimize className="h-4 w-4 md:h-5 md:w-5" />
+                ) : (
+                  <Maximize className="h-4 w-4 md:h-5 md:w-5" />
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+
+VideoPlayer.displayName = 'VideoPlayer';
+
+export { VideoPlayer };
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -96,7 +97,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -573,7 +573,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1961,6 +1960,12 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1979,6 +1984,32 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2054,6 +2085,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2213,6 +2259,39 @@
       "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2686,6 +2765,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2784,7 +2864,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2958,7 +3039,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2968,7 +3048,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "devOptional": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3047,7 +3126,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -3553,7 +3631,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4083,7 +4160,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4705,6 +4781,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4760,7 +4837,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -5068,7 +5146,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5246,7 +5323,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6169,7 +6245,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10"
       },
@@ -6855,7 +6930,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8316,6 +8390,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9090,6 +9165,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9105,6 +9181,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9117,7 +9194,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -9214,7 +9292,6 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9223,7 +9300,6 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9235,7 +9311,6 @@
       "version": "7.65.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.65.0.tgz",
       "integrity": "sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -10237,7 +10312,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10536,7 +10610,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11090,7 +11163,6 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -30,8 +31,8 @@
     "next": "16.0.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-i18next": "^15.1.0",
     "react-hook-form": "^7.65.0",
+    "react-i18next": "^15.1.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.1.12"
   },


### PR DESCRIPTION
- shadcn/uiのSliderコンポーネントを追加
- VideoPlayerコンポーネントを作成（再生/一時停止、プログレスバー、音量、フルスクリーン機能）
- 3箇所の<video>タグをVideoPlayerコンポーネントに置き換え
  - frontend/app/videos/groups/[id]/page.tsx
  - frontend/app/share/[token]/page.tsx
  - frontend/app/videos/[id]/page.tsx
- @radix-ui/react-sliderを依存関係に追加