### PR TITLE
feat: チャット機能にストリーミング対応を追加

### DIFF
--- a/backend/app/chat/urls.py
+++ b/backend/app/chat/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
 from .views import (ChatFeedbackView, ChatHistoryExportView, ChatHistoryView,
-                    ChatView)
+                    ChatStreamView, ChatView)
 
 urlpatterns = [
     path("", ChatView.as_view(), name="chat"),
+    path("stream/", ChatStreamView.as_view(), name="chat-stream"),
     path("history/", ChatHistoryView.as_view(), name="chat-history"),
     path(
         "history/export/", ChatHistoryExportView.as_view(), name="chat-history-export"


### PR DESCRIPTION
- RAGチャットサービスにrun_streamメソッドを追加
- Server-Sent Events (SSE)を使用したストリーミングエンドポイントを実装
- フロントエンドにストリーミング対応のUIとAPIクライアントを追加
- ストリーミング失敗時のフォールバック機能を実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time streaming chat: incremental token updates, SSE-based streaming endpoint, and client-side streaming API delivering related-video info and final metadata.
* **Bug Fixes / Reliability**
  * Automatic fallback to non-streaming chat if streaming fails; improved error signaling for streaming and auth retry handling.
* **Tests**
  * Expanded tests covering streaming token flows, completion metadata, error/fallback scenarios, auth retry paths, and malformed-stream handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->