### PR TITLE
Fix video URL generation to preserve frontend port number

### DIFF
--- a/frontend/src/components/video/VideoCard.tsx
+++ b/frontend/src/components/video/VideoCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { VideoInGroup, VideoList as VideoListType } from '@/lib/api';
+import { apiClient } from '@/lib/api';
 import { Card, CardContent } from '@/components/ui/card';
 import { getStatusBadgeClassName, getStatusLabel, formatDate } from '@/lib/utils/video';
 import { Link } from '@/lib/i18n';
@@ -39,7 +40,7 @@ export function VideoCard({ video, showLink = true, className = '', onClick }: V
               muted
               playsInline
               preload="metadata"
-              src={video.file}
+              src={apiClient.getVideoUrl(video.file)}
               onMouseEnter={(e) => {
                 const video = e.currentTarget;
                 video.play().catch(() => {});

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -59,6 +59,18 @@ describe('ApiClient', () => {
       const result = apiClient.getVideoUrl(videoFile);
       expect(result).toBe('http://localhost:60158/api/media/videos/1/video.mp4');
     });
+
+    it('should rewrite absolute API URL with frontend origin', () => {
+      const videoFile = 'http://localhost:8000/api/media/videos/1/video.mp4';
+      const result = apiClient.getVideoUrl(videoFile);
+      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4');
+    });
+
+    it('should preserve external URLs like S3 without rewriting', () => {
+      const videoFile = 'https://s3.amazonaws.com/bucket/videos/1/video.mp4';
+      const result = apiClient.getVideoUrl(videoFile);
+      expect(result).toBe('https://s3.amazonaws.com/bucket/videos/1/video.mp4');
+    });
   });
 
   describe('getSharedVideoUrl', () => {
@@ -97,6 +109,20 @@ describe('ApiClient', () => {
       const shareToken = 'test-token-abc';
       const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
       expect(result).toBe('http://localhost:60158/api/media/videos/1/video.mp4?share_token=test-token-abc');
+    });
+
+    it('should rewrite absolute API URL with frontend origin and add share_token', () => {
+      const videoFile = 'http://localhost:8000/api/media/videos/1/video.mp4';
+      const shareToken = 'test-token-def';
+      const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
+      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?share_token=test-token-def');
+    });
+
+    it('should add share_token to external URLs like S3 without rewriting origin', () => {
+      const videoFile = 'https://s3.amazonaws.com/bucket/videos/1/video.mp4';
+      const shareToken = 'test-token-ghi';
+      const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
+      expect(result).toBe('https://s3.amazonaws.com/bucket/videos/1/video.mp4?share_token=test-token-ghi');
     });
   });
 });

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { apiClient } from '../api';
+
+describe('ApiClient', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    // Save original location
+    originalLocation = window.location;
+
+    // Mock window.location.origin
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        ...originalLocation,
+        origin: 'http://localhost:3000',
+      },
+    });
+  });
+
+  afterEach(() => {
+    // Restore original location
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  describe('getVideoUrl', () => {
+    it('should convert relative path to absolute URL with current origin', () => {
+      const videoFile = '/api/media/videos/1/video.mp4';
+      const result = apiClient.getVideoUrl(videoFile);
+      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4');
+    });
+
+    it('should handle URL with query parameters', () => {
+      const videoFile = '/api/media/videos/1/video.mp4?v=123';
+      const result = apiClient.getVideoUrl(videoFile);
+      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?v=123');
+    });
+
+    it('should preserve hash in URL', () => {
+      const videoFile = '/api/media/videos/1/video.mp4#t=10';
+      const result = apiClient.getVideoUrl(videoFile);
+      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4#t=10');
+    });
+
+    it('should work with different port numbers', () => {
+      // Change origin to non-standard port
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: {
+          ...originalLocation,
+          origin: 'http://localhost:60158',
+        },
+      });
+
+      const videoFile = '/api/media/videos/1/video.mp4';
+      const result = apiClient.getVideoUrl(videoFile);
+      expect(result).toBe('http://localhost:60158/api/media/videos/1/video.mp4');
+    });
+  });
+
+  describe('getSharedVideoUrl', () => {
+    it('should add share_token query parameter to relative path', () => {
+      const videoFile = '/api/media/videos/1/video.mp4';
+      const shareToken = 'test-token-123';
+      const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
+      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?share_token=test-token-123');
+    });
+
+    it('should append share_token to existing query parameters', () => {
+      const videoFile = '/api/media/videos/1/video.mp4?v=123';
+      const shareToken = 'test-token-456';
+      const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
+      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?v=123&share_token=test-token-456');
+    });
+
+    it('should preserve hash in URL', () => {
+      const videoFile = '/api/media/videos/1/video.mp4#t=10';
+      const shareToken = 'test-token-789';
+      const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
+      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?share_token=test-token-789#t=10');
+    });
+
+    it('should work with different port numbers', () => {
+      // Change origin to non-standard port
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: {
+          ...originalLocation,
+          origin: 'http://localhost:60158',
+        },
+      });
+
+      const videoFile = '/api/media/videos/1/video.mp4';
+      const shareToken = 'test-token-abc';
+      const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
+      expect(result).toBe('http://localhost:60158/api/media/videos/1/video.mp4?share_token=test-token-abc');
+    });
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -674,6 +674,12 @@ class ApiClient {
     return response.json();
   }
 
