### PR TITLE
chore: upgrade Node.js to 24.13.0 in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12.0-alpine AS build
+FROM node:24.13.0-alpine3.23 AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
Update Node.js base image from 22.12.0-alpine to 24.13.0-alpine3.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Node.js base image version in the build environment to a newer release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->