### PR TITLE
feat: add embedding vector re-indexing feature

### DIFF
--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -2,6 +2,7 @@
 Celery tasks package for video transcription
 """
 
+from app.tasks.reindexing import reindex_all_videos_embeddings
 from app.tasks.transcription import transcribe_video
 
-__all__ = ["transcribe_video"]
+__all__ = ["transcribe_video", "reindex_all_videos_embeddings"]

--- a/backend/app/tasks/reindexing.py
+++ b/backend/app/tasks/reindexing.py
@@ -1,0 +1,92 @@
+"""
+Re-indexing task for regenerating embedding vectors
+"""
+
+import logging
+
+from celery import shared_task
+
+from app.models import Video
+from app.tasks.vector_indexing import index_scenes_batch
+from app.utils.vector_manager import delete_all_vectors
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True)
+def reindex_all_videos_embeddings(self):
+    """
+    Regenerate embedding vectors for all videos
+    Used when switching embedding models (EMBEDDING_PROVIDER/EMBEDDING_MODEL)
+
+    Returns:
+        dict: Result containing status, counts, and error information
+    """
+    try:
+        # 1. Get completed videos with transcripts
+        videos = (
+            Video.objects.filter(status="completed")
+            .exclude(transcript__isnull=True)
+            .exclude(transcript="")
+            .select_related("user")
+        )
+
+        total = videos.count()
+        logger.info(f"Starting re-indexing: {total} videos")
+
+        if total == 0:
+            return {
+                "status": "completed",
+                "total_videos": 0,
+                "successful_count": 0,
+                "failed_count": 0,
+                "message": "No videos to re-index",
+            }
+
+        # 2. Delete all existing vectors
+        logger.info("Deleting all existing vectors...")
+        deleted_count = delete_all_vectors()
+        logger.info(f"Deleted {deleted_count} vectors")
+
+        # 3. Re-index each video
+        successful_count = 0
+        failed_videos = []
+
+        for index, video in enumerate(videos, start=1):
+            try:
+                # Re-index scenes (uses OPENAI_API_KEY environment variable)
+                index_scenes_batch(video.transcript, video)
+                successful_count += 1
+
+                logger.info(
+                    f"[{index}/{total}] Successfully re-indexed video {video.id} ({video.title})"
+                )
+
+            except Exception as e:
+                logger.error(
+                    f"Failed to re-index video {video.id}: {str(e)}", exc_info=True
+                )
+                failed_videos.append(
+                    {"video_id": video.id, "title": video.title, "error": str(e)}
+                )
+
+        # 4. Return result
+        result = {
+            "status": "completed",
+            "total_videos": total,
+            "successful_count": successful_count,
+            "failed_count": len(failed_videos),
+            "failed_videos": failed_videos,
+            "message": f"Re-indexed {successful_count}/{total} videos",
+        }
+
+        logger.info(f"Re-indexing completed: {result['message']}")
+        return result
+
+    except Exception as e:
+        logger.error(f"Re-indexing task failed: {str(e)}", exc_info=True)
+        return {
+            "status": "failed",
+            "error": str(e),
+            "message": "Re-indexing task encountered an error",
+        }

--- a/backend/app/tasks/vector_indexing.py
+++ b/backend/app/tasks/vector_indexing.py
@@ -4,7 +4,6 @@ Vector indexing utilities for RAG
 
 import logging
 
-from django.conf import settings
 from langchain_postgres import PGVector
 
 from app.tasks.srt_processing import parse_srt_scenes

--- a/backend/app/tasks/vector_indexing.py
+++ b/backend/app/tasks/vector_indexing.py
@@ -14,15 +14,13 @@ from app.utils.vector_manager import PGVectorManager
 logger = logging.getLogger(__name__)
 
 
-def index_scenes_to_vectorstore(scene_docs, video, api_key):
+def index_scenes_to_vectorstore(scene_docs, video, api_key=None):
     """
     Create vector index using LangChain + pgvector
     scene_docs: [{text, metadata}]
-    api_key: API key for OpenAI (required when using OpenAI provider)
+    api_key: Optional API key for OpenAI (uses environment variable if not provided)
     """
     try:
-        if settings.EMBEDDING_PROVIDER == "openai" and not api_key:
-            raise ValueError("OpenAI API key is required when using OpenAI embeddings")
         embeddings = get_embeddings(api_key)
         config = PGVectorManager.get_config()
 
@@ -87,10 +85,9 @@ def create_scene_metadata(video, scene):
 def index_scenes_batch(scene_split_srt, video, api_key=None):
     """
     Batch index scenes to pgvector
