### PR TITLE
Remove Celery Beat from README dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ videoq/
 
 #### Background Processing
 - **Celery** (>=5.5.3) - Background task processing
-- **Celery Beat** - Periodic task scheduler
 - **Redis** (>=7.0.0) - Celery broker and queue management
 
 #### Database


### PR DESCRIPTION
# README依存関係の更新

## 概要
README.mdの依存関係セクションから、使用していないCelery Beatの記述を削除しました。

## 変更内容
- `README.md`のBackground Processingセクションから「Celery Beat - Periodic task scheduler」の行を削除

## 理由
プロジェクトでCelery Beatを使用していないため、依存関係リストから削除してドキュメントを正確に保つため。

## 影響範囲
- ドキュメントのみの変更
- コードや機能への影響なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation by removing reference to Celery Beat from the Background Processing section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->