### PR TITLE
docs: Update documentation for i18next to next-intl migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,21 +50,22 @@ videoq/
 │   └── README.md                   # Backend README
 ├── frontend/                       # Next.js + TypeScript frontend
 │   ├── app/                        # Next.js App Router
-│   │   ├── page.tsx                # Home page
-│   │   ├── login/                  # Login page
-│   │   ├── signup/                 # Sign-up page
-│   │   │   └── check-email/        # Waiting for email confirmation page
-│   │   ├── verify-email/           # Email verification page
-│   │   ├── forgot-password/        # Password reset request page
-│   │   ├── reset-password/         # Password reset page
-│   │   ├── settings/               # Settings page
-│   │   ├── videos/                 # Video pages
-│   │   │   ├── page.tsx            # Video list page
-│   │   │   ├── [id]/               # Video detail page
-│   │   │   └── groups/             # Video group pages
-│   │   │       └── [id]/           # Video group detail page
-│   │   └── share/                  # Share pages
-│   │       └── [token]/            # Share token page
+│   │   └── [locale]/               # Locale-based routing
+│   │       ├── page.tsx            # Home page
+│   │       ├── login/              # Login page
+│   │       ├── signup/             # Sign-up page
+│   │       │   └── check-email/    # Waiting for email confirmation page
+│   │       ├── verify-email/       # Email verification page
+│   │       ├── forgot-password/    # Password reset request page
+│   │       ├── reset-password/     # Password reset page
+│   │       ├── settings/           # Settings page
+│   │       ├── videos/             # Video pages
+│   │       │   ├── page.tsx        # Video list page
+│   │       │   ├── [id]/           # Video detail page
+│   │       │   └── groups/         # Video group pages
+│   │       │       └── [id]/       # Video group detail page
+│   │       └── share/              # Share pages
+│   │           └── [token]/        # Share token page
 │   ├── components/                 # React components
 │   │   ├── auth/                   # Auth components
 │   │   ├── video/                  # Video components
@@ -74,7 +75,7 @@ videoq/
 │   │   └── ui/                     # UI components (shadcn/ui)
 │   ├── hooks/                      # Custom hooks (useAuth, useVideos, useAsyncState, etc.)
 │   ├── lib/                        # Libraries/utilities (api, errorUtils, etc.)
-│   ├── i18n/                       # Internationalization (i18next config and locales)
+│   ├── i18n/                       # Internationalization (next-intl config and locales)
 │   ├── package.json                # Node.js dependencies
 │   ├── package-lock.json           # npm lockfile
 │   ├── Dockerfile                  # Frontend Docker image
@@ -166,9 +167,7 @@ videoq/
 - **@dnd-kit/utilities** (^3.2.2) - DnD utilities
 
 #### Internationalization
-- **i18next** (^24.2.1) - Internationalization framework
-- **react-i18next** (^15.1.0) - React integration for i18next
-- **i18next-browser-languagedetector** (^8.0.0) - Language detection
+- **next-intl** (^4.5.8) - Internationalization framework for Next.js
 
 #### Utilities
 - **date-fns** (^4.1.0) - Date utilities

--- a/docs/requirements/screen-transition-diagram.md
+++ b/docs/requirements/screen-transition-diagram.md
@@ -77,27 +77,31 @@ stateDiagram-v2
 ## Screen List
 
 ### Authentication Related
-- **Home** (`/`): Home page
-- **Login** (`/login`): Login page
-- **Signup** (`/signup`): Sign up page
-- **CheckEmail** (`/signup/check-email`): Email confirmation waiting page
-- **VerifyEmail** (`/verify-email`): Email verification page
-- **ForgotPassword** (`/forgot-password`): Password reset request page
-- **ResetPassword** (`/reset-password`): Password reset page
+- **Home** (`/` or `/[locale]`): Home page (e.g., `/`, `/en`, `/ja`)
+- **Login** (`/[locale]/login`): Login page (e.g., `/login`, `/en/login`, `/ja/login`)
+- **Signup** (`/[locale]/signup`): Sign up page
+- **CheckEmail** (`/[locale]/signup/check-email`): Email confirmation waiting page
+- **VerifyEmail** (`/[locale]/verify-email`): Email verification page
+- **ForgotPassword** (`/[locale]/forgot-password`): Password reset request page
+- **ResetPassword** (`/[locale]/reset-password`): Password reset page
 
 ### Video Management
-- **VideoList** (`/videos`): Video list page
-- **VideoDetail** (`/videos/[id]`): Video detail page
+- **VideoList** (`/[locale]/videos`): Video list page
+- **VideoDetail** (`/[locale]/videos/[id]`): Video detail page
 
 ### Group Management
-- **VideoGroupList** (`/videos/groups`): Group list page
-- **VideoGroupDetail** (`/videos/groups/[id]`): Group detail page
+- **VideoGroupList** (`/[locale]/videos/groups`): Group list page
+- **VideoGroupDetail** (`/[locale]/videos/groups/[id]`): Group detail page
 
 ### Sharing
-- **SharePage** (`/share/[token]`): Share page (no authentication required)
+- **SharePage** (`/[locale]/share/[token]`): Share page (no authentication required)
 
 ### Settings
