### PR TITLE
docs: remove references to deleted Per-User LLM Settings feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ videoq/
 
 #### AI/ML
 - **OpenAI API**: Whisper (transcription), Chat (dialogue), Embeddings (vectorization)
-  - Chat model and temperature are user-configurable (see Per-User LLM Settings)
   - Embedding and LLM providers are configurable (OpenAI or Ollama)
   - Model selection via `EMBEDDING_MODEL` and `LLM_MODEL` environment variables
 - **Ollama** (optional): Local LLM and embedding models without API keys

--- a/docs/architecture/prompt-engineering.md
+++ b/docs/architecture/prompt-engineering.md
@@ -4,21 +4,6 @@
 
 VideoQ's AI chat feature uses RAG (Retrieval-Augmented Generation) architecture to generate answers based on video transcription data. This document describes the design and implementation of prompt engineering used in RAG.
 
-## User-Configurable LLM Settings
-
-Each user can customize their LLM preferences via the Settings page:
-
-- **LLM Model**: The chat model used for generating responses (e.g., `gpt-4o-mini`, `gpt-4o`, `gpt-4-turbo`)
-  - Default: `gpt-4o-mini`
-  - Stored in `User.preferred_llm_model`
-- **Temperature**: Controls randomness/creativity of responses (range: 0.0 to 2.0)
-  - Default: `0.0`
-  - Stored in `User.preferred_llm_temperature`
-  - Lower values produce more focused, deterministic outputs
-  - Higher values produce more creative, varied outputs
-
-These settings are applied when generating chat responses using the `get_langchain_llm` function in `backend/app/chat/services/llm.py`.
-
 ## Architecture
 
 ### Prompt Components

--- a/docs/architecture/system-configuration-diagram.md
+++ b/docs/architecture/system-configuration-diagram.md
@@ -69,7 +69,7 @@ graph TB
     subgraph External["External Services"]
         OpenAI["OpenAI API
         - Whisper API (or local whisper.cpp)
-        - GPT API (user-configurable model/temp)
+        - GPT API
         - Embeddings API (EMBEDDING_PROVIDER=openai)"]
         Ollama["Ollama Server
         Optional (Local)

--- a/docs/database/data-dictionary.md
+++ b/docs/database/data-dictionary.md
@@ -32,10 +32,7 @@ Table that stores user information for the system.
 | is_superuser | BOOLEAN | NOT NULL | False | Superuser permissions |
 | first_name | VARCHAR(150) | NOT NULL | '' | First name |
 | last_name | VARCHAR(150) | NOT NULL | '' | Last name |
-| openai_api_key_encrypted | BYTEA | NULL | NULL | Encrypted OpenAI API key (stored per user) |
 | video_limit | INTEGER | NULL, CHECK (video_limit >= 0) | 0 | Max number of videos the user can upload (`NULL` = unlimited, `0` = uploads disabled) |
-| preferred_llm_model | VARCHAR(100) | NOT NULL | 'gpt-4o-mini' | Preferred LLM model for chat (e.g., gpt-4o-mini, gpt-4o, gpt-4-turbo) |
-| preferred_llm_temperature | REAL | NOT NULL, CHECK (0.0 <= preferred_llm_temperature <= 2.0) | 0.0 | Temperature for LLM responses (0.0 to 2.0) |
 
 ### Indexes
 - PRIMARY KEY: `id`

--- a/docs/database/er-diagram.md
+++ b/docs/database/er-diagram.md
@@ -30,10 +30,7 @@ erDiagram
         bool is_superuser
         string first_name
         string last_name
-        bytes openai_api_key_encrypted
         int video_limit
-        string preferred_llm_model
-        float preferred_llm_temperature
     }
     
     Video {
@@ -172,7 +169,6 @@ erDiagram
 ### Check Constraints
 - `Video.status`: Must be one of 'pending', 'processing', 'completed', 'error'
 - `ChatLog.feedback`: Must be 'good', 'bad', or NULL
-- `User.preferred_llm_temperature`: Must be between 0.0 and 2.0
 
 ## Indexes
 

--- a/docs/design/class-diagram.md
+++ b/docs/design/class-diagram.md
@@ -16,10 +16,7 @@ classDiagram
         +bool is_active
         +bool is_staff
         +bool is_superuser
-        +bytes openai_api_key_encrypted
         +int video_limit (nullable)
-        +string preferred_llm_model
-        +float preferred_llm_temperature
     }
     
     class Video {

--- a/docs/design/sequence-diagram.md
+++ b/docs/design/sequence-diagram.md
@@ -76,13 +76,12 @@ sequenceDiagram
     User->>Frontend: Input Question
     Frontend->>Backend: POST /api/chat/ (body: group_id=123)
     Backend->>Backend: Get OpenAI API Key (User)
-    Backend->>Backend: Get User LLM Settings<br/>(model, temperature)
     Backend->>DB: Get VideoGroup
     DB-->>Backend: VideoGroup Information
     Backend->>PGVector: Search Related Scenes(Vector Search)
     PGVector-->>Backend: Related Scenes List
     Backend->>Backend: Build Context
-    Backend->>OpenAI: Send Chat Request<br/>(with user's model/temp)
+    Backend->>OpenAI: Send Chat Request
     OpenAI-->>Backend: LLM Answer
     Backend->>DB: Save ChatLog
     DB-->>Backend: ChatLog Saved
@@ -160,7 +159,6 @@ sequenceDiagram
     Backend->>DB: Get VideoGroup by id + share_token
     DB-->>Backend: VideoGroup Information
     Backend->>Backend: Get OpenAI API Key (Group Owner)
-    Backend->>Backend: Get Owner's LLM Settings<br/>(model, temperature)
     Backend->>Backend: Execute RAG Processing
     Backend->>DB: Save ChatLog(is_shared_origin: True)
     Backend-->>Frontend: Answer


### PR DESCRIPTION
Remove all documentation references to the user-configurable LLM settings (preferred_llm_model, preferred_llm_temperature, openai_api_key_encrypted) that were removed in migration 0012.

Updated files:
- README.md: Remove mention of user-configurable chat model/temperature
- docs/database/er-diagram.md: Remove fields from User entity and constraints
- docs/database/data-dictionary.md: Remove fields from User table definition
- docs/architecture/prompt-engineering.md: Remove entire "User-Configurable LLM Settings" section
- docs/design/class-diagram.md: Remove fields from User class
- docs/architecture/system-configuration-diagram.md: Update OpenAI API description
- docs/design/sequence-diagram.md: Remove "Get User LLM Settings" steps from chat flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated documentation to remove references to user-configurable LLM model and temperature settings, including removal of configuration details from architecture guides, database schema documentation, and system design diagrams.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->