### PR TITLE
refactor: API関連のパスを/api/プレフィックスで統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ After all services are up, you can access:
 
 - **Frontend**: http://localhost
 - **Backend API**: http://localhost/api
-- **Admin**: http://localhost/admin
+- **Admin**: http://localhost/api/admin
 - **API Documentation (Swagger)**: http://localhost/api/docs/
 - **API Documentation (ReDoc)**: http://localhost/api/redoc/
 

--- a/backend/app/media/views.py
+++ b/backend/app/media/views.py
@@ -45,6 +45,6 @@ class ProtectedMediaView(APIView):
         content_type, _ = mimetypes.guess_type(file_path)
         if content_type:
             response["Content-Type"] = content_type
-        response["X-Accel-Redirect"] = f"/protected_media/{path}"
+        response["X-Accel-Redirect"] = f"/api/protected_media/{path}"
 
         return response

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -296,9 +296,9 @@ if USE_S3_STORAGE:
     }
 else:
     # Local development settings
-    STATIC_URL = "/static/"
+    STATIC_URL = "/api/static/"
     STATIC_ROOT = BASE_DIR / "staticfiles"
-    MEDIA_URL = "/media/"
+    MEDIA_URL = "/api/media/"
     MEDIA_ROOT = BASE_DIR / "media"
 
     # Use custom storage for media files (with timestamp-based filename conversion)

--- a/backend/videoq/urls.py
+++ b/backend/videoq/urls.py
@@ -23,7 +23,7 @@ from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
                                    SpectacularSwaggerView)
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
+    path("api/admin/", admin.site.urls),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(
         "api/docs/",
@@ -34,7 +34,7 @@ urlpatterns = [
     path("api/auth/", include("app.auth.urls")),
     path("api/chat/", include("app.chat.urls")),
     path("api/videos/", include("app.video.urls")),
-    path("", include("app.urls")),
+    path("api/", include("app.urls")),
 ]
 
 # Serve MEDIA files only in development environment

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,35 +20,19 @@ http {
         listen 80;
         server_name _;
 
-        location /static/ {
+        # Static files served directly by nginx
+        location /api/static/ {
             alias /static/;
         }
 
-        location /protected_media/ {
+        # Protected media files (internal use only)
+        location /api/protected_media/ {
             internal;
             alias /media/;
         }
 
-        # Media routes to backend
-        location /media/ {
-            proxy_pass http://backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        # API routes to backend
+        # All API routes to backend (admin, media, auth, etc.)
         location /api/ {
-            proxy_pass http://backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        # Admin routes to backend
-        location /admin/ {
             proxy_pass http://backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -63,7 +47,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            
+
             # WebSocket support for Next.js
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
- admin、static、media、protected_mediaのパスを/api/配下に統一
- nginx.confの設定を簡素化し、/api/配下のルーティングを統合
- README.mdの管理者URLを更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized application URL structure to consolidate all backend routes under a unified `/api/` namespace prefix.
  * Updated Admin panel access URL from the root path to `/api/admin/`.
  * Relocated static and media file routes to use the new `/api/` prefix for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->