### PR TITLE
Add stripe Python SDK (>=14.3.0) to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,5 +20,6 @@ pgvector>=0.3.0
 psycopg2-binary>=2.9.11
 redis>=7.0.0
 scikit-learn>=1.7.2
+stripe>=14.3.0
 uvicorn-worker>=0.4.0
 uvicorn>=0.38.0


### PR DESCRIPTION
Install stripe Python SDK version 14.3.0 or higher in backend/requirements.txt as part of Phase 1 setup for Stripe billing integration (T001).

This dependency is required for implementing usage-based billing features including subscription management and usage tracking.