### PR TITLE
フロントエンドで動画アップロード制限を事前チェックしてユーザー体験を改善

### DIFF
--- a/backend/app/auth/serializers.py
+++ b/backend/app/auth/serializers.py
@@ -80,9 +80,15 @@ class LoginSerializer(serializers.Serializer, CredentialsSerializerMixin):
 
 
 class UserSerializer(serializers.ModelSerializer):
+    video_count = serializers.SerializerMethodField()
+
     class Meta:
         model = User
-        fields = ["id", "username", "email"]
+        fields = ["id", "username", "email", "video_limit", "video_count"]
+
+    def get_video_count(self, obj):
+        """現在のユーザーの動画数を返す"""
+        return obj.videos.count()
 
 
 class RefreshSerializer(serializers.Serializer):

--- a/frontend/components/common/__tests__/OpenAIApiKeyRequiredBanner.test.tsx
+++ b/frontend/components/common/__tests__/OpenAIApiKeyRequiredBanner.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { OpenAIApiKeyRequiredBanner } from '../OpenAIApiKeyRequiredBanner'
+
+describe('OpenAIApiKeyRequiredBanner', () => {
+  it('renders with empty className when not provided', () => {
+    const { container } = render(<OpenAIApiKeyRequiredBanner />)
+
+    expect(screen.getByText('openaiApiKey.banner.title')).toBeInTheDocument()
+    expect(screen.getByText('openaiApiKey.banner.message')).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: 'openaiApiKey.banner.settingsLink' })
+    expect(link).toHaveAttribute('href', '/settings')
+
+    expect(container.firstChild).toHaveAttribute('class', '')
+  })
+
+  it('applies provided className', () => {
+    const { container } = render(<OpenAIApiKeyRequiredBanner className="my-banner" />)
+
+    expect(container.firstChild).toHaveClass('my-banner')
+  })
+})

--- a/frontend/components/settings/__tests__/OpenAIApiKeySettings.test.tsx
+++ b/frontend/components/settings/__tests__/OpenAIApiKeySettings.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { OpenAIApiKeySettings } from '../OpenAIApiKeySettings'
+import { apiClient } from '@/lib/api'
+import { setOpenAIApiKeyStatusCache } from '@/hooks/useOpenAIApiKeyStatus'
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    setOpenAIApiKey: jest.fn(),
+    deleteOpenAIApiKey: jest.fn(),
+  },
+}))
+
+jest.mock('@/hooks/useOpenAIApiKeyStatus', () => ({
+  setOpenAIApiKeyStatusCache: jest.fn(),
+}))
+
+describe('OpenAIApiKeySettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('saves api key successfully and calls callbacks', async () => {
+    const onApiKeyChange = jest.fn()
+    ;(apiClient.setOpenAIApiKey as jest.Mock).mockResolvedValue(undefined)
+
+    render(<OpenAIApiKeySettings hasApiKey={false} onApiKeyChange={onApiKeyChange} />)
+
+    const input = screen.getByLabelText('apiKeyLabel')
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'sk-test' } })
+    })
+
+    const saveButton = screen.getByRole('button', { name: 'save' })
+
+    await act(async () => {
+      fireEvent.click(saveButton)
+    })
+
+    await waitFor(() => {
+      expect(apiClient.setOpenAIApiKey).toHaveBeenCalledWith({ api_key: 'sk-test' })
+    })
+
+    expect(screen.getByText('successSaved')).toBeInTheDocument()
+    expect(screen.getByText('hasApiKeyMessage')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'delete' })).toBeInTheDocument()
+
+    expect(setOpenAIApiKeyStatusCache).toHaveBeenCalledWith(true)
+    expect(onApiKeyChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows error message when save fails with Error', async () => {
+    const onApiKeyChange = jest.fn()
+    ;(apiClient.setOpenAIApiKey as jest.Mock).mockRejectedValue(new Error('save failed'))
+
+    render(<OpenAIApiKeySettings hasApiKey={false} onApiKeyChange={onApiKeyChange} />)
+
+    const input = screen.getByLabelText('apiKeyLabel')
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'sk-test' } })
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('save failed')).toBeInTheDocument()
+    })
+
+    expect(setOpenAIApiKeyStatusCache).not.toHaveBeenCalled()
+    expect(onApiKeyChange).not.toHaveBeenCalled()
+  })
+
+  it('does not delete when confirm is cancelled', async () => {
+    const onApiKeyChange = jest.fn()
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<OpenAIApiKeySettings hasApiKey={true} onApiKeyChange={onApiKeyChange} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'delete' }))
+    })
+
+    expect(apiClient.deleteOpenAIApiKey).not.toHaveBeenCalled()
+    expect(setOpenAIApiKeyStatusCache).not.toHaveBeenCalled()
+    expect(onApiKeyChange).not.toHaveBeenCalled()
+
+    confirmSpy.mockRestore()
+  })
+
+  it('deletes api key successfully when confirmed', async () => {
+    const onApiKeyChange = jest.fn()
+    jest.spyOn(window, 'confirm').mockReturnValue(true)
+    ;(apiClient.deleteOpenAIApiKey as jest.Mock).mockResolvedValue(undefined)
+
+    render(<OpenAIApiKeySettings hasApiKey={true} onApiKeyChange={onApiKeyChange} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'delete' }))
+    })
+
+    await waitFor(() => {
+      expect(apiClient.deleteOpenAIApiKey).toHaveBeenCalledTimes(1)
+    })
+
+    expect(screen.getByText('successDeleted')).toBeInTheDocument()
+    expect(screen.getByText('noApiKeyMessage')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'delete' })).not.toBeInTheDocument()
+
+    expect(setOpenAIApiKeyStatusCache).toHaveBeenCalledWith(false)
+    expect(onApiKeyChange).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/i18n/locales/en/translation.json
+++ b/frontend/i18n/locales/en/translation.json
@@ -159,6 +159,9 @@
         "title": "OpenAI API Key Required",
         "message": "You need to set your OpenAI API key to upload and transcribe videos.",
         "settingsLink": "Go to Settings"
