### PR TITLE
fix: Check API key before fetching available models in LLM settings

### DIFF
--- a/frontend/src/components/settings/LLMSettings.tsx
+++ b/frontend/src/components/settings/LLMSettings.tsx
@@ -23,10 +23,21 @@ export function LLMSettings({ initialSettings, onSettingsChange }: LLMSettingsPr
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  // Fetch available models on mount
+  // Fetch available models on mount (only if API key is set)
   useEffect(() => {
     const fetchModels = async () => {
       try {
+        // First check if API key is set
+        const apiKeyStatus = await apiClient.getOpenAIApiKeyStatus();
+
+        if (!apiKeyStatus.has_api_key) {
+          // If no API key, skip fetching models and show a warning
+          setError(t('settings.openaiApiKey.noApiKeyMessage'));
+          setModelsLoading(false);
+          return;
+        }
+
+        // Fetch available models only if API key exists
         const response = await apiClient.getAvailableModels();
         setAvailableModels(response.models);
       } catch (err) {


### PR DESCRIPTION
Fixed an issue where attempting to retrieve available models on the LLM settings page would result in an HTTP 400 error if the OpenAI API key was not properly configured.

Changes implemented:
- Added API key status verification before attempting to fetch the model list
- If the API key is missing, models retrieval is now skipped with an appropriate error message displayed
- This ensures users receive clear feedback instead of seeing "HTTP error! status: 400"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LLM Settings to properly validate API key presence before attempting to load available models. The component now displays an appropriate error message when no API key is configured, preventing unnecessary failed requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->