### PR TITLE
docs: OpenAI APIキーの説明を実装に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,13 +228,23 @@ Required variables:
 - `ALLOWED_HOSTS` - Allowed hostnames (comma-separated)
 - `CORS_ALLOWED_ORIGINS` - CORS allowed origins (comma-separated)
 - `SECURE_COOKIES` - Set to "true" in production with HTTPS to enable secure cookie flag (default: "false")
-- `ANYMAIL_*` - Email sending config (for email verification and password reset)
+- Email sending config (for email verification and password reset)
+  - `USE_MAILGUN` - Use Mailgun if "true" (default: "false")
+  - If `USE_MAILGUN=true`
+    - `MAILGUN_API_KEY`
+    - `MAILGUN_SENDER_DOMAIN`
+  - Else (SMTP / custom backend)
+    - `EMAIL_BACKEND` - Django email backend (default: console backend)
+    - `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD`, `EMAIL_USE_TLS`
+    - `DEFAULT_FROM_EMAIL`
 - `FRONTEND_URL` - Frontend URL (used for links in emails)
 - `USE_S3_STORAGE` - Use S3 storage if "true" (default: "false")
 - `AWS_STORAGE_BUCKET_NAME` - S3 bucket name (required if `USE_S3_STORAGE=true`)
 - `AWS_ACCESS_KEY_ID` - AWS access key ID (required if `USE_S3_STORAGE=true`)
 - `AWS_SECRET_ACCESS_KEY` - AWS secret access key (required if `USE_S3_STORAGE=true`)
 - `NEXT_PUBLIC_API_URL` - API URL for Next.js
+
+Tip: When using the default Docker Compose + Nginx setup, `NEXT_PUBLIC_API_URL` should typically be `http://localhost/api`.
 
 #### 2. Start all services
 
@@ -637,8 +647,9 @@ curl -X POST "$BASE_URL/api/chat/feedback/" \
 
 Notes:
 - If you pass `group_id`, vector search (RAG) is limited to videos in that group.
-- **Each user must set their own OpenAI API key in the settings page.** The system no longer uses a shared `OPENAI_API_KEY` environment variable. All OpenAI-related features (transcription, chat) require a user-configured API key.
-- Chat is also available with a share token (use the `share_token` query parameter).
+- **Each user must set their own OpenAI API key in the settings page** (stored encrypted in the DB).
+- Chat is also available with a share token (use the `share_token` query parameter). **In this case, the backend uses the group owner's OpenAI API key.**
+- `OPENAI_API_KEY` is an optional environment variable and is not used in the standard user flow.
 - Do not send a `system` message; the backend constructs the system prompt internally. Only the latest `user` message in `messages` is used.
 - The system uses prompt engineering for RAG. See [Prompt Engineering Documentation](docs/architecture/prompt-engineering.md) for details on how prompts are constructed and customized.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -394,14 +394,14 @@ docker compose logs -f celery-worker
 
 ### Transcription task fails
 
