### PR TITLE
refactor: rename WHISPER_BACKEND value from "local" to "whisper.cpp"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,6 @@ LLM_PROVIDER=openai
 LLM_MODEL=gpt-4o-mini
 
 # Whisper backend settings
-# WHISPER_BACKEND: "openai" (default) or "local" (whisper.cpp server)
+# WHISPER_BACKEND: "openai" (default) or "whisper.cpp" (local whisper.cpp server)
 WHISPER_BACKEND=openai
 WHISPER_LOCAL_URL=http://host.docker.internal:8080

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ bash ./models/download-ggml-model.sh large-v3-turbo
 Update `.env` in VideoQ root:
 
 ```bash
-WHISPER_BACKEND=local
+WHISPER_BACKEND=whisper.cpp
 WHISPER_LOCAL_URL=http://host.docker.internal:8080
 ```
 

--- a/backend/app/utils/whisper_client.py
+++ b/backend/app/utils/whisper_client.py
@@ -14,7 +14,7 @@ class WhisperConfig:
     """Configuration for Whisper backend selection"""
 
     BACKEND_OPENAI = "openai"
-    BACKEND_LOCAL = "local"
+    BACKEND_LOCAL = "whisper.cpp"
 
     def __init__(self):
         self.backend = os.getenv("WHISPER_BACKEND", self.BACKEND_OPENAI).lower()

--- a/backend/app/utils/whisper_client.py
+++ b/backend/app/utils/whisper_client.py
@@ -17,6 +17,11 @@ class WhisperConfig:
     BACKEND_LOCAL = "whisper.cpp"
 
     def __init__(self):