-- **Settings** (`/settings`): Settings page
+- **Settings** (`/[locale]/settings`): Settings page
+
+**Note**: The application uses next-intl with `localePrefix: "as-needed"` configuration:
+- Default locale (`en`) URLs don't include the locale prefix: `/videos`
+- Other locales include the prefix: `/ja/videos`
 
 ## Transition Conditions
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -83,7 +83,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Internationalization (i18n)
 
-This frontend supports multiple languages using [i18next](https://www.i18next.com/) and `react-i18next`.
+This frontend supports multiple languages using [next-intl](https://next-intl-docs.vercel.app/).
 
 ### Supported Languages
 - English (`en`) - Default
@@ -91,30 +91,37 @@ This frontend supports multiple languages using [i18next](https://www.i18next.co
 
 ### Language Detection
 
-Language is auto-detected in this order:
-1. `lang` query parameter (e.g., `?lang=ja`)
-2. Cookie (`i18next` cookie)
-3. localStorage (`i18nextLng`)
-4. Browser settings (navigator language)
+Language is auto-detected based on:
+1. URL path prefix (e.g., `/ja/videos`, `/en/videos`)
+2. Browser settings (Accept-Language header)
+3. Default locale (`en`) if none of the above match
 
-### Usage in React Components
+The routing is configured with `localePrefix: "as-needed"`, which means:
+- Default locale (`en`) URLs don't include the locale prefix: `/videos`
+- Other locales include the prefix: `/ja/videos`
+
+### Usage in React Server Components
 
 ```typescript
-import { useTranslation } from 'react-i18next';
+import { useTranslations } from 'next-intl';
 
 function MyComponent() {
-  const { t } = useTranslation();
+  const t = useTranslations();
   return <div>{t('translation.key')}</div>;
 }
 ```
 
-### Usage in Non-React Code
+### Usage in Client Components
 
 ```typescript
-import { initI18n } from '@/i18n/config';
+'use client';
 
-const i18n = initI18n();
-const text = i18n.t('translation.key');
+import { useTranslations } from 'next-intl';
+
+function MyComponent() {
+  const t = useTranslations();
+  return <div>{t('translation.key')}</div>;
+}
 ```
 
 ### Translation Files
@@ -127,31 +134,31 @@ Translation strings are defined in:
 
 ### Configuration
 
-The root layout wraps the app with `I18nProvider`, which:
-- Initializes i18next on the client
-- Updates `document.documentElement.lang` based on detected language
-- Provides translation context to all components
+- **Routing**: `frontend/i18n/routing.ts` - Defines supported locales and routing configuration
+- **Request**: `frontend/i18n/request.ts` - Loads translation messages based on the current locale
+- **Layout**: The root layout (`app/[locale]/layout.tsx`) provides translations to all pages
 
 ## Directory structure
 
 ```
 frontend/
 ├── app/                      # Next.js App Router
-│   ├── page.tsx              # Home page
-│   ├── login/                # Login page
-│   ├── signup/               # Sign-up page
-│   │   └── check-email/      # Waiting-for-confirmation page
-│   ├── verify-email/         # Email verification page
-│   ├── forgot-password/      # Password reset request page
-│   ├── reset-password/       # Password reset page
-│   ├── settings/             # Settings page
-│   ├── videos/               # Video pages
-│   │   ├── page.tsx          # Video list page
-│   │   ├── [id]/             # Video detail page
-│   │   └── groups/           # Video group pages
-│   │       └── [id]/         # Video group detail page
-│   └── share/                # Share pages
-│       └── [token]/          # Share token page
+│   └── [locale]/             # Locale-based routing
+│       ├── page.tsx          # Home page
+│       ├── login/            # Login page
+│       ├── signup/           # Sign-up page
+│       │   └── check-email/  # Waiting-for-confirmation page
+│       ├── verify-email/     # Email verification page
+│       ├── forgot-password/  # Password reset request page
+│       ├── reset-password/   # Password reset page
+│       ├── settings/         # Settings page
+│       ├── videos/           # Video pages
+│       │   ├── page.tsx      # Video list page
+│       │   ├── [id]/         # Video detail page
+│       │   └── groups/       # Video group pages
+│       │       └── [id]/     # Video group detail page
+│       └── share/            # Share pages
+│           └── [token]/      # Share token page
 ├── components/               # React components
 │   ├── auth/                 # Auth components
 │   ├── video/                # Video components
@@ -161,6 +168,12 @@ frontend/
 │   └── ui/                   # UI components (shadcn/ui)
 ├── hooks/                    # Custom hooks (useAuth, useVideos, useAsyncState, etc.)
 ├── lib/                      # Libraries and utilities (api, errorUtils, etc.)
+├── i18n/                     # Internationalization (next-intl config and locales)
+│   ├── locales/              # Translation files
+│   │   ├── en/               # English translations
+│   │   └── ja/               # Japanese translations
+│   ├── routing.ts            # Routing configuration
+│   └── request.ts            # Request configuration
 ├── public/                   # Static assets
 ├── package.json              # Node.js dependencies
 ├── Dockerfile                # Frontend Docker image


### PR DESCRIPTION
- Update README.md to reflect next-intl routing structure
- Update screen transition diagram with locale-based routing
- Update frontend README with next-intl usage examples