### PR TITLE
Fix video URL to always return relative URLs for consistent port hand…

### DIFF
--- a/backend/app/video/serializers.py
+++ b/backend/app/video/serializers.py
@@ -8,6 +8,16 @@ from app.tasks import transcribe_video
 logger = logging.getLogger(__name__)
 
 
+class RelativeFileField(serializers.FileField):
+    """Custom FileField that always returns relative URLs instead of absolute URLs"""
+
+    def to_representation(self, value):
+        if not value:
+            return None
+        # Return only the relative URL path (without host/port)
+        return value.url
+
+
 class UserOwnedSerializerMixin:
     """Common serializer base class for user-owned resources"""
 
@@ -29,6 +39,7 @@ class VideoSerializer(serializers.ModelSerializer):
     """Serializer for Video model"""
 
     tags = serializers.SerializerMethodField()
+    file = RelativeFileField(read_only=True)
 
     class Meta:
         model = Video
@@ -123,6 +134,7 @@ class VideoListSerializer(serializers.ModelSerializer):
     """Serializer for Video list"""
 
     tags = serializers.SerializerMethodField()
+    file = RelativeFileField(read_only=True)
 
     class Meta:
         model = Video


### PR DESCRIPTION
…ling

Previously, video file URLs were returned as absolute URLs with incorrect port numbers (http://localhost/api/media/...) due to Django REST Framework's default FileField behavior when request context is provided. This caused videos to fail loading when the frontend runs on non-standard ports.

The shared group API worked correctly because it didn't pass request context, resulting in relative URLs that the frontend could properly resolve.

Changes:
- Add RelativeFileField that always returns relative URLs (value.url)
- Update VideoSerializer and VideoListSerializer to use RelativeFileField
- Ensures consistency with shared group API behavior
- Works with both local storage (relative URLs) and S3 (absolute S3 URLs)

This fix ensures all video URLs are returned in a format that allows the frontend to correctly resolve them with the appropriate port number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Video file URLs in API responses now return as relative paths instead of absolute URLs, providing more flexible file access across different environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->