+  // Get video URL with correct origin
+  getVideoUrl(videoFile: string): string {
+    const url = new URL(videoFile, window.location.origin);
+    return url.toString();
+  }
+
   // Get video URL for shared group (add share_token as query parameter)
   getSharedVideoUrl(videoFile: string, shareToken: string): string {
     const url = new URL(videoFile, window.location.origin);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -676,13 +676,31 @@ class ApiClient {
 
   // Get video URL with correct origin
   getVideoUrl(videoFile: string): string {
-    const url = new URL(videoFile, window.location.origin);
+    const baseOrigin = window.location.origin;
+    const apiOrigin = new URL(API_URL, baseOrigin).origin;
+    const url = new URL(videoFile, baseOrigin);
+
+    // Only rewrite URL if it's from the API origin (not external URLs like S3)
+    if (url.origin === apiOrigin) {
+      return new URL(`${url.pathname}${url.search}${url.hash}`, baseOrigin).toString();
+    }
     return url.toString();
   }
 
   // Get video URL for shared group (add share_token as query parameter)
   getSharedVideoUrl(videoFile: string, shareToken: string): string {
-    const url = new URL(videoFile, window.location.origin);
+    const baseOrigin = window.location.origin;
+    const apiOrigin = new URL(API_URL, baseOrigin).origin;
+    const url = new URL(videoFile, baseOrigin);
+
+    // Only rewrite URL if it's from the API origin (not external URLs like S3)
+    if (url.origin === apiOrigin) {
+      const rewrittenUrl = new URL(`${url.pathname}${url.search}${url.hash}`, baseOrigin);
+      rewrittenUrl.searchParams.set('share_token', shareToken);
+      return rewrittenUrl.toString();
+    }
+
+    // For external URLs, just add share_token
     url.searchParams.set('share_token', shareToken);
     return url.toString();
   }

--- a/frontend/src/lib/utils/__tests__/video.test.ts
+++ b/frontend/src/lib/utils/__tests__/video.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { getStatusLabel, timeStringToSeconds } from '../video';
+
+describe('video utils', () => {
+  describe('getStatusLabel', () => {
+    it('should return translation key for status', () => {
+      expect(getStatusLabel('pending')).toBe('common.status.pending');
+      expect(getStatusLabel('processing')).toBe('common.status.processing');
+      expect(getStatusLabel('completed')).toBe('common.status.completed');
+      expect(getStatusLabel('error')).toBe('common.status.error');
+    });
+
+    it('should handle unknown status', () => {
+      expect(getStatusLabel('unknown')).toBe('common.status.unknown');
+    });
+  });
+
+  describe('timeStringToSeconds', () => {
+    it('should convert HH:MM:SS format to seconds', () => {
+      expect(timeStringToSeconds('01:30:45')).toBe(5445); // 1*3600 + 30*60 + 45
+      expect(timeStringToSeconds('00:00:30')).toBe(30);
+      expect(timeStringToSeconds('02:00:00')).toBe(7200);
+    });
+
+    it('should convert MM:SS format to seconds', () => {
+      expect(timeStringToSeconds('05:30')).toBe(330); // 5*60 + 30
+      expect(timeStringToSeconds('00:45')).toBe(45);
+      expect(timeStringToSeconds('10:00')).toBe(600);
+    });
+
+    it('should convert SS format to seconds', () => {
+      expect(timeStringToSeconds('45')).toBe(45);
+      expect(timeStringToSeconds('120')).toBe(120);
+    });
+
+    it('should handle time with milliseconds', () => {
+      expect(timeStringToSeconds('01:30:45,123')).toBe(5445);
+      expect(timeStringToSeconds('01:30:45.456')).toBe(5445);
+    });
+
+    it('should return 0 for empty or invalid input', () => {
+      expect(timeStringToSeconds('')).toBe(0);
+      expect(timeStringToSeconds('invalid')).toBe(0);
+      expect(timeStringToSeconds(':::')).toBe(0);
+    });
+  });
+});

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -321,7 +321,7 @@ export default function VideoDetailPage() {
                   ref={videoRef}
                   controls
                   className="w-full rounded"
-                  src={video.file}
+                  src={apiClient.getVideoUrl(video.file)}
                   onLoadedMetadata={handleVideoLoaded}
                 >
                   {t('common.messages.browserNoVideoSupport')}

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -863,7 +863,7 @@ export default function VideoGroupDetailPage() {
                           key={selectedVideo.id}
                           controls
                           className="w-full h-full max-h-[400px] lg:max-h-[500px] rounded object-contain"
-                          src={selectedVideo.file}
+                          src={apiClient.getVideoUrl(selectedVideo.file)}
                           onCanPlay={handleVideoCanPlay}
                         >
                           {t('common.messages.browserNoVideoSupport')}


### PR DESCRIPTION
Previously, video URLs used the backend's host and port, causing videos to fail when the frontend runs on a non-standard port (e.g., :60158). This fix reconstructs video URLs on the frontend side using window.location.origin, similar to the existing share page implementation.

Changes:
- Add getVideoUrl() method to ApiClient
- Update VideoCard, VideoDetailPage, and VideoGroupDetailPage to use getVideoUrl()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video URL handling across video cards and playback pages for more reliable playback, sharing, and thumbnail behavior.

* **Tests**
  * Added unit tests for video URL construction and for video utilities (status labels and time parsing) to ensure consistent playback, sharing, and time/status displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->