-1. **Ensure OpenAI API key is configured (system administrator):**
-   - Set `OPENAI_API_KEY` environment variable in your deployment configuration (e.g., in `.env` file or Docker Compose environment)
-   - This is a system-level setting, not user-configurable
-   - The API key is used for both Whisper transcription and ChatGPT API calls
+1. **Ensure the video owner has set an OpenAI API key:**
+   - The API key is stored per user (encrypted) and is required for transcription and chat.
+   - Set via the settings UI or the API endpoint `POST /api/auth/me/openai-api-key/`.
+   - (Share-link chat uses the group owner's API key.)
 
-2. **Validate API key:**
-   - Test the API key directly with OpenAI API
-   - Ensure it has access to Whisper API and ChatGPT API
+2. **Validate the API key:**
+   - Test the API key directly with the OpenAI API.
+   - Ensure it has access to Whisper and chat models as needed.
 
 3. **Check video file exists:**
 ```bash

--- a/docs/architecture/bpmn.md
+++ b/docs/architecture/bpmn.md
@@ -70,8 +70,8 @@ flowchart TD
     ValidateQuestion -->|Valid| CheckAuth{Authentication Check}
     CheckAuth -->|Unauthenticated| RequireAuth[Require Authentication]
     RequireAuth --> End([End])
-    CheckAuth -->|Authenticated| CheckAPIKey{System API Key<br/>Configuration Check}
-    CheckAPIKey -->|Not Configured| RequireAPIKey[System API Key Not Configured]
+    CheckAuth -->|Authenticated| CheckAPIKey{OpenAI API Key<br/>Configuration Check<br/>(User / Group Owner when shared)}
+    CheckAPIKey -->|Not Configured| RequireAPIKey[OpenAI API Key Not Configured]
     RequireAPIKey --> End
     CheckAPIKey -->|Configured| CheckGroup{Group Specified}
     

--- a/docs/architecture/flowchart.md
+++ b/docs/architecture/flowchart.md
@@ -57,7 +57,7 @@ flowchart TD
     Validate1 -->|Valid| Send[Send API Request]
     Send --> Auth{Authentication Check}
     Auth -->|Failed| Error2[Authentication Error]
-    Auth -->|Success| CheckAPIKey{System API Key<br/>Configured?}
+    Auth -->|Success| CheckAPIKey{OpenAI API Key Configured?<br/>(User / Group Owner when shared)}
     CheckAPIKey -->|Not Configured| Error3[API Key Not Configured Error]
     CheckAPIKey -->|Configured| CheckGroup{Group Specified?}
     CheckGroup -->|No| NoContext[No Context]

--- a/docs/database/data-flow-diagram.md
+++ b/docs/database/data-flow-diagram.md
@@ -50,7 +50,7 @@ flowchart TD
     
     API --> Auth{Authentication Check}
     Auth -->|Failed| Error1[Authentication Error]
-    Auth -->|Success| GetAPIKey[Get System<br/>OpenAI API Key]
+    Auth -->|Success| GetAPIKey[Get OpenAI API Key<br/>(User)]
     
     GetAPIKey --> GetGroup[(Database<br/>Get VideoGroup)]
     
@@ -138,7 +138,7 @@ flowchart TD
     Guest --> Chat[Send Chat]
     Chat --> API3[POST /api/chat/?share_token=<token>]
     API3 --> ValidateToken2[(Database<br/>Verify Token)]
-    ValidateToken2 --> GetAPIKey[Get System<br/>OpenAI API Key]
+    ValidateToken2 --> GetAPIKey[Get OpenAI API Key<br/>(Group Owner)]
     GetAPIKey --> RAG[RAG Processing]
     RAG --> SaveLog[(Database<br/>Save ChatLog<br/>is_shared_origin: True)]
     SaveLog --> ReturnAnswer[Return Answer]

--- a/docs/design/deployment-diagram.md
+++ b/docs/design/deployment-diagram.md
@@ -91,11 +91,9 @@ graph LR
     
     subgraph Ports["Port Mapping"]
         P1[80:80<br/>nginx]
-        P2[8000:8000<br/>backend]
     end
     
     S6 --> P1
-    S3 --> P2
 ```
 
 ## Network Configuration
@@ -214,7 +212,7 @@ graph TB
         E11[FRONTEND_URL]
         E12[USE_S3_STORAGE]
         E13[AWS_*]
-        E14[OPENAI_API_KEY]
+        E14[OPENAI_API_KEY<br/>(optional / not used in standard flow)]
         E15[NEXT_PUBLIC_API_URL]
     end
     

--- a/docs/design/sequence-diagram.md
+++ b/docs/design/sequence-diagram.md
@@ -56,8 +56,8 @@ sequenceDiagram
     participant OpenAI as OpenAI API
 
     User->>Frontend: Input Question
-    Frontend->>Backend: POST /api/chat/?group_id=123
-    Backend->>Backend: Get System OpenAI API Key
+    Frontend->>Backend: POST /api/chat/ (body: group_id=123)
+    Backend->>Backend: Get OpenAI API Key (User)
     Backend->>DB: Get VideoGroup
     DB-->>Backend: VideoGroup Information
     Backend->>PGVector: Search Related Scenes(Vector Search)
@@ -137,10 +137,10 @@ sequenceDiagram
     Frontend-->>Guest: Display Group Information
     
     Guest->>Frontend: Send Chat
-    Frontend->>Backend: POST /api/chat/?share_token={token}
-    Backend->>DB: Search Group by share_token
+    Frontend->>Backend: POST /api/chat/?share_token={token} (body: group_id={id})
+    Backend->>DB: Get VideoGroup by id + share_token
     DB-->>Backend: VideoGroup Information
-    Backend->>Backend: Get System OpenAI API Key
+    Backend->>Backend: Get OpenAI API Key (Group Owner)
     Backend->>Backend: Execute RAG Processing
     Backend->>DB: Save ChatLog(is_shared_origin: True)
     Backend-->>Frontend: Answer

--- a/docs/requirements/activity-diagram.md
+++ b/docs/requirements/activity-diagram.md
@@ -46,7 +46,7 @@ flowchart TD
     Auth -->|Authenticated| GetGroup{Group Specified?}
     
     GetGroup -->|Yes| ValidateGroup[Validate Group Existence]
-    GetGroup -->|No| GetAPIKey[Get System<br/>OpenAI API Key]
+    GetGroup -->|No| GetAPIKey[Get OpenAI API Key<br/>(User / Group Owner when shared)]
     ValidateGroup --> GetAPIKey
     GetAPIKey --> CheckKey{API Key<br/>Configured?}
     CheckKey -->|Not Configured| Error2[API Key Not Configured Error]

--- a/docs/requirements/use-case-diagram.md
+++ b/docs/requirements/use-case-diagram.md
@@ -152,4 +152,4 @@ graph TB
 ### Settings
 - **UC31 View User Info**: Display current user information
 
-**Note:** OpenAI API key is managed at the system level (via `OPENAI_API_KEY` environment variable), not by individual users.
+**Note:** OpenAI API key is managed per user (stored encrypted). For share-link chat, the group owner's API key is used.


### PR DESCRIPTION
- README.md: メール設定の環境変数説明を更新（Mailgun/SMTP）
- README.md: OpenAI APIキーがユーザー単位（暗号化保存）であることを明記
- README.md: 共有リンクチャットではグループオーナーのキーを使用することを追記
- backend/README.md: トラブルシュートをユーザー単位キー前提に修正
- docs/: 全図表で「System API Key」を「User/Group Owner API Key」に修正
- docs/: チャットAPIのgroup_idをクエリからbodyに修正
- docs/: Docker Composeのポート設定を修正（backendの8000:8000公開を削除）