+      },
+      "uploadLimitWarning": {
+        "message": "You have reached the video upload limit ({limit} videos). To upload new videos, please delete existing ones."
       }
     },
     "upload": {

--- a/frontend/i18n/locales/ja/translation.json
+++ b/frontend/i18n/locales/ja/translation.json
@@ -159,6 +159,9 @@
         "title": "OpenAI APIキーが必要です",
         "message": "動画をアップロードして文字起こしを行うには、OpenAI APIキーを設定する必要があります。",
         "settingsLink": "設定画面へ"
+      },
+      "uploadLimitWarning": {
+        "message": "動画のアップロード上限（{limit}本）に達しました。新しい動画をアップロードするには、既存の動画を削除してください。"
       }
     },
     "upload": {

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -10,6 +10,8 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
+  modulePathIgnorePatterns: ['<rootDir>/.next/'],
+  watchPathIgnorePatterns: ['<rootDir>/.next/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -14,6 +14,9 @@ export interface RefreshResponse {
 export interface User {
   id: number;
   username: string;
+  email: string;
+  video_limit: number | null;
+  video_count: number;
 }
 
 export interface SignupRequest {
@@ -243,13 +246,33 @@ class ApiClient {
     }))) as unknown;
 
     if (errorData && typeof errorData === 'object') {
+      // Handle non_field_errors array (DRF validation errors)
+      const nonFieldErrors = (errorData as { non_field_errors?: unknown }).non_field_errors;
+      if (Array.isArray(nonFieldErrors) && nonFieldErrors.length > 0) {
+        const firstError = nonFieldErrors[0];
+        if (typeof firstError === 'string') {
+          throw new Error(firstError);
+        }
+      }
+
+      // Handle detail string
       const maybeDetail = (errorData as { detail?: unknown }).detail;
-      const maybeMessage = (errorData as { message?: unknown }).message;
       if (typeof maybeDetail === 'string') {
         throw new Error(maybeDetail);
       }
+
+      // Handle message string
+      const maybeMessage = (errorData as { message?: unknown }).message;
       if (typeof maybeMessage === 'string') {
         throw new Error(maybeMessage);
+      }
+
+      // Handle field-specific errors
+      for (const key in errorData as Record<string, unknown>) {
+        const value = (errorData as Record<string, unknown>)[key];
+        if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+          throw new Error(value[0]); // フィールド名を省略してメッセージのみ表示
+        }
       }
     }
 


### PR DESCRIPTION
- UserSerializerにvideo_countとvideo_limitフィールドを追加
- 動画一覧ページでアップロード制限をチェックし、制限に達している場合はアップロードボタンを無効化
- アップロード制限に達した場合の警告メッセージを表示
- エラーハンドリングを改善（non_field_errorsとフィールド固有エラーの処理を追加）