### PR TITLE
Remove is_external_upload field references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,6 @@ The automatic transcription process is handled by Celery background tasks, organ
 - Audio extraction: Uses ffmpeg to convert video to MP3 format
 - Parallel processing: Multiple audio segments are transcribed concurrently using asyncio
 - Error handling: Comprehensive error handling with retry logic (max 3 retries)
-- External uploads: Video files uploaded via external API are automatically deleted after processing
 
 #### Scene Detection (scene_otsu)
 
@@ -565,8 +564,7 @@ curl -X POST "$BASE_URL/api/videos/" \
   -H "Authorization: Bearer $ACCESS" \
   -F "file=@/path/to/movie.mp4" \
   -F "title=Demo Video" \
-  -F "description=Description" \
-  -F "delete_after_processing=false"
+  -F "description=Description"
 
 # List
 curl -H "Authorization: Bearer $ACCESS" "$BASE_URL/api/videos/"
@@ -698,7 +696,6 @@ curl -X DELETE -H "Authorization: Bearer $ACCESS" \
 ```
 
 Notes:
-- For videos uploaded via external API clients, the source files are deleted after processing. Protected media delivery is not available for those files; only transcripts and metadata can be retrieved.
 
 ### Error Responses
 
@@ -710,8 +707,6 @@ Common error responses:
 - **404**: Resource not found (e.g., `"Share link not found"`, `"Group not found"`)
 
 ### Authentication Modes
-
-**For external clients, always use the `Authorization` header (Bearer). Do not use cookie-based auth, as it can cause uploaded files to remain stored.**
 
 - **External clients**: Use the `Authorization` header (Bearer) only
 - **Internal browser app**: HttpOnly Cookie-based authentication (automatic token refresh, XSS protection)
@@ -742,7 +737,7 @@ All services communicate within the `videoq-network` Docker network (defined in 
 ### Main Models
 
 - **User**: User info (extends Django AbstractUser)
-- **Video**: Video info (title, description, file, transcript, status, external upload flag, duration, etc.)
+- **Video**: Video info (title, description, file, transcript, status, external_id, etc.)
 - **VideoGroup**: Video groups (name, description, share token, etc.)
 - **VideoGroupMember**: Association between videos and groups (ordering support)
 - **ChatLog**: Chat logs (question, answer, related videos, shared-from flag, feedback, etc.)

--- a/docs/database/data-dictionary.md
+++ b/docs/database/data-dictionary.md
@@ -68,7 +68,6 @@ Table that stores information about uploaded videos.
 | transcript | TEXT | NOT NULL | '' | Transcription result (SRT format) |
 | status | VARCHAR(20) | NOT NULL | 'pending' | Processing status |
 | error_message | TEXT | NOT NULL | '' | Error message (when error occurs) |
-| is_external_upload | BOOLEAN | NOT NULL | False | Whether uploaded via external API |
 | external_id | VARCHAR(255) | UNIQUE, NULL | NULL | ID from external LMS (e.g., Moodle cm_id, Canvas content_id) |
 
 ### status Values

--- a/docs/database/er-diagram.md
+++ b/docs/database/er-diagram.md
@@ -41,7 +41,6 @@ erDiagram
         text transcript
         string status
         text error_message
-        bool is_external_upload
         string external_id UK
     }
     

--- a/docs/design/class-diagram.md
+++ b/docs/design/class-diagram.md
@@ -30,7 +30,6 @@ classDiagram
         +string transcript
         +string status
         +string error_message
-        +bool is_external_upload
         +string external_id (unique, nullable)
         +__str__()
     }


### PR DESCRIPTION
# Remove is_external_upload field references from documentation

## 概要

`is_external_upload`フィールドに関する記述をドキュメントから削除しました。

## 変更内容

以下のドキュメントファイルから`is_external_upload`フィールドに関する記述を削除：

- **README.md**
  - 外部アップロードに関する説明文を削除
  - API使用例から`delete_after_processing`パラメータの記述を削除
  - 外部クライアント向けの注意事項を削除
  - Videoモデルの説明から`is_external_upload`を削除

- **docs/database/data-dictionary.md**
  - Videoテーブルの`is_external_upload`カラム定義を削除

- **docs/database/er-diagram.md**
  - ER図から`is_external_upload`属性を削除

- **docs/design/class-diagram.md**
  - クラス図から`is_external_upload`属性を削除

## 影響範囲

- ドキュメントのみの変更
- コードへの影響なし

## 確認事項

- [ ] ドキュメントの整合性が保たれているか
- [ ] 削除した記述が実際のコードベースで使用されていないか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comprehensive technical documentation including database schemas, entity-relationship diagrams, class diagrams, and data dictionary definitions to align with video model structural changes.
  * Removed outdated references to external upload processes, legacy authentication procedures, and deprecated configuration options from documentation to improve clarity.
  * Refreshed all technical reference materials to maintain consistency and accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->