### PR TITLE
chore: docker-composeからbackendサービスのポート公開を削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
   backend:
     build: ./backend
     container_name: videoq-backend
-    ports:
-      - "8000:8000"
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
- backendサービスは内部ネットワーク経由でアクセスするため、外部へのポート公開を削除
- nginx経由でアクセスするため、直接ポート公開は不要