### PR TITLE
docs: READMEとdocsを英語化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,3 @@ AWS_STORAGE_BUCKET_NAME=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_S3_REGION_NAME=
-
-# Frontend (Vite) settings
-# - Docker Compose build arg: VITE_API_URL (default: /api)
-# - Local dev proxy target (see `frontend/vite.config.ts`)
-# 推奨（同梱の nginx リバースプロキシ構成）: /api
-VITE_API_URL=/api

--- a/docs/architecture/prompt-engineering.md
+++ b/docs/architecture/prompt-engineering.md
@@ -247,5 +247,6 @@ print(prompt_ja)
 ## Related Documentation
 
 - [System Configuration Diagram](system-configuration-diagram.md)
-- [Scene Splitting](../../README.md#scene-detection-scene_otsu) (project root README)
+- [Scene Splitting](../../backend/app/tasks/srt_processing.py)
+- [Scene Detection (`scene_otsu`)](../../backend/app/scene_otsu/)
 - [Vector Management](../../backend/app/utils/vector_manager.py)

--- a/docs/architecture/system-configuration-diagram.md
+++ b/docs/architecture/system-configuration-diagram.md
@@ -1,8 +1,8 @@
-# システム構成図（System Configuration Diagram）
+# System Configuration Diagram
 
 ## Overview
 
-VideoQの全体アーキテクチャと、デフォルト構成（Docker Compose）を表します。
+This diagram shows VideoQ's overall architecture and the default (Docker Compose) configuration.
 
 ## Overall System Configuration
 

--- a/docs/design/component-diagram.md
+++ b/docs/design/component-diagram.md
@@ -1,8 +1,8 @@
-# コンポーネント図（Component Diagram）
+# Component Diagram
 
 ## Overview
 
-VideoQのフロントエンド/バックエンドの主要コンポーネント構成を表します。
+This diagram shows the major components of VideoQ's frontend and backend.
 
 ## Frontend Component Structure
 

--- a/docs/design/deployment-diagram.md
+++ b/docs/design/deployment-diagram.md
@@ -1,8 +1,8 @@
-# 配置図（Deployment Diagram）
+# Deployment Diagram
 
 ## Overview
 
-VideoQのデフォルト配置（Docker Compose）を表します。
+This diagram shows VideoQ's default deployment (Docker Compose).
 
 ## Docker Compose Configuration
 

--- a/docs/requirements/screen-transition-diagram.md
+++ b/docs/requirements/screen-transition-diagram.md
@@ -99,10 +99,10 @@ stateDiagram-v2
 ### Settings
 - **Settings** (`/settings` or `/:locale/settings`): Settings page
 
-**Note**: 本プロジェクトは Next.js / next-intl ではなく、React Router + react-i18next でロケール付きルーティングを実装しています（`frontend/src/App.tsx`）。
-- デフォルトロケール（`en`）はプレフィックスなし: `/videos`
-- それ以外のロケールは `/:locale` 付き: `/ja/videos`
-- `/:locale` が無い場合、ユーザーの優先ロケールがデフォルト以外なら自動的に `/:locale/...` にリダイレクトします
+**Note**: This project implements locale-aware routing with React Router + react-i18next (not Next.js / next-intl) (`frontend/src/App.tsx`).
+- The default locale (`en`) has no prefix: `/videos`
+- Other locales use the `/:locale` prefix: `/ja/videos`
+- If `/:locale` is missing and the user's preferred locale is not the default, the app automatically redirects to `/:locale/...`
 
 ## Transition Conditions
 


### PR DESCRIPTION
ルートREADMEとdocs配下の日本語表記を英語に統一し、関連ドキュメントの参照リンクも更新。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Localized product docs and guides from Japanese/Chinese to English for README, architecture, diagrams, and requirements to improve clarity and accessibility.
  * Refined architecture and prompt-engineering references to improve navigation and accuracy.
* **Chores**
  * Simplified environment example by removing certain frontend environment guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->