+    api_key: Optional API key for OpenAI (uses environment variable if not provided)
     """
     try:
-        if settings.EMBEDDING_PROVIDER == "openai" and not api_key:
-            raise ValueError("OpenAI API key is required when using OpenAI embeddings")
         logger.info("Starting scene indexing to pgvector...")
         scenes = parse_srt_scenes(scene_split_srt)
         logger.info(f"Parsed {len(scenes)} scenes from SRT")
@@ -108,3 +105,4 @@ def index_scenes_batch(scene_split_srt, video, api_key=None):
 
     except Exception as e:
         logger.warning(f"Failed to prepare scenes for indexing: {e}", exc_info=True)
+        raise  # Re-raise exception for caller to handle

--- a/backend/app/utils/embeddings.py
+++ b/backend/app/utils/embeddings.py
@@ -15,7 +15,7 @@ def get_embeddings(api_key: Optional[str] = None) -> Embeddings:
     Get the configured embedding model based on EMBEDDING_PROVIDER setting.
 
     Args:
-        api_key: Optional API key for OpenAI. Required when using OpenAI provider.
+        api_key: Optional API key for OpenAI. If not provided, uses OPENAI_API_KEY environment variable.
 
     Returns:
         Embeddings: An instance of the configured embedding model.
@@ -26,10 +26,15 @@ def get_embeddings(api_key: Optional[str] = None) -> Embeddings:
     provider = settings.EMBEDDING_PROVIDER
 
     if provider == "openai":
-        if not api_key:
-            raise ValueError("OpenAI API key is required when using OpenAI embeddings")
+        # Use provided api_key or fall back to environment variable
+        openai_key = api_key or settings.OPENAI_API_KEY
+        if not openai_key:
+            raise ValueError(
+                "OpenAI API key is required when using OpenAI embeddings. "
+                "Provide api_key parameter or set OPENAI_API_KEY environment variable."
+            )
         return OpenAIEmbeddings(
-            model=settings.EMBEDDING_MODEL, api_key=SecretStr(api_key)
+            model=settings.EMBEDDING_MODEL, api_key=SecretStr(openai_key)
         )
 
     elif provider == "ollama":

--- a/docs/requirements/use-case-diagram.md
+++ b/docs/requirements/use-case-diagram.md
@@ -10,7 +10,8 @@ This diagram represents the main use cases of the VideoQ system.
 graph TB
     User[User]
     Guest[Guest User]
-    
+    Admin[Administrator]
+
     subgraph Authentication["Authentication"]
         UC1[Sign Up]
         UC2[Email Verification]
@@ -19,7 +20,7 @@ graph TB
         UC5[Password Reset]
         UC6[Token Refresh]
     end
-    
+
     subgraph VideoManagement["Video Management"]
         UC7[Upload Video]
         UC8[List Videos]
@@ -28,12 +29,12 @@ graph TB
         UC11[Delete Video]
         UC12[View Transcript]
     end
-    
+
     subgraph Transcription["Transcription Processing"]
         UC13[Auto Transcription]
         UC14[Check Transcription Status]
     end
-    
+
     subgraph GroupManagement["Group Management"]
         UC15[Create Group]
         UC16[List Groups]
@@ -44,26 +45,31 @@ graph TB
         UC21[Remove Video from Group]
         UC22[Reorder Videos in Group]
     end
-    
+
     subgraph Chat["Chat Features"]
         UC23[Send Chat]
         UC24[View Chat History]
         UC25[Export Chat History]
         UC26[Send Feedback]
     end
-    
+
     subgraph Sharing["Sharing Features"]
         UC27[Generate Share Link]
         UC28[Delete Share Link]
         UC29[View Shared Group]
         UC30[Chat with Shared Group]
     end
-    
+
     subgraph Settings["Settings"]
         UC31[View User Info]
         UC32[Set OpenAI API Key]
         UC33[Delete OpenAI API Key]
         UC34[Configure LLM Settings]
+    end
+
+    subgraph Administration["Administration"]
+        UC35[Re-index Video Embeddings]
+        UC36[Monitor Re-indexing Progress]
     end
     
     User --> UC1
@@ -103,9 +109,13 @@ graph TB
     
     Guest --> UC29
     Guest --> UC30
-    
+
+    Admin --> UC35
+    Admin --> UC36
+
     UC7 -.->|Auto Execute| UC13
     UC13 -.->|Completion Notification| UC14
+    UC13 -.->|Creates Embeddings| UC35
     UC20 --> UC23
     UC27 --> UC29
     UC29 --> UC30
@@ -161,4 +171,11 @@ graph TB
 - **UC33 Delete OpenAI API Key**: Delete user's stored OpenAI API key
 - **UC34 Configure LLM Settings**: Configure preferred LLM model and temperature (0.0-2.0)
 
-**Note:** OpenAI API key is managed per user (stored encrypted). For share-link chat, the group owner's API key is used. When using local whisper.cpp server (WHISPER_BACKEND=local), OpenAI API key is not required for transcription.
+### Administration
+- **UC35 Re-index Video Embeddings**: Re-generate all video embeddings with new model (superuser only)
+- **UC36 Monitor Re-indexing Progress**: Monitor re-indexing task progress via Celery logs
+
+**Note:**
+- OpenAI API key is managed per user (stored encrypted). For share-link chat, the group owner's API key is used.
+- When using local whisper.cpp server (WHISPER_BACKEND=local), OpenAI API key is not required for transcription.
+- Re-indexing uses the global `OPENAI_API_KEY` environment variable and is required when switching embedding providers (OpenAI ↔ Ollama) or models.


### PR DESCRIPTION
Add admin functionality to re-index all video embeddings when switching embedding models (e.g., OpenAI ↔ Ollama).

Changes:
- Add reindex_all_videos_embeddings Celery task
- Add Django admin action "Re-index video embeddings"
- Add delete_all_vectors() to vector_manager
- Update embeddings.py to use OPENAI_API_KEY env var as fallback
- Fix vector_indexing.py to make api_key optional and re-raise exceptions
- Export new task in tasks/__init__.py

The re-indexing process:
1. Deletes all existing vectors from pgvector
2. Re-generates embeddings using current EMBEDDING_PROVIDER
3. Uses environment variables (no user API keys required)
4. Handles errors gracefully and reports failed videos

Usage: Django admin → Videos → Select action → "Re-index video embeddings"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Superuser-only admin action to re-index all video embeddings; starts an asynchronous background job and reports the task ID (re-indexes all videos regardless of selection).

* **Refactor**
  * Embedding API key now optional with fallback to environment variable.
  * Added ability to delete all stored vectors.
  * Improved error handling and logging across embedding/indexing flows.

* **Documentation**
  * Expanded re-indexing guide, diagrams, and admin workflow instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->