### PR TITLE
Fix/adjust video group layout column width

### DIFF
--- a/frontend/app/[locale]/share/[token]/page.tsx
+++ b/frontend/app/[locale]/share/[token]/page.tsx
@@ -209,9 +209,9 @@ export default function SharedGroupPage() {
           </div>
 
           {/* Responsive layout: Tab switching on mobile, 3-column on PC */}
-          <div className="flex flex-col lg:grid flex-1 min-h-0 gap-4 lg:gap-6 lg:grid-cols-[320px_minmax(0,1fr)_360px]">
+          <div className="flex flex-col lg:grid flex-1 min-h-0 gap-4 lg:gap-6 lg:grid-cols-[1fr_2fr_1fr]">
             {/* Left: Video list */}
-            <div className={`flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
+            <div className={`flex-col min-h-0 min-w-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
               <Card className="h-[500px] lg:h-[600px] flex flex-col">
                 <CardHeader>
                   <CardTitle>{t('videos.shared.tabs.videos')}</CardTitle>
@@ -238,7 +238,7 @@ export default function SharedGroupPage() {
             </div>
 
             {/* Center: Video player */}
-            <div className={`flex-col min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden lg:flex'}`}>
+            <div className={`flex-col min-h-0 min-w-0 ${mobileTab === 'player' ? 'flex' : 'hidden lg:flex'}`}>
               <Card className="h-[500px] lg:h-[600px] flex flex-col">
                 <CardHeader>
                   <CardTitle className="text-base lg:text-lg">
@@ -278,7 +278,7 @@ export default function SharedGroupPage() {
             </div>
 
             {/* Right: Chat */}
-            <div className={`flex-col min-h-0 ${mobileTab === 'chat' ? 'flex' : 'hidden lg:flex'}`}>
+            <div className={`flex-col min-h-0 min-w-0 ${mobileTab === 'chat' ? 'flex' : 'hidden lg:flex'}`}>
               <ChatPanel
                 groupId={group.id}
                 onVideoPlay={handleVideoPlayFromTime}

--- a/frontend/app/[locale]/share/[token]/page.tsx
+++ b/frontend/app/[locale]/share/[token]/page.tsx
@@ -46,6 +46,11 @@ function VideoItem({ video, isSelected, onSelect }: VideoItemProps) {
   );
 }
 
+/**
+ * Renders the shared group page showing a list of videos, a central video player, and chat, handling loading, errors, mobile tab navigation, video selection, and play-from-time requests.
+ *
+ * @returns The React element representing the shared video group page.
+ */
 export default function SharedGroupPage() {
   const params = useParams();
   const shareToken = params?.token as string;

--- a/frontend/app/[locale]/videos/groups/[id]/page.tsx
+++ b/frontend/app/[locale]/videos/groups/[id]/page.tsx
@@ -840,9 +840,9 @@ export default function VideoGroupDetailPage() {
           </div>
 
           {/* Responsive layout: Tab switching on mobile, 3-column on PC */}
-          <div className="flex flex-col lg:grid flex-1 min-h-0 gap-4 lg:gap-6 lg:grid-cols-[360px_minmax(0,1fr)_360px]">
+          <div className="flex flex-col lg:grid flex-1 min-h-0 gap-4 lg:gap-6 lg:grid-cols-[1fr_2fr_1fr]">
           {/* Left: Video list */}
-          <div className={`flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
+          <div className={`flex-col min-h-0 min-w-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
             <Card className="h-[500px] lg:h-[600px] flex flex-col">
               <CardHeader>
                 <CardTitle>{t('videos.groupDetail.videoListTitle')}</CardTitle>
@@ -887,7 +887,7 @@ export default function VideoGroupDetailPage() {
           </div>
 
           {/* Center: Video player */}
-          <div className={`flex-col min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden lg:flex'}`}>
+          <div className={`flex-col min-h-0 min-w-0 ${mobileTab === 'player' ? 'flex' : 'hidden lg:flex'}`}>
             <Card className="h-[500px] lg:h-[600px] flex flex-col">
               <CardHeader>
                 <CardTitle className="text-base lg:text-lg">
@@ -927,7 +927,7 @@ export default function VideoGroupDetailPage() {
           </div>
 
           {/* Right: Chat */}
-          <div className={`flex-col min-h-0 ${mobileTab === 'chat' ? 'flex' : 'hidden lg:flex'}`}>
+          <div className={`flex-col min-h-0 min-w-0 ${mobileTab === 'chat' ? 'flex' : 'hidden lg:flex'}`}>
             <ChatPanel
               groupId={groupId ?? undefined}
               onVideoPlay={handleVideoPlayFromTime}

--- a/frontend/app/[locale]/videos/groups/[id]/page.tsx
+++ b/frontend/app/[locale]/videos/groups/[id]/page.tsx
@@ -134,6 +134,15 @@ function SortableVideoItem({ video, isSelected, onSelect, onRemove, isMobile = f
   );
 }
 
+/**
+ * Renders the Video Group Detail page with video list, player, and chat for a single video group.
+ *
+ * Displays group metadata (with inline edit), manages loading and reordering videos, adding/removing videos,
+ * generating and copying share links, and provides a responsive layout that switches between tabs on mobile
+ * and a three-column layout on larger screens.
+ *
+ * @returns The rendered Video Group Detail page component.
+ */
 export default function VideoGroupDetailPage() {
   const params = useParams();
   const router = useRouter();
@@ -941,4 +950,3 @@ export default function VideoGroupDetailPage() {
     </div>
   );
 }
-

--- a/frontend/app/[locale]/videos/groups/[id]/page.tsx
+++ b/frontend/app/[locale]/videos/groups/[id]/page.tsx
@@ -840,7 +840,7 @@ export default function VideoGroupDetailPage() {
           </div>
 
           {/* Responsive layout: Tab switching on mobile, 3-column on PC */}
-          <div className="flex flex-col lg:grid flex-1 min-h-0 gap-4 lg:gap-6 lg:grid-cols-[320px_minmax(0,1fr)_360px]">
+          <div className="flex flex-col lg:grid flex-1 min-h-0 gap-4 lg:gap-6 lg:grid-cols-[360px_minmax(0,1fr)_360px]">
           {/* Left: Video list */}
           <div className={`flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
             <Card className="h-[500px] lg:h-[600px] flex flex-col">


### PR DESCRIPTION
# Layout Enhancements for Video Group Detail and Share Pages

## Overview
The three-column layout for video group detail and share pages has been modified from fixed-width to ratio-based responsive design, resolving overflow issues.

## Changes Implemented

### Layout Improvements
- **From fixed-width to ratio-based**: Changed grid column definitions from `320px_minmax(0,1fr)_360px` to `1fr_2fr_1fr`
  - Left column (video list): 1fr
  - Center column (video player): 2fr (twice the width)
  - Right column (chat): 1fr

### Overflow Issue Resolution
- Added `min-w-0` class to each column to prevent content overflow

## Modified Files
- `frontend/app/[locale]/videos/groups/[id]/page.tsx`
- `frontend/app/[locale]/share/[token]/page.tsx`

## Commit History
1. `fix: Adjusted left column width in video group detail page from 320px to 360px`
2. `refactor: Modified layout of video group detail page to use ratio-based columns and added min-w-0`
3. `refactor: Modified layout of share page to use ratio-based columns and added min-w-0`

## Benefits
- More flexible responsive design
- Consistent display across different screen sizes
- Prevention of content overflow
- Increased space for the central video player

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Shared Group page with loading/error handling, mobile tab navigation, video selection, and play-from-time behavior.
* **Bug Fixes**
  * Adjusted large-screen column proportions to widen the center content area.
  * Added minimum-width constraints to multiple flexible columns to prevent overflow and improve layout stability.
* **Documentation**
  * Added descriptive docblocks for group and video pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->