### PR TITLE
Fix video URL to use absolute URLs from backend for separate deployment

### DIFF
--- a/backend/app/video/serializers.py
+++ b/backend/app/video/serializers.py
@@ -8,16 +8,6 @@ from app.tasks import transcribe_video
 logger = logging.getLogger(__name__)
 
 
-class RelativeFileField(serializers.FileField):
-    """Custom FileField that always returns relative URLs instead of absolute URLs"""
-
-    def to_representation(self, value):
-        if not value:
-            return None
-        # Return only the relative URL path (without host/port)
-        return value.url
-
-
 class UserOwnedSerializerMixin:
     """Common serializer base class for user-owned resources"""
 
@@ -39,7 +29,6 @@ class VideoSerializer(serializers.ModelSerializer):
     """Serializer for Video model"""
 
     tags = serializers.SerializerMethodField()
-    file = RelativeFileField(read_only=True)
 
     class Meta:
         model = Video
@@ -134,7 +123,6 @@ class VideoListSerializer(serializers.ModelSerializer):
     """Serializer for Video list"""
 
     tags = serializers.SerializerMethodField()
-    file = RelativeFileField(read_only=True)
 
     class Meta:
         model = Video

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -27,46 +27,31 @@ describe('ApiClient', () => {
   });
 
   describe('getVideoUrl', () => {
-    it('should convert relative path to absolute URL with current origin', () => {
-      const videoFile = '/api/media/videos/1/video.mp4';
+    it('should return backend absolute URL as-is', () => {
+      const videoFile = 'http://localhost:8000/media/videos/1/video.mp4';
       const result = apiClient.getVideoUrl(videoFile);
-      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4');
+      expect(result).toBe('http://localhost:8000/media/videos/1/video.mp4');
     });
 
     it('should handle URL with query parameters', () => {
-      const videoFile = '/api/media/videos/1/video.mp4?v=123';
+      const videoFile = 'http://localhost:8000/media/videos/1/video.mp4?v=123';
       const result = apiClient.getVideoUrl(videoFile);
-      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?v=123');
+      expect(result).toBe('http://localhost:8000/media/videos/1/video.mp4?v=123');
     });
 
     it('should preserve hash in URL', () => {
-      const videoFile = '/api/media/videos/1/video.mp4#t=10';
+      const videoFile = 'http://localhost:8000/media/videos/1/video.mp4#t=10';
       const result = apiClient.getVideoUrl(videoFile);
-      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4#t=10');
+      expect(result).toBe('http://localhost:8000/media/videos/1/video.mp4#t=10');
     });
 
-    it('should work with different port numbers', () => {
-      // Change origin to non-standard port
-      Object.defineProperty(window, 'location', {
-        writable: true,
-        value: {
-          ...originalLocation,
-          origin: 'http://localhost:60158',
-        },
-      });
-
-      const videoFile = '/api/media/videos/1/video.mp4';
+    it('should work with production backend URLs', () => {
+      const videoFile = 'https://api.example.com/media/videos/1/video.mp4';
       const result = apiClient.getVideoUrl(videoFile);
-      expect(result).toBe('http://localhost:60158/api/media/videos/1/video.mp4');
+      expect(result).toBe('https://api.example.com/media/videos/1/video.mp4');
     });
 
-    it('should rewrite absolute API URL with frontend origin', () => {
-      const videoFile = 'http://localhost:8000/api/media/videos/1/video.mp4';
-      const result = apiClient.getVideoUrl(videoFile);
-      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4');
-    });
-
-    it('should preserve external URLs like S3 without rewriting', () => {
+    it('should preserve external URLs like S3', () => {
       const videoFile = 'https://s3.amazonaws.com/bucket/videos/1/video.mp4';
       const result = apiClient.getVideoUrl(videoFile);
       expect(result).toBe('https://s3.amazonaws.com/bucket/videos/1/video.mp4');
@@ -74,51 +59,35 @@ describe('ApiClient', () => {
   });
 
   describe('getSharedVideoUrl', () => {
-    it('should add share_token query parameter to relative path', () => {
-      const videoFile = '/api/media/videos/1/video.mp4';
+    it('should add share_token query parameter to backend URL', () => {
+      const videoFile = 'http://localhost:8000/media/videos/1/video.mp4';
       const shareToken = 'test-token-123';
       const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
-      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?share_token=test-token-123');
+      expect(result).toBe('http://localhost:8000/media/videos/1/video.mp4?share_token=test-token-123');
     });
 
     it('should append share_token to existing query parameters', () => {
-      const videoFile = '/api/media/videos/1/video.mp4?v=123';
+      const videoFile = 'http://localhost:8000/media/videos/1/video.mp4?v=123';
       const shareToken = 'test-token-456';
       const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
-      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?v=123&share_token=test-token-456');
+      expect(result).toBe('http://localhost:8000/media/videos/1/video.mp4?v=123&share_token=test-token-456');
     });
 
     it('should preserve hash in URL', () => {
-      const videoFile = '/api/media/videos/1/video.mp4#t=10';
+      const videoFile = 'http://localhost:8000/media/videos/1/video.mp4#t=10';
       const shareToken = 'test-token-789';
       const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
-      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?share_token=test-token-789#t=10');
+      expect(result).toBe('http://localhost:8000/media/videos/1/video.mp4?share_token=test-token-789#t=10');
     });
 
-    it('should work with different port numbers', () => {
-      // Change origin to non-standard port
-      Object.defineProperty(window, 'location', {
-        writable: true,
-        value: {
-          ...originalLocation,
-          origin: 'http://localhost:60158',
-        },
-      });
-
-      const videoFile = '/api/media/videos/1/video.mp4';
+    it('should work with production backend URLs', () => {
+      const videoFile = 'https://api.example.com/media/videos/1/video.mp4';
       const shareToken = 'test-token-abc';
       const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
-      expect(result).toBe('http://localhost:60158/api/media/videos/1/video.mp4?share_token=test-token-abc');
+      expect(result).toBe('https://api.example.com/media/videos/1/video.mp4?share_token=test-token-abc');
     });
 
-    it('should rewrite absolute API URL with frontend origin and add share_token', () => {
-      const videoFile = 'http://localhost:8000/api/media/videos/1/video.mp4';
-      const shareToken = 'test-token-def';
-      const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
-      expect(result).toBe('http://localhost:3000/api/media/videos/1/video.mp4?share_token=test-token-def');
-    });
-
-    it('should add share_token to external URLs like S3 without rewriting origin', () => {
+    it('should add share_token to external URLs like S3', () => {
       const videoFile = 'https://s3.amazonaws.com/bucket/videos/1/video.mp4';
       const shareToken = 'test-token-ghi';
       const result = apiClient.getSharedVideoUrl(videoFile, shareToken);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -674,33 +674,14 @@ class ApiClient {
     return response.json();
   }
 
-  // Get video URL with correct origin
+  // Get video URL (backend returns absolute URLs)
   getVideoUrl(videoFile: string): string {
-    const baseOrigin = window.location.origin;
-    const apiOrigin = new URL(API_URL, baseOrigin).origin;
-    const url = new URL(videoFile, baseOrigin);
-
-    // Only rewrite URL if it's from the API origin (not external URLs like S3)
-    if (url.origin === apiOrigin) {
-      return new URL(`${url.pathname}${url.search}${url.hash}`, baseOrigin).toString();
-    }
-    return url.toString();
+    return videoFile;
   }
 
   // Get video URL for shared group (add share_token as query parameter)
   getSharedVideoUrl(videoFile: string, shareToken: string): string {
-    const baseOrigin = window.location.origin;
-    const apiOrigin = new URL(API_URL, baseOrigin).origin;
-    const url = new URL(videoFile, baseOrigin);
-
-    // Only rewrite URL if it's from the API origin (not external URLs like S3)
-    if (url.origin === apiOrigin) {
-      const rewrittenUrl = new URL(`${url.pathname}${url.search}${url.hash}`, baseOrigin);
-      rewrittenUrl.searchParams.set('share_token', shareToken);
-      return rewrittenUrl.toString();
-    }
-
-    // For external URLs, just add share_token
+    const url = new URL(videoFile);
     url.searchParams.set('share_token', shareToken);
     return url.toString();
   }


### PR DESCRIPTION
Remove RelativeFileField and let Django return absolute URLs with full domain. Simplify frontend getVideoUrl to use backend URLs as-is instead of rewriting. This allows frontend and backend to be deployed on separate domains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video file URLs are now returned as complete absolute URLs instead of relative paths, ensuring consistent formatting across API responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->