### PR TITLE
refactor: Remove scene index numbers from reference entries

### DIFF
--- a/backend/app/chat/services/rag_chat.py
+++ b/backend/app/chat/services/rag_chat.py
@@ -135,7 +135,7 @@ class RagChatService:
 
         reference_entries: List[str] = []
 
-        for idx, doc in enumerate(docs, start=1):
+        for doc in docs:
             metadata = getattr(doc, "metadata", {}) or {}
             title = metadata.get("video_title", "")
             start_time = metadata.get("start_time", "")
@@ -143,7 +143,7 @@ class RagChatService:
             page_content = getattr(doc, "page_content", "")
 
             reference_entries.append(
-                f"[{idx}] {title} {start_time} - {end_time}\n{page_content}"
+                f"{title} {start_time} - {end_time}\n{page_content}"
             )
 
         return reference_entries


### PR DESCRIPTION
Remove the enumeration-based index numbers ([1], [2], etc.) from scene references in the RAG chat response. This simplifies the reference format to just show video title and timestamp ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated reference entry formatting in chat responses by removing numeric index labels, resulting in a cleaner and more streamlined presentation of reference information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->