+        """
+        Initialize WhisperConfig from environment variables.
+        
+        Reads WHISPER_BACKEND (default "openai") and WHISPER_LOCAL_URL (default "http://host.docker.internal:8080"), stores the lowercase backend in `self.backend` and the local server URL in `self.local_url`. Logs the configured backend and, if the backend equals BACKEND_LOCAL, logs the local server URL.
+        """
         self.backend = os.getenv("WHISPER_BACKEND", self.BACKEND_OPENAI).lower()
         self.local_url = os.getenv(
             "WHISPER_LOCAL_URL", "http://host.docker.internal:8080"

--- a/docs/architecture/bpmn.md
+++ b/docs/architecture/bpmn.md
@@ -45,7 +45,7 @@ flowchart TD
     
     ProcessTask --> ExtractAudio[Extract Audio]
     ExtractAudio --> CheckBackend{"WHISPER_BACKEND<br>Setting Check"}
-    CheckBackend -->|local| Transcribe[Execute Transcription<br>Local whisper.cpp]
+    CheckBackend -->|whisper.cpp| Transcribe[Execute Transcription<br>Local whisper.cpp]
     CheckBackend -->|openai| TranscribeAPI[Execute Transcription<br>OpenAI API]
     Transcribe --> CheckResult{Processing Result}
     TranscribeAPI --> CheckResult

--- a/docs/architecture/flowchart.md
+++ b/docs/architecture/flowchart.md
@@ -26,7 +26,7 @@ flowchart TD
     Worker --> UpdateStatus[Update status: processing]
     UpdateStatus --> SaveDB2[(Database Update)]
     SaveDB2 --> CheckBackend{"WHISPER_BACKEND<br>Setting Check"}
-    CheckBackend -->|local| CheckFile2{"File Exists<br>Check"}
+    CheckBackend -->|whisper.cpp| CheckFile2{"File Exists<br>Check"}
     CheckBackend -->|openai| CheckFile{"File Exists<br>Check"}
     CheckFile -->|Not Exists| Error3[Error Processing]
     CheckFile -->|Exists| Extract[Extract Audio<br/>with ffmpeg]

--- a/docs/database/data-flow-diagram.md
+++ b/docs/database/data-flow-diagram.md
@@ -25,7 +25,7 @@ flowchart TD
     UpdateStatus --> SaveDB2[(Database<br/>Update)]
     
     SaveDB2 --> CheckBackend{"WHISPER_BACKEND<br>Setting Check"}
-    CheckBackend -->|local| ReadFile2[File Storage<br/>Read Video File]
+    CheckBackend -->|whisper.cpp| ReadFile2[File Storage<br/>Read Video File]
     CheckBackend -->|openai| ReadFile[File Storage<br/>Read Video File]
 
     Worker --> ReadFile[File Storage<br/>Read Video File]

--- a/docs/design/deployment-diagram.md
+++ b/docs/design/deployment-diagram.md
@@ -227,7 +227,7 @@ graph TB
         E13[AWS_*]
         E14["OPENAI_API_KEY<br/>(required when using OpenAI services)"]
         E15[VITE_API_URL]
-        E16["WHISPER_BACKEND<br/>(openai or local)"]
+        E16["WHISPER_BACKEND<br/>(openai or whisper.cpp)"]
         E17["WHISPER_LOCAL_URL<br/>(local whisper.cpp server URL)"]
         E18["EMBEDDING_PROVIDER<br/>(openai or ollama)"]
         E19["EMBEDDING_MODEL<br/>(embedding model for selected provider)"]

--- a/docs/design/sequence-diagram.md
+++ b/docs/design/sequence-diagram.md
@@ -30,7 +30,7 @@ sequenceDiagram
     Celery->>DB: Update status(processing)
     Celery->>Celery: Extract Audio with ffmpeg
     Celery->>Celery: Check WHISPER_BACKEND setting
-    alt WHISPER_BACKEND=local
+    alt WHISPER_BACKEND=whisper.cpp
         Note over Celery,Whisper: Local whisper.cpp server (no API key needed)
         Celery->>Whisper: Send Audio File (local server)
         Whisper-->>Celery: Transcription Result

--- a/docs/requirements/activity-diagram.md
+++ b/docs/requirements/activity-diagram.md
@@ -18,7 +18,7 @@ flowchart TD
     Queue --> Worker[Celery Worker<br/>Receives Task]
     Worker --> UpdateStatus1[Update status: processing]
     UpdateStatus1 --> CheckBackend{"WHISPER_BACKEND<br>Setting Check"}
-    CheckBackend -->|local| Extract[Extract Audio with ffmpeg]
+    CheckBackend -->|whisper.cpp| Extract[Extract Audio with ffmpeg]
     CheckBackend -->|openai| Extract[Extract Audio with ffmpeg]
     Extract --> CheckSize{"File Size<br>Check"}
     CheckSize -->|24MB or less| Transcribe1[Execute Transcription<br/>with Whisper API]

--- a/docs/requirements/use-case-diagram.md
+++ b/docs/requirements/use-case-diagram.md
@@ -168,5 +168,5 @@ graph TB
 
 **Note:**
 - LLM and embedding configuration is managed globally via environment variables (`LLM_PROVIDER`, `LLM_MODEL`, `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`).
-- When using local whisper.cpp server (WHISPER_BACKEND=local), OpenAI API key is not required for transcription.
+- When using local whisper.cpp server (WHISPER_BACKEND=whisper.cpp), OpenAI API key is not required for transcription.
 - Re-indexing uses the global `OPENAI_API_KEY` or `OLLAMA_BASE_URL` environment variable (depending on `EMBEDDING_PROVIDER`) and is required when switching embedding providers (OpenAI ↔ Ollama) or models.


### PR DESCRIPTION
Update the WHISPER_BACKEND configuration value from "local" to "whisper.cpp" across codebase and documentation for clearer identification of the whisper.cpp backend implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Clarified the local backend identifier in environment examples and config from "local" to "whisper.cpp".

* **Documentation**
  * Updated architecture, design, and flow diagrams and related docs to reflect the "whisper.cpp" backend label across the project.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->