### PR TITLE
test: add comprehensive test coverage for backend and frontend

### DIFF
--- a/backend/app/models/tests/__init__.py
+++ b/backend/app/models/tests/__init__.py
@@ -1,0 +1,1 @@
+# Models tests package

--- a/backend/app/models/tests/test_chat.py
+++ b/backend/app/models/tests/test_chat.py
@@ -1,0 +1,156 @@
+"""
+Tests for ChatLog model
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import ChatLog, VideoGroup
+
+User = get_user_model()
+
+
+class ChatLogModelTests(TestCase):
+    """Tests for ChatLog model"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+        )
+
+    def test_create_chat_log(self):
+        """Test creating a chat log"""
+        chat_log = ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="What is this video about?",
+            answer="This video is about testing.",
+        )
+
+        self.assertEqual(chat_log.question, "What is this video about?")
+        self.assertEqual(chat_log.answer, "This video is about testing.")
+        self.assertEqual(chat_log.user, self.user)
+        self.assertEqual(chat_log.group, self.group)
+
+    def test_default_related_videos_is_empty_list(self):
+        """Test that default related_videos is empty list"""
+        chat_log = ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="Question",
+            answer="Answer",
+        )
+
+        self.assertEqual(chat_log.related_videos, [])
+
+    def test_related_videos_stores_json(self):
+        """Test that related_videos stores JSON data"""
+        related = [
+            {"video_id": 1, "title": "Video 1", "start_time": "00:00:10"},
+            {"video_id": 2, "title": "Video 2", "start_time": "00:01:30"},
+        ]
+
+        chat_log = ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="Question",
+            answer="Answer",
+            related_videos=related,
+        )
+
+        chat_log.refresh_from_db()
+        self.assertEqual(chat_log.related_videos, related)
+
+    def test_default_is_shared_origin_is_false(self):
+        """Test that default is_shared_origin is False"""
+        chat_log = ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="Question",
+            answer="Answer",
+        )
+
+        self.assertFalse(chat_log.is_shared_origin)
+
+    def test_feedback_choices(self):
+        """Test valid feedback choices"""
+        chat_log = ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="Question",
+            answer="Answer",
+            feedback="good",
+        )
+        self.assertEqual(chat_log.feedback, "good")
+
+        chat_log.feedback = "bad"
+        chat_log.save()
+        self.assertEqual(chat_log.feedback, "bad")
+
+    def test_feedback_is_optional(self):
+        """Test that feedback is optional"""
+        chat_log = ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="Question",
+            answer="Answer",
+        )
+
+        self.assertIsNone(chat_log.feedback)
+
+    def test_created_at_is_auto_set(self):
+        """Test that created_at is automatically set"""
+        chat_log = ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="Question",
+            answer="Answer",
+        )
+
+        self.assertIsNotNone(chat_log.created_at)
+
+    def test_ordering_by_created_at_desc(self):
+        """Test that chat logs are ordered by created_at descending"""
+        log1 = ChatLog.objects.create(
+            user=self.user, group=self.group, question="Q1", answer="A1"
+        )
+        log2 = ChatLog.objects.create(
+            user=self.user, group=self.group, question="Q2", answer="A2"
+        )
+        log3 = ChatLog.objects.create(
+            user=self.user, group=self.group, question="Q3", answer="A3"
+        )
+
+        logs = list(ChatLog.objects.all())
+
+        # Most recent first
+        self.assertEqual(logs[0], log3)
+        self.assertEqual(logs[1], log2)
+        self.assertEqual(logs[2], log1)
+
+    def test_cascade_delete_on_user(self):
+        """Test that chat logs are deleted when user is deleted"""
+        ChatLog.objects.create(
+            user=self.user, group=self.group, question="Q", answer="A"
+        )
+
+        self.user.delete()
+
+        self.assertEqual(ChatLog.objects.count(), 0)
+
+    def test_cascade_delete_on_group(self):
+        """Test that chat logs are deleted when group is deleted"""
+        ChatLog.objects.create(
+            user=self.user, group=self.group, question="Q", answer="A"
+        )
+
+        self.group.delete()
+
+        self.assertEqual(ChatLog.objects.count(), 0)

--- a/backend/app/models/tests/test_signals.py
+++ b/backend/app/models/tests/test_signals.py
@@ -1,0 +1,247 @@
+"""
+Tests for model signals
+"""
+
+import time
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import Video, VideoGroup, VideoGroupMember
+from app.models.signals import _should_delete_videos
+
+User = get_user_model()
+
+
+class ShouldDeleteVideosTests(TestCase):
+    """Tests for _should_delete_videos helper function"""
+
+    def test_no_change_returns_false(self):
+        """Test that no change returns False"""
+        self.assertFalse(_should_delete_videos(5, 5))
+        self.assertFalse(_should_delete_videos(None, None))
+        self.assertFalse(_should_delete_videos(0, 0))
+
+    def test_change_to_unlimited_returns_false(self):
+        """Test that changing to unlimited returns False"""
+        self.assertFalse(_should_delete_videos(5, None))
+        self.assertFalse(_should_delete_videos(0, None))
+
+    def test_unlimited_to_limited_returns_true(self):
+        """Test that unlimited to limited returns True"""
+        self.assertTrue(_should_delete_videos(None, 5))
+        self.assertTrue(_should_delete_videos(None, 0))
+
+    def test_limited_to_more_limited_returns_true(self):
+        """Test that reducing limit returns True"""
+        self.assertTrue(_should_delete_videos(10, 5))
+        self.assertTrue(_should_delete_videos(5, 0))
+
+    def test_limited_to_less_limited_returns_false(self):
+        """Test that increasing limit returns False"""
+        self.assertFalse(_should_delete_videos(5, 10))
+        self.assertFalse(_should_delete_videos(0, 5))
+
+
+class DeleteVideoVectorsSignalTests(TestCase):
+    """Tests for delete_video_vectors_signal"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_signal_calls_delete_video_vectors(self, mock_delete):
+        """Test that signal calls delete_video_vectors on video deletion"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+        video_id = video.id
+
+        video.delete()
+
+        mock_delete.assert_called_once_with(video_id)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_signal_handles_error_gracefully(self, mock_delete):
+        """Test that signal handles errors gracefully"""
+        mock_delete.side_effect = Exception("Delete failed")
+
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+
+        # Should not raise, video should be deleted
+        video.delete()
+
+        self.assertFalse(Video.objects.filter(id=video.id).exists())
+
+
+class HandleVideoLimitReductionSignalTests(TestCase):
+    """Tests for handle_video_limit_reduction signal"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        # Create videos with staggered timestamps
+        self.videos = []
+        for i in range(5):
+            video = Video.objects.create(
+                user=self.user,
+                title=f"Video {i}",
+                status="completed",
+            )
+            self.videos.append(video)
+            if i < 4:
+                time.sleep(0.01)
+
+    def test_new_user_creation_does_not_trigger(self):
+        """Test that new user creation doesn't trigger deletion"""
+        # Should not raise any errors
+        new_user = User.objects.create_user(
+            username="newuser",
+            email="new@example.com",
+            password="testpass123",
+            video_limit=5,
+        )
+
+        self.assertEqual(new_user.video_limit, 5)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_deletes_oldest_videos_first(self, mock_delete):
+        """Test that oldest videos are deleted first"""
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 5)
+
+        self.user.video_limit = 2
+        self.user.save()
+
+        # Should have 2 videos remaining
+        remaining = Video.objects.filter(user=self.user)
+        self.assertEqual(remaining.count(), 2)
+
+        # Newest 2 should remain
+        remaining_ids = list(remaining.values_list("id", flat=True))
+        self.assertIn(self.videos[3].id, remaining_ids)
+        self.assertIn(self.videos[4].id, remaining_ids)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_keeps_correct_number_of_videos(self, mock_delete):
+        """Test that correct number of videos is kept"""
+        self.user.video_limit = 3
+        self.user.save()
+
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 3)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_unlimited_to_limited_deletes_excess(self, mock_delete):
+        """Test that going from unlimited to limited deletes excess"""
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 5)
+
+        self.user.video_limit = 3
+        self.user.save()
+
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 3)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_limited_to_more_limited_deletes_excess(self, mock_delete):
+        """Test that reducing limit deletes excess"""
+        self.user.video_limit = 5
+        self.user.save()
+
+        self.user.video_limit = 2
+        self.user.save()
+
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 2)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_reduce_to_zero_deletes_all(self, mock_delete):
+        """Test that reducing to 0 deletes all videos"""
+        self.user.video_limit = 0
+        self.user.save()
+
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 0)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_increase_limit_does_not_delete(self, mock_delete):
+        """Test that increasing limit doesn't delete videos"""
+        self.user.video_limit = 3
+        self.user.save()
+
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 3)
+
+        self.user.video_limit = 10
+        self.user.save()
+
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 3)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_change_to_unlimited_does_not_delete(self, mock_delete):
+        """Test that changing to unlimited doesn't delete videos"""
+        self.user.video_limit = 3
+        self.user.save()
+
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 3)
+
+        self.user.video_limit = None
+        self.user.save()
+
+        self.assertEqual(Video.objects.filter(user=self.user).count(), 3)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_same_limit_does_not_delete(self, mock_delete):
+        """Test that setting same limit doesn't delete videos"""
+        self.user.video_limit = 5
+        self.user.save()
+
+        mock_delete.reset_mock()
+
+        self.user.video_limit = 5
+        self.user.save()
+
+        mock_delete.assert_not_called()
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_triggers_vector_cleanup(self, mock_delete):
+        """Test that deletion triggers vector cleanup via signal"""
+        self.user.video_limit = 2
+        self.user.save()
+
+        # 3 videos should be deleted
+        self.assertEqual(mock_delete.call_count, 3)
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_removes_videos_from_groups(self, mock_delete):
+        """Test that deleted videos are removed from groups"""
+        group = VideoGroup.objects.create(user=self.user, name="Test Group")
+        for video in self.videos:
+            VideoGroupMember.objects.create(group=group, video=video)
+
+        self.assertEqual(VideoGroupMember.objects.filter(group=group).count(), 5)
+
+        self.user.video_limit = 2
+        self.user.save()
+
+        self.assertEqual(VideoGroupMember.objects.filter(group=group).count(), 2)
+        # Group should still exist
+        self.assertTrue(VideoGroup.objects.filter(pk=group.pk).exists())
+
+    @patch("app.utils.vector_manager.delete_video_vectors")
+    def test_admin_update_works(self, mock_delete):
+        """Test that admin-style updates work correctly"""
+        # Simulate admin update
+        user = User.objects.get(pk=self.user.pk)
+        user.video_limit = 2
+        user.save()
+
+        self.assertEqual(Video.objects.filter(user=user).count(), 2)

--- a/backend/app/models/tests/test_tag.py
+++ b/backend/app/models/tests/test_tag.py
@@ -1,0 +1,192 @@
+"""
+Tests for Tag and VideoTag models
+"""
+
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError
+from django.test import TestCase
+
+from app.models import Tag, Video, VideoTag
+
+User = get_user_model()
+
+
+class TagModelTests(TestCase):
+    """Tests for Tag model"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+
+    def test_create_tag(self):
+        """Test creating a tag"""
+        tag = Tag.objects.create(
+            user=self.user,
+            name="Important",
+            color="#FF0000",
+        )
+
+        self.assertEqual(tag.name, "Important")
+        self.assertEqual(tag.color, "#FF0000")
+        self.assertEqual(tag.user, self.user)
+
+    def test_default_color(self):
+        """Test that default color is set"""
+        tag = Tag.objects.create(
+            user=self.user,
+            name="Test Tag",
+        )
+
+        self.assertEqual(tag.color, "#3B82F6")
+
+    def test_created_at_is_auto_set(self):
+        """Test that created_at is automatically set"""
+        tag = Tag.objects.create(
+            user=self.user,
+            name="Test Tag",
+        )
+
+        self.assertIsNotNone(tag.created_at)
+
+    def test_unique_together_user_name(self):
+        """Test that tag name is unique per user"""
+        Tag.objects.create(user=self.user, name="Important")
+
+        with self.assertRaises(IntegrityError):
+            Tag.objects.create(user=self.user, name="Important")
+
+    def test_same_name_different_users(self):
+        """Test that different users can have tags with same name"""
+        user2 = User.objects.create_user(
+            username="user2",
+            email="user2@example.com",
+            password="testpass123",
+        )
+
+        Tag.objects.create(user=self.user, name="Important")
+        Tag.objects.create(user=user2, name="Important")
+
+        self.assertEqual(Tag.objects.filter(name="Important").count(), 2)
+
+    def test_str_representation(self):
+        """Test string representation of tag"""
+        tag = Tag.objects.create(
+            user=self.user,
+            name="Important",
+        )
+
+        self.assertEqual(str(tag), "Important (by testuser)")
+
+    def test_ordering_by_name(self):
+        """Test that tags are ordered by name"""
+        Tag.objects.create(user=self.user, name="Zebra")
+        Tag.objects.create(user=self.user, name="Apple")
+        Tag.objects.create(user=self.user, name="Mango")
+
+        tags = list(Tag.objects.all())
+
+        self.assertEqual(tags[0].name, "Apple")
+        self.assertEqual(tags[1].name, "Mango")
+        self.assertEqual(tags[2].name, "Zebra")
+
+    def test_cascade_delete_on_user(self):
+        """Test that tags are deleted when user is deleted"""
+        tag = Tag.objects.create(user=self.user, name="Important")
+        tag_id = tag.id
+
+        self.user.delete()
+
+        self.assertFalse(Tag.objects.filter(id=tag_id).exists())
+
+
+class VideoTagModelTests(TestCase):
+    """Tests for VideoTag model"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+        self.tag = Tag.objects.create(
+            user=self.user,
+            name="Important",
+        )
+
+    def test_add_tag_to_video(self):
+        """Test adding a tag to a video"""
+        video_tag = VideoTag.objects.create(
+            video=self.video,
+            tag=self.tag,
+        )
+
+        self.assertEqual(video_tag.video, self.video)
+        self.assertEqual(video_tag.tag, self.tag)
+
+    def test_added_at_is_auto_set(self):
+        """Test that added_at is automatically set"""
+        video_tag = VideoTag.objects.create(
+            video=self.video,
+            tag=self.tag,
+        )
+
+        self.assertIsNotNone(video_tag.added_at)
+
+    def test_unique_together_video_tag(self):
+        """Test that same tag can't be added twice to same video"""
+        VideoTag.objects.create(video=self.video, tag=self.tag)
+
+        with self.assertRaises(IntegrityError):
+            VideoTag.objects.create(video=self.video, tag=self.tag)
+
+    def test_video_can_have_multiple_tags(self):
+        """Test that video can have multiple tags"""
+        tag2 = Tag.objects.create(user=self.user, name="Urgent")
+
+        VideoTag.objects.create(video=self.video, tag=self.tag)
+        VideoTag.objects.create(video=self.video, tag=tag2)
+
+        self.assertEqual(VideoTag.objects.filter(video=self.video).count(), 2)
+
+    def test_tag_can_be_on_multiple_videos(self):
+        """Test that tag can be on multiple videos"""
+        video2 = Video.objects.create(user=self.user, title="Video 2")
+
+        VideoTag.objects.create(video=self.video, tag=self.tag)
+        VideoTag.objects.create(video=video2, tag=self.tag)
+
+        self.assertEqual(VideoTag.objects.filter(tag=self.tag).count(), 2)
+
+    def test_str_representation(self):
+        """Test string representation of video tag"""
+        video_tag = VideoTag.objects.create(
+            video=self.video,
+            tag=self.tag,
+        )
+
+        self.assertEqual(str(video_tag), "Important on Test Video")
+
+    def test_cascade_delete_on_video(self):
+        """Test that video tags are deleted when video is deleted"""
+        VideoTag.objects.create(video=self.video, tag=self.tag)
+
+        self.video.delete()
+
+        self.assertEqual(VideoTag.objects.count(), 0)
+
+    def test_cascade_delete_on_tag(self):
+        """Test that video tags are deleted when tag is deleted"""
+        VideoTag.objects.create(video=self.video, tag=self.tag)
+
+        self.tag.delete()
+
+        self.assertEqual(VideoTag.objects.count(), 0)

--- a/backend/app/models/tests/test_user.py
+++ b/backend/app/models/tests/test_user.py
@@ -1,0 +1,87 @@
+"""
+Tests for User model
+"""
+
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError
+from django.test import TestCase
+
+User = get_user_model()
+
+
+class UserModelTests(TestCase):
+    """Tests for User model"""
+
+    def test_create_user_with_required_fields(self):
+        """Test creating a user with required fields"""
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+
+        self.assertEqual(user.username, "testuser")
+        self.assertEqual(user.email, "test@example.com")
+        self.assertTrue(user.check_password("testpass123"))
+
+    def test_email_is_unique(self):
+        """Test that email must be unique"""
+        User.objects.create_user(
+            username="user1",
+            email="test@example.com",
+            password="testpass123",
+        )
+
+        with self.assertRaises(IntegrityError):
+            User.objects.create_user(
+                username="user2",
+                email="test@example.com",
+                password="testpass123",
+            )
+
+    def test_default_video_limit_is_zero(self):
+        """Test that default video_limit is 0"""
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+
+        self.assertEqual(user.video_limit, 0)
+
+    def test_video_limit_can_be_none(self):
+        """Test that video_limit can be None (unlimited)"""
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+
+        self.assertIsNone(user.video_limit)
+
+    def test_video_limit_can_be_positive(self):
+        """Test that video_limit can be a positive integer"""
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=10,
+        )
+
+        self.assertEqual(user.video_limit, 10)
+
+    def test_user_inherits_from_abstract_user(self):
+        """Test that User inherits all AbstractUser functionality"""
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+
+        # Test AbstractUser fields
+        self.assertTrue(hasattr(user, "first_name"))
+        self.assertTrue(hasattr(user, "last_name"))
+        self.assertTrue(hasattr(user, "is_staff"))
+        self.assertTrue(hasattr(user, "is_active"))
+        self.assertTrue(hasattr(user, "date_joined"))

--- a/backend/app/models/tests/test_video.py
+++ b/backend/app/models/tests/test_video.py
@@ -1,0 +1,127 @@
+"""
+Tests for Video model
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import Video
+
+User = get_user_model()
+
+
+class VideoModelTests(TestCase):
+    """Tests for Video model"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+
+    def test_create_video_with_required_fields(self):
+        """Test creating a video with required fields"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+
+        self.assertEqual(video.title, "Test Video")
+        self.assertEqual(video.user, self.user)
+        self.assertEqual(video.status, "pending")
+
+    def test_default_status_is_pending(self):
+        """Test that default status is pending"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+
+        self.assertEqual(video.status, "pending")
+
+    def test_status_choices(self):
+        """Test valid status choices"""
+        for status, _ in Video.STATUS_CHOICES:
+            video = Video.objects.create(
+                user=self.user,
+                title=f"Video {status}",
+                status=status,
+            )
+            self.assertEqual(video.status, status)
+
+    def test_description_is_optional(self):
+        """Test that description is optional"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+
+        self.assertEqual(video.description, "")
+
+    def test_transcript_is_optional(self):
+        """Test that transcript is optional"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+
+        self.assertEqual(video.transcript, "")
+
+    def test_external_id_is_optional(self):
+        """Test that external_id is optional"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+
+        self.assertIsNone(video.external_id)
+
+    def test_external_id_is_unique(self):
+        """Test that external_id must be unique when set"""
+        Video.objects.create(
+            user=self.user,
+            title="Video 1",
+            external_id="ext-123",
+        )
+
+        from django.db import IntegrityError
+
+        with self.assertRaises(IntegrityError):
+            Video.objects.create(
+                user=self.user,
+                title="Video 2",
+                external_id="ext-123",
+            )
+
+    def test_uploaded_at_is_auto_set(self):
+        """Test that uploaded_at is automatically set"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+
+        self.assertIsNotNone(video.uploaded_at)
+
+    def test_str_representation(self):
+        """Test string representation of video"""
+        video = Video.objects.create(
+            user=self.user,
+            title="My Video",
+        )
+
+        self.assertEqual(str(video), "My Video (by testuser)")
+
+    def test_ordering_by_uploaded_at_desc(self):
+        """Test that videos are ordered by uploaded_at descending"""
+        video1 = Video.objects.create(user=self.user, title="Video 1")
+        video2 = Video.objects.create(user=self.user, title="Video 2")
+        video3 = Video.objects.create(user=self.user, title="Video 3")
+
+        videos = list(Video.objects.all())
+
+        # Most recently created should be first
+        self.assertEqual(videos[0], video3)
+        self.assertEqual(videos[1], video2)
+        self.assertEqual(videos[2], video1)

--- a/backend/app/models/tests/test_video_group.py
+++ b/backend/app/models/tests/test_video_group.py
@@ -1,0 +1,247 @@
+"""
+Tests for VideoGroup and VideoGroupMember models
+"""
+
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError
+from django.test import TestCase
+
+from app.models import Video, VideoGroup, VideoGroupMember
+
+User = get_user_model()
+
+
+class VideoGroupModelTests(TestCase):
+    """Tests for VideoGroup model"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+
+    def test_create_video_group(self):
+        """Test creating a video group"""
+        group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+            description="Test Description",
+        )
+
+        self.assertEqual(group.name, "Test Group")
+        self.assertEqual(group.description, "Test Description")
+        self.assertEqual(group.user, self.user)
+
+    def test_description_is_optional(self):
+        """Test that description is optional"""
+        group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+        )
+
+        self.assertEqual(group.description, "")
+
+    def test_share_token_is_optional(self):
+        """Test that share_token is optional"""
+        group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+        )
+
+        self.assertIsNone(group.share_token)
+
+    def test_share_token_is_unique(self):
+        """Test that share_token must be unique"""
+        VideoGroup.objects.create(
+            user=self.user,
+            name="Group 1",
+            share_token="unique-token-123",
+        )
+
+        with self.assertRaises(IntegrityError):
+            VideoGroup.objects.create(
+                user=self.user,
+                name="Group 2",
+                share_token="unique-token-123",
+            )
+
+    def test_created_at_is_auto_set(self):
+        """Test that created_at is automatically set"""
+        group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+        )
+
+        self.assertIsNotNone(group.created_at)
+
+    def test_updated_at_is_auto_updated(self):
+        """Test that updated_at is automatically updated"""
+        group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+        )
+
+        original_updated_at = group.updated_at
+
+        group.name = "Updated Name"
+        group.save()
+
+        self.assertNotEqual(group.updated_at, original_updated_at)
+
+    def test_str_representation(self):
+        """Test string representation of video group"""
+        group = VideoGroup.objects.create(
+            user=self.user,
+            name="My Group",
+        )
+
+        self.assertEqual(str(group), "My Group (by testuser)")
+
+    def test_ordering_by_created_at_desc(self):
+        """Test that groups are ordered by created_at descending"""
+        group1 = VideoGroup.objects.create(user=self.user, name="Group 1")
+        group2 = VideoGroup.objects.create(user=self.user, name="Group 2")
+        group3 = VideoGroup.objects.create(user=self.user, name="Group 3")
+
+        groups = list(VideoGroup.objects.all())
+
+        # Most recently created should be first
+        self.assertEqual(groups[0], group3)
+        self.assertEqual(groups[1], group2)
+        self.assertEqual(groups[2], group1)
+
+    def test_cascade_delete_on_user(self):
+        """Test that groups are deleted when user is deleted"""
+        group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+        )
+        group_id = group.id
+
+        self.user.delete()
+
+        self.assertFalse(VideoGroup.objects.filter(id=group_id).exists())
+
+
+class VideoGroupMemberModelTests(TestCase):
+    """Tests for VideoGroupMember model"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+        )
+
+    def test_add_video_to_group(self):
+        """Test adding a video to a group"""
+        member = VideoGroupMember.objects.create(
+            group=self.group,
+            video=self.video,
+            order=0,
+        )
+
+        self.assertEqual(member.group, self.group)
+        self.assertEqual(member.video, self.video)
+        self.assertEqual(member.order, 0)
+
+    def test_default_order_is_zero(self):
+        """Test that default order is 0"""
+        member = VideoGroupMember.objects.create(
+            group=self.group,
+            video=self.video,
+        )
+
+        self.assertEqual(member.order, 0)
+
+    def test_added_at_is_auto_set(self):
+        """Test that added_at is automatically set"""
+        member = VideoGroupMember.objects.create(
+            group=self.group,
+            video=self.video,
+        )
+
+        self.assertIsNotNone(member.added_at)
+
+    def test_unique_together_constraint(self):
+        """Test that same video can't be added twice to same group"""
+        VideoGroupMember.objects.create(
+            group=self.group,
+            video=self.video,
+        )
+
+        with self.assertRaises(IntegrityError):
+            VideoGroupMember.objects.create(
+                group=self.group,
+                video=self.video,
+            )
+
+    def test_video_can_be_in_multiple_groups(self):
+        """Test that video can be added to multiple groups"""
+        group2 = VideoGroup.objects.create(
+            user=self.user,
+            name="Another Group",
+        )
+
+        VideoGroupMember.objects.create(group=self.group, video=self.video)
+        VideoGroupMember.objects.create(group=group2, video=self.video)
+
+        self.assertEqual(VideoGroupMember.objects.filter(video=self.video).count(), 2)
+
+    def test_str_representation(self):
+        """Test string representation of video group member"""
+        member = VideoGroupMember.objects.create(
+            group=self.group,
+            video=self.video,
+        )
+
+        self.assertEqual(str(member), "Test Video in Test Group")
+
+    def test_ordering_by_order_then_added_at(self):
+        """Test that members are ordered by order, then added_at"""
+        video2 = Video.objects.create(user=self.user, title="Video 2")
+        video3 = Video.objects.create(user=self.user, title="Video 3")
+
+        member3 = VideoGroupMember.objects.create(
+            group=self.group, video=video3, order=0
+        )
+        member1 = VideoGroupMember.objects.create(
+            group=self.group, video=self.video, order=1
+        )
+        member2 = VideoGroupMember.objects.create(
+            group=self.group, video=video2, order=0
+        )
+
+        members = list(VideoGroupMember.objects.filter(group=self.group))
+
+        # Same order should be sorted by added_at
+        self.assertEqual(members[0], member3)  # order 0, earlier
+        self.assertEqual(members[1], member2)  # order 0, later
+        self.assertEqual(members[2], member1)  # order 1
+
+    def test_cascade_delete_on_group(self):
+        """Test that members are deleted when group is deleted"""
+        VideoGroupMember.objects.create(group=self.group, video=self.video)
+
+        self.group.delete()
+
+        self.assertEqual(VideoGroupMember.objects.count(), 0)
+
+    def test_cascade_delete_on_video(self):
+        """Test that members are deleted when video is deleted"""
+        VideoGroupMember.objects.create(group=self.group, video=self.video)
+
+        self.video.delete()
+
+        self.assertEqual(VideoGroupMember.objects.count(), 0)

--- a/backend/app/scene_otsu/tests/__init__.py
+++ b/backend/app/scene_otsu/tests/__init__.py
@@ -1,0 +1,1 @@
+# Scene Otsu tests package

--- a/backend/app/scene_otsu/tests/test_embedders.py
+++ b/backend/app/scene_otsu/tests/test_embedders.py
@@ -1,0 +1,192 @@
+"""
+Tests for scene_otsu embedder classes
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from django.test import TestCase, override_settings
+
+
+class BaseEmbedderTests(TestCase):
+    """Tests for BaseEmbedder class"""
+
+    @patch("app.scene_otsu.embedders.OpenAIEmbeddings")
+    @patch("app.scene_otsu.embedders.tiktoken.encoding_for_model")
+    def test_count_tokens(self, mock_tiktoken, mock_openai_embeddings):
+        """Test token counting"""
+        from app.scene_otsu.embedders import OpenAIEmbedder
+
+        mock_encoding = MagicMock()
+        mock_encoding.encode.return_value = [1, 2, 3, 4, 5]
+        mock_tiktoken.return_value = mock_encoding
+
+        embedder = OpenAIEmbedder(api_key="test-key")
+
+        count = embedder.count_tokens("Hello world")
+
+        self.assertEqual(count, 5)
+        mock_encoding.encode.assert_called_once_with("Hello world")
+
+    @patch("app.scene_otsu.embedders.OpenAIEmbeddings")
+    @patch("app.scene_otsu.embedders.tiktoken.encoding_for_model")
+    def test_get_embeddings_batches(self, mock_tiktoken, mock_openai_embeddings):
+        """Test that get_embeddings processes in batches"""
+        from app.scene_otsu.embedders import OpenAIEmbedder
+
+        mock_encoding = MagicMock()
+        mock_tiktoken.return_value = mock_encoding
+
+        mock_embeddings_instance = MagicMock()
+        mock_embeddings_instance.embed_documents.return_value = [
+            [0.1, 0.2, 0.3],
+            [0.4, 0.5, 0.6],
+        ]
+        mock_openai_embeddings.return_value = mock_embeddings_instance
+
+        embedder = OpenAIEmbedder(api_key="test-key", batch_size=2)
+
+        texts = ["Text 1", "Text 2", "Text 3", "Text 4"]
+
+        with patch.object(embedder, "_embed_batch") as mock_embed_batch:
+            mock_embed_batch.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+            result = embedder.get_embeddings(texts)
+
+            # Should be called twice for 4 texts with batch_size=2
+            self.assertEqual(mock_embed_batch.call_count, 2)
+
+
+class OpenAIEmbedderTests(TestCase):
+    """Tests for OpenAIEmbedder class"""
+
+    @patch("app.scene_otsu.embedders.OpenAIEmbeddings")
+    @patch("app.scene_otsu.embedders.tiktoken.encoding_for_model")
+    def test_initialization(self, mock_tiktoken, mock_openai_embeddings):
+        """Test OpenAIEmbedder initialization"""
+        from app.scene_otsu.embedders import OpenAIEmbedder
+
+        embedder = OpenAIEmbedder(
+            api_key="test-api-key",
+            model="text-embedding-3-small",
+            batch_size=16,
+        )
+
+        self.assertEqual(embedder.model, "text-embedding-3-small")
+        self.assertEqual(embedder.batch_size, 16)
+        mock_openai_embeddings.assert_called_once()
+
+    @patch("app.scene_otsu.embedders.OpenAIEmbeddings")
+    @patch("app.scene_otsu.embedders.tiktoken.encoding_for_model")
+    def test_uses_correct_model_for_tiktoken(
+        self, mock_tiktoken, mock_openai_embeddings
+    ):
+        """Test that correct model is used for tiktoken"""
+        from app.scene_otsu.embedders import OpenAIEmbedder
+
+        OpenAIEmbedder(api_key="test-key", model="text-embedding-ada-002")
+
+        mock_tiktoken.assert_called_once_with("text-embedding-ada-002")
+
+
+class OllamaEmbedderTests(TestCase):
+    """Tests for OllamaEmbedder class"""
+
+    @patch("app.scene_otsu.embedders.OllamaEmbeddings")
+    @patch("app.scene_otsu.embedders.tiktoken.get_encoding")
+    def test_initialization(self, mock_tiktoken, mock_ollama_embeddings):
+        """Test OllamaEmbedder initialization"""
+        from app.scene_otsu.embedders import OllamaEmbedder
+
+        embedder = OllamaEmbedder(
+            model="qwen3-embedding:0.6b",
+            base_url="http://localhost:11434",
+            batch_size=8,
+        )
+
+        self.assertEqual(embedder.model, "qwen3-embedding:0.6b")
+        self.assertEqual(embedder.base_url, "http://localhost:11434")
+        self.assertEqual(embedder.batch_size, 8)
+
+    @patch("app.scene_otsu.embedders.OllamaEmbeddings")
+    @patch("app.scene_otsu.embedders.tiktoken.get_encoding")
+    def test_uses_cl100k_base_encoding(self, mock_tiktoken, mock_ollama_embeddings):
+        """Test that cl100k_base encoding is used for Ollama"""
+        from app.scene_otsu.embedders import OllamaEmbedder
+
+        OllamaEmbedder()
+
+        mock_tiktoken.assert_called_once_with("cl100k_base")
+
+
+@override_settings(
+    EMBEDDING_PROVIDER="openai", EMBEDDING_MODEL="text-embedding-3-small"
+)
+class CreateEmbedderOpenAITests(TestCase):
+    """Tests for create_embedder function with OpenAI"""
+
+    @patch("app.scene_otsu.embedders.OpenAIEmbedder")
+    def test_creates_openai_embedder(self, mock_openai_embedder):
+        """Test that OpenAI embedder is created"""
+        from app.scene_otsu.embedders import create_embedder
+
+        create_embedder(api_key="test-key")
+
+        mock_openai_embedder.assert_called_once_with(
+            api_key="test-key",
+            model="text-embedding-3-small",
+            batch_size=16,
+        )
+
+    def test_raises_without_api_key(self):
+        """Test that ValueError is raised without API key"""
+        from app.scene_otsu.embedders import create_embedder
+
+        with self.assertRaises(ValueError) as context:
+            create_embedder(api_key=None)
+
+        self.assertIn("OpenAI API key is required", str(context.exception))
+
+
+@override_settings(
+    EMBEDDING_PROVIDER="ollama",
+    EMBEDDING_MODEL="qwen3-embedding:0.6b",
+    OLLAMA_BASE_URL="http://localhost:11434",
+)
+class CreateEmbedderOllamaTests(TestCase):
+    """Tests for create_embedder function with Ollama"""
+
+    @patch("app.scene_otsu.embedders.OllamaEmbedder")
+    def test_creates_ollama_embedder(self, mock_ollama_embedder):
+        """Test that Ollama embedder is created"""
+        from app.scene_otsu.embedders import create_embedder
+
+        create_embedder()
+
+        mock_ollama_embedder.assert_called_once_with(
+            model="qwen3-embedding:0.6b",
+            base_url="http://localhost:11434",
+            batch_size=16,
+        )
+
+    @patch("app.scene_otsu.embedders.OllamaEmbedder")
+    def test_does_not_require_api_key(self, mock_ollama_embedder):
+        """Test that API key is not required for Ollama"""
+        from app.scene_otsu.embedders import create_embedder
+
+        # Should not raise
+        create_embedder(api_key=None)
+
+
+@override_settings(EMBEDDING_PROVIDER="invalid")
+class CreateEmbedderInvalidTests(TestCase):
+    """Tests for create_embedder function with invalid provider"""
+
+    def test_raises_for_invalid_provider(self):
+        """Test that ValueError is raised for invalid provider"""
+        from app.scene_otsu.embedders import create_embedder
+
+        with self.assertRaises(ValueError) as context:
+            create_embedder(api_key="test-key")
+
+        self.assertIn("Invalid EMBEDDING_PROVIDER", str(context.exception))

--- a/backend/app/scene_otsu/tests/test_embedders.py
+++ b/backend/app/scene_otsu/tests/test_embedders.py
@@ -4,7 +4,6 @@ Tests for scene_otsu embedder classes
 
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 from django.test import TestCase, override_settings
 
 
@@ -51,7 +50,7 @@ class BaseEmbedderTests(TestCase):
         with patch.object(embedder, "_embed_batch") as mock_embed_batch:
             mock_embed_batch.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
 
-            result = embedder.get_embeddings(texts)
+            embedder.get_embeddings(texts)
 
             # Should be called twice for 4 texts with batch_size=2
             self.assertEqual(mock_embed_batch.call_count, 2)

--- a/backend/app/scene_otsu/tests/test_parsers.py
+++ b/backend/app/scene_otsu/tests/test_parsers.py
@@ -1,0 +1,221 @@
+"""
+Tests for scene_otsu parser functions
+"""
+
+from django.test import TestCase
+
+from app.scene_otsu.parsers import SubtitleParser, scenes_to_srt_string
+from app.scene_otsu.types import SceneSegment
+
+
+class SubtitleParserParseSrtStringTests(TestCase):
+    """Tests for SubtitleParser.parse_srt_string"""
+
+    def test_parse_single_subtitle(self):
+        """Test parsing single subtitle"""
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Hello world"""
+
+        result = SubtitleParser.parse_srt_string(srt_content)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], "00:00:00,000")  # start
+        self.assertEqual(result[0][1], "00:00:05,000")  # end
+        self.assertEqual(result[0][2], "Hello world")  # text
+
+    def test_parse_multiple_subtitles(self):
+        """Test parsing multiple subtitles"""
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Hello
+
+2
+00:00:05,000 --> 00:00:10,000
+World"""
+
+        result = SubtitleParser.parse_srt_string(srt_content)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][2], "Hello")
+        self.assertEqual(result[1][2], "World")
+
+    def test_parse_multiline_text(self):
+        """Test parsing multiline subtitle text"""
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Hello
+World
+Test"""
+
+        result = SubtitleParser.parse_srt_string(srt_content)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][2], "Hello World Test")
+
+    def test_parse_empty_string(self):
+        """Test parsing empty string"""
+        result = SubtitleParser.parse_srt_string("")
+        self.assertEqual(result, [])
+
+    def test_skip_invalid_blocks(self):
+        """Test that invalid blocks are skipped"""
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Valid
+
+2
+Invalid timing line
+Should be skipped
+
+3
+00:00:10,000 --> 00:00:15,000
+Also valid"""
+
+        result = SubtitleParser.parse_srt_string(srt_content)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][2], "Valid")
+        self.assertEqual(result[1][2], "Also valid")
+
+    def test_strip_whitespace(self):
+        """Test that whitespace is handled properly"""
+        srt_content = """1
+  00:00:00,000 --> 00:00:05,000
+  Hello world  """
+
+        result = SubtitleParser.parse_srt_string(srt_content)
+
+        self.assertEqual(len(result), 1)
+
+
+class SubtitleParserParseSrtToItemsTests(TestCase):
+    """Tests for SubtitleParser.parse_srt_to_items"""
+
+    def test_returns_subtitle_items(self):
+        """Test that SubtitleItems are returned"""
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Hello world"""
+
+        result = SubtitleParser.parse_srt_to_items(srt_content)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].index, 1)
+        self.assertEqual(result[0].start_time, "00:00:00,000")
+        self.assertEqual(result[0].end_time, "00:00:05,000")
+        self.assertEqual(result[0].text, "Hello world")
+
+    def test_calculates_seconds(self):
+        """Test that start_sec and end_sec are calculated"""
+        srt_content = """1
+00:01:30,500 --> 00:02:00,000
+Test"""
+
+        result = SubtitleParser.parse_srt_to_items(srt_content)
+
+        self.assertEqual(result[0].start_sec, 90.5)
+        self.assertEqual(result[0].end_sec, 120.0)
+
+
+class SubtitleParserParseSrtScenesTests(TestCase):
+    """Tests for SubtitleParser.parse_srt_scenes"""
+
+    def test_returns_dict_format(self):
+        """Test that dict format is returned"""
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Hello world"""
+
+        result = SubtitleParser.parse_srt_scenes(srt_content)
+
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], dict)
+        self.assertIn("index", result[0])
+        self.assertIn("start_time", result[0])
+        self.assertIn("end_time", result[0])
+        self.assertIn("start_sec", result[0])
+        self.assertIn("end_sec", result[0])
+        self.assertIn("text", result[0])
+
+    def test_multiple_scenes(self):
+        """Test parsing multiple scenes"""
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Scene one
+
+2
+00:00:05,000 --> 00:00:10,000
+Scene two
+
+3
+00:00:10,000 --> 00:00:15,000
+Scene three"""
+
+        result = SubtitleParser.parse_srt_scenes(srt_content)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]["text"], "Scene one")
+        self.assertEqual(result[1]["text"], "Scene two")
+        self.assertEqual(result[2]["text"], "Scene three")
+
+
+class ScenesToSrtStringTests(TestCase):
+    """Tests for scenes_to_srt_string function"""
+
+    def test_single_scene(self):
+        """Test converting single scene to SRT"""
+        scenes = [
+            SceneSegment(
+                start_time="00:00:00,000",
+                end_time="00:00:05,000",
+                subtitles=["Hello world"],
+            )
+        ]
+
+        result = scenes_to_srt_string(scenes)
+
+        self.assertIn("1", result)
+        self.assertIn("00:00:00,000 --> 00:00:05,000", result)
+        self.assertIn("Hello world", result)
+
+    def test_multiple_scenes(self):
+        """Test converting multiple scenes to SRT"""
+        scenes = [
+            SceneSegment(
+                start_time="00:00:00,000",
+                end_time="00:00:05,000",
+                subtitles=["Hello"],
+            ),
+            SceneSegment(
+                start_time="00:00:05,000",
+                end_time="00:00:10,000",
+                subtitles=["World"],
+            ),
+        ]
+
+        result = scenes_to_srt_string(scenes)
+
+        self.assertIn("1", result)
+        self.assertIn("2", result)
+        self.assertIn("Hello", result)
+        self.assertIn("World", result)
+
+    def test_multiple_subtitles_in_scene(self):
+        """Test scene with multiple subtitles"""
+        scenes = [
+            SceneSegment(
+                start_time="00:00:00,000",
+                end_time="00:00:05,000",
+                subtitles=["Hello", "World", "Test"],
+            )
+        ]
+
+        result = scenes_to_srt_string(scenes)
+
+        self.assertIn("Hello World Test", result)
+
+    def test_empty_scenes_list(self):
+        """Test empty scenes list"""
+        result = scenes_to_srt_string([])
+        self.assertEqual(result, "")

--- a/backend/app/scene_otsu/tests/test_splitter.py
+++ b/backend/app/scene_otsu/tests/test_splitter.py
@@ -1,0 +1,254 @@
+"""
+Tests for scene_otsu SceneSplitter class
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from django.test import TestCase, override_settings
+
+from app.scene_otsu.splitter import SceneSplitter
+from app.scene_otsu.types import SceneSegment
+
+
+@override_settings(
+    EMBEDDING_PROVIDER="openai", EMBEDDING_MODEL="text-embedding-3-small"
+)
+class SceneSplitterInitializationTests(TestCase):
+    """Tests for SceneSplitter initialization"""
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_initialization_with_api_key(self, mock_create_embedder):
+        """Test initialization with API key"""
+        splitter = SceneSplitter(api_key="test-key")
+
+        mock_create_embedder.assert_called_once_with(api_key="test-key", batch_size=16)
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_initialization_with_custom_batch_size(self, mock_create_embedder):
+        """Test initialization with custom batch size"""
+        splitter = SceneSplitter(api_key="test-key", batch_size=32)
+
+        mock_create_embedder.assert_called_once_with(api_key="test-key", batch_size=32)
+
+
+@override_settings(
+    EMBEDDING_PROVIDER="openai", EMBEDDING_MODEL="text-embedding-3-small"
+)
+class SceneSplitterOtsuThresholdTests(TestCase):
+    """Tests for SceneSplitter._find_otsu_threshold"""
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_returns_zero_for_single_embedding(self, mock_create_embedder):
+        """Test that zero is returned for single embedding"""
+        splitter = SceneSplitter(api_key="test-key")
+
+        embeddings = np.array([[0.1, 0.2, 0.3]])
+
+        result = splitter._find_otsu_threshold(embeddings)
+
+        self.assertEqual(result, 0)
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_finds_threshold_for_two_embeddings(self, mock_create_embedder):
+        """Test finding threshold for two embeddings"""
+        splitter = SceneSplitter(api_key="test-key")
+
+        embeddings = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        )
+
+        result = splitter._find_otsu_threshold(embeddings)
+
+        self.assertEqual(result, 1)  # Should split after first embedding
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_finds_optimal_split_point(self, mock_create_embedder):
+        """Test finding optimal split point in sequence"""
+        splitter = SceneSplitter(api_key="test-key")
+
+        # Create embeddings with clear clusters
+        embeddings = np.array(
+            [
+                [1.0, 0.0],
+                [0.9, 0.1],
+                [0.8, 0.2],  # First cluster
+                [0.0, 1.0],
+                [0.1, 0.9],  # Second cluster
+            ]
+        )
+
+        result = splitter._find_otsu_threshold(embeddings)
+
+        # Should split between clusters (after index 2 or 3)
+        self.assertIn(result, [3, 4])
+
+
+@override_settings(
+    EMBEDDING_PROVIDER="openai", EMBEDDING_MODEL="text-embedding-3-small"
+)
+class SceneSplitterSplitLongTextTests(TestCase):
+    """Tests for SceneSplitter._split_long_text"""
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_returns_single_scene_if_within_limit(self, mock_create_embedder):
+        """Test returning single scene if text is within limit"""
+        mock_embedder = MagicMock()
+        mock_encoding = MagicMock()
+        mock_encoding.encode.return_value = [1, 2, 3]  # 3 tokens
+        mock_embedder.encoding = mock_encoding
+        mock_create_embedder.return_value = mock_embedder
+
+        splitter = SceneSplitter(api_key="test-key")
+
+        result = splitter._split_long_text(
+            "Short text",
+            "00:00:00,000",
+            "00:00:05,000",
+            max_tokens=10,
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].subtitles, ["Short text"])
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_splits_long_text_into_chunks(self, mock_create_embedder):
+        """Test splitting long text into chunks"""
+        mock_embedder = MagicMock()
+        mock_encoding = MagicMock()
+        # Simulate 10 tokens
+        mock_encoding.encode.return_value = list(range(10))
+        mock_encoding.decode.side_effect = lambda tokens: f"chunk_{len(tokens)}"
+        mock_embedder.encoding = mock_encoding
+        mock_create_embedder.return_value = mock_embedder
+
+        splitter = SceneSplitter(api_key="test-key")
+
+        result = splitter._split_long_text(
+            "Long text that exceeds the limit",
+            "00:00:00,000",
+            "00:00:10,000",
+            max_tokens=5,
+        )
+
+        self.assertEqual(len(result), 2)  # 10 tokens / 5 = 2 chunks
+
+
+@override_settings(
+    EMBEDDING_PROVIDER="openai", EMBEDDING_MODEL="text-embedding-3-small"
+)
+class SceneSplitterProcessTests(TestCase):
+    """Tests for SceneSplitter.process"""
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_returns_empty_string_for_empty_input(self, mock_create_embedder):
+        """Test returning empty string for empty input"""
+        splitter = SceneSplitter(api_key="test-key")
+
+        result = splitter.process("")
+
+        self.assertEqual(result, "")
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    @patch("app.scene_otsu.splitter.SubtitleParser.parse_srt_string")
+    def test_returns_empty_string_for_no_subtitles(
+        self, mock_parse, mock_create_embedder
+    ):
+        """Test returning empty string when no subtitles parsed"""
+        mock_parse.return_value = []
+
+        splitter = SceneSplitter(api_key="test-key")
+
+        result = splitter.process("invalid srt")
+
+        self.assertEqual(result, "")
+
+    @patch("app.scene_otsu.splitter.normalize")
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_processes_srt_and_returns_split(
+        self, mock_create_embedder, mock_normalize
+    ):
+        """Test processing SRT and returning split result"""
+        mock_embedder = MagicMock()
+        mock_embedder.get_embeddings.return_value = np.array(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+            ]
+        )
+        mock_embedder.count_tokens.return_value = 5
+        mock_create_embedder.return_value = mock_embedder
+        mock_normalize.return_value = np.array(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+            ]
+        )
+
+        splitter = SceneSplitter(api_key="test-key")
+
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Hello world
+
+2
+00:00:05,000 --> 00:00:10,000
+Test content"""
+
+        result = splitter.process(srt_content, max_tokens=200)
+
+        self.assertIsInstance(result, str)
+        self.assertIn("-->", result)
+
+    @patch("app.scene_otsu.splitter.normalize")
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_handles_single_subtitle(self, mock_create_embedder, mock_normalize):
+        """Test handling single subtitle"""
+        mock_embedder = MagicMock()
+        mock_embedder.get_embeddings.return_value = np.array([[1.0, 0.0]])
+        mock_embedder.count_tokens.return_value = 5
+        mock_create_embedder.return_value = mock_embedder
+        mock_normalize.return_value = np.array([[1.0, 0.0]])
+
+        splitter = SceneSplitter(api_key="test-key")
+
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Single subtitle"""
+
+        result = splitter.process(srt_content, max_tokens=200)
+
+        self.assertIn("Single subtitle", result)
+
+
+@override_settings(
+    EMBEDDING_PROVIDER="openai", EMBEDDING_MODEL="text-embedding-3-small"
+)
+class SceneSplitterTokenPrefixSumTests(TestCase):
+    """Tests for SceneSplitter._calculate_token_prefix_sum"""
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_calculates_prefix_sum(self, mock_create_embedder):
+        """Test calculating token prefix sum"""
+        mock_embedder = MagicMock()
+        mock_embedder.count_tokens.side_effect = [10, 20, 30]
+        mock_create_embedder.return_value = mock_embedder
+
+        splitter = SceneSplitter(api_key="test-key")
+
+        texts = ["text1", "text2", "text3"]
+        result = splitter._calculate_token_prefix_sum(texts)
+
+        self.assertEqual(result, [0, 10, 30, 60])
+
+    @patch("app.scene_otsu.splitter.create_embedder")
+    def test_empty_texts_returns_zero(self, mock_create_embedder):
+        """Test that empty texts returns [0]"""
+        splitter = SceneSplitter(api_key="test-key")
+
+        result = splitter._calculate_token_prefix_sum([])
+
+        self.assertEqual(result, [0])

--- a/backend/app/scene_otsu/tests/test_splitter.py
+++ b/backend/app/scene_otsu/tests/test_splitter.py
@@ -8,7 +8,6 @@ import numpy as np
 from django.test import TestCase, override_settings
 
 from app.scene_otsu.splitter import SceneSplitter
-from app.scene_otsu.types import SceneSegment
 
 
 @override_settings(
@@ -20,14 +19,14 @@ class SceneSplitterInitializationTests(TestCase):
     @patch("app.scene_otsu.splitter.create_embedder")
     def test_initialization_with_api_key(self, mock_create_embedder):
         """Test initialization with API key"""
-        splitter = SceneSplitter(api_key="test-key")
+        SceneSplitter(api_key="test-key")
 
         mock_create_embedder.assert_called_once_with(api_key="test-key", batch_size=16)
 
     @patch("app.scene_otsu.splitter.create_embedder")
     def test_initialization_with_custom_batch_size(self, mock_create_embedder):
         """Test initialization with custom batch size"""
-        splitter = SceneSplitter(api_key="test-key", batch_size=32)
+        SceneSplitter(api_key="test-key", batch_size=32)
 
         mock_create_embedder.assert_called_once_with(api_key="test-key", batch_size=32)
 

--- a/backend/app/scene_otsu/tests/test_utils.py
+++ b/backend/app/scene_otsu/tests/test_utils.py
@@ -1,0 +1,99 @@
+"""
+Tests for scene_otsu utility functions
+"""
+
+from django.test import TestCase
+
+from app.scene_otsu.utils import TimestampConverter
+
+
+class TimestampConverterSecondsToTimestampTests(TestCase):
+    """Tests for TimestampConverter.seconds_to_timestamp"""
+
+    def test_zero_seconds(self):
+        """Test conversion of zero seconds"""
+        result = TimestampConverter.seconds_to_timestamp(0)
+        self.assertEqual(result, "00:00:00,000")
+
+    def test_seconds_only(self):
+        """Test conversion of seconds only"""
+        result = TimestampConverter.seconds_to_timestamp(45)
+        self.assertEqual(result, "00:00:45,000")
+
+    def test_with_milliseconds(self):
+        """Test conversion with milliseconds"""
+        result = TimestampConverter.seconds_to_timestamp(45.123)
+        self.assertEqual(result, "00:00:45,123")
+
+    def test_minutes_and_seconds(self):
+        """Test conversion of minutes and seconds"""
+        result = TimestampConverter.seconds_to_timestamp(125)  # 2:05
+        self.assertEqual(result, "00:02:05,000")
+
+    def test_hours(self):
+        """Test conversion with hours"""
+        result = TimestampConverter.seconds_to_timestamp(3661.5)  # 1:01:01.5
+        self.assertEqual(result, "01:01:01,500")
+
+    def test_large_hours(self):
+        """Test conversion with large hour values"""
+        result = TimestampConverter.seconds_to_timestamp(36000)  # 10 hours
+        self.assertEqual(result, "10:00:00,000")
+
+
+class TimestampConverterParseTimestampTests(TestCase):
+    """Tests for TimestampConverter.parse_timestamp"""
+
+    def test_parse_zero_timestamp(self):
+        """Test parsing zero timestamp"""
+        result = TimestampConverter.parse_timestamp("00:00:00,000")
+        self.assertEqual(result, 0.0)
+
+    def test_parse_with_milliseconds(self):
+        """Test parsing with milliseconds"""
+        result = TimestampConverter.parse_timestamp("00:00:45,500")
+        self.assertEqual(result, 45.5)
+
+    def test_parse_minutes_and_seconds(self):
+        """Test parsing minutes and seconds"""
+        result = TimestampConverter.parse_timestamp("00:02:30,000")
+        self.assertEqual(result, 150.0)
+
+    def test_parse_hours(self):
+        """Test parsing with hours"""
+        result = TimestampConverter.parse_timestamp("01:30:00,000")
+        self.assertEqual(result, 5400.0)
+
+    def test_parse_with_dot_separator(self):
+        """Test parsing with dot instead of comma"""
+        result = TimestampConverter.parse_timestamp("00:00:45.500")
+        self.assertEqual(result, 45.5)
+
+    def test_parse_without_milliseconds(self):
+        """Test parsing without milliseconds"""
+        result = TimestampConverter.parse_timestamp("00:01:30")
+        self.assertEqual(result, 90.0)
+
+
+class TimestampConverterCalculateDurationTests(TestCase):
+    """Tests for TimestampConverter.calculate_duration"""
+
+    def test_calculate_simple_duration(self):
+        """Test calculating simple duration"""
+        result = TimestampConverter.calculate_duration("00:00:00,000", "00:00:10,000")
+        self.assertEqual(result, 10.0)
+
+    def test_calculate_duration_with_milliseconds(self):
+        """Test calculating duration with milliseconds"""
+        result = TimestampConverter.calculate_duration("00:00:05,500", "00:00:15,750")
+        self.assertEqual(result, 10.25)
+
+    def test_calculate_duration_spanning_minutes(self):
+        """Test calculating duration spanning minutes"""
+        result = TimestampConverter.calculate_duration("00:00:50,000", "00:01:10,000")
+        self.assertEqual(result, 20.0)
+
+    def test_calculate_duration_spanning_hours(self):
+        """Test calculating duration spanning hours"""
+        result = TimestampConverter.calculate_duration("00:59:30,000", "01:00:30,000")
+        self.assertEqual(result, 60.0)

--- a/backend/app/scene_otsu/utils.py
+++ b/backend/app/scene_otsu/utils.py
@@ -10,7 +10,7 @@ class TimestampConverter:
         hours = int(seconds // 3600)
         minutes = int((seconds % 3600) // 60)
         secs = int(seconds % 60)
-        milliseconds = int((seconds % 1) * 1000)
+        milliseconds = round((seconds % 1) * 1000)
         return f"{hours:02d}:{minutes:02d}:{secs:02d},{milliseconds:03d}"
 
     @staticmethod

--- a/backend/app/scene_otsu/utils.py
+++ b/backend/app/scene_otsu/utils.py
@@ -11,6 +11,18 @@ class TimestampConverter:
         minutes = int((seconds % 3600) // 60)
         secs = int(seconds % 60)
         milliseconds = round((seconds % 1) * 1000)
+
+        # Handle potential overflow from rounding milliseconds
+        if milliseconds == 1000:
+            milliseconds = 0
+            secs += 1
+        if secs == 60:
+            secs = 0
+            minutes += 1
+        if minutes == 60:
+            minutes = 0
+            hours += 1
+
         return f"{hours:02d}:{minutes:02d}:{secs:02d},{milliseconds:03d}"
 
     @staticmethod

--- a/backend/app/tasks/tests/__init__.py
+++ b/backend/app/tasks/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tasks tests package

--- a/backend/app/tasks/tests/test_audio_processing.py
+++ b/backend/app/tasks/tests/test_audio_processing.py
@@ -1,0 +1,429 @@
+"""
+Tests for audio processing functions
+"""
+
+import asyncio
+import json
+import os
+import subprocess
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from django.test import TestCase
+
+from app.tasks.audio_processing import (SUPPORTED_FORMATS,
+                                        _extract_audio_segment,
+                                        _extract_full_audio,
+                                        _get_video_duration,
+                                        _split_audio_into_segments,
+                                        extract_and_split_audio,
+                                        process_audio_segments_async,
+                                        process_audio_segments_parallel,
+                                        transcribe_audio_segment_async)
+from app.utils.task_helpers import TemporaryFileManager
+
+
+class SupportedFormatsTests(TestCase):
+    """Tests for supported audio formats"""
+
+    def test_common_formats_supported(self):
+        """Test that common audio formats are supported"""
+        common_formats = [".mp3", ".mp4", ".wav", ".flac", ".ogg", ".m4a"]
+        for fmt in common_formats:
+            self.assertIn(fmt, SUPPORTED_FORMATS)
+
+    def test_webm_supported(self):
+        """Test that webm format is supported"""
+        self.assertIn(".webm", SUPPORTED_FORMATS)
+
+
+class GetVideoDurationTests(TestCase):
+    """Tests for _get_video_duration function"""
+
+    @patch("subprocess.run")
+    def test_returns_duration_in_seconds(self, mock_run):
+        """Test that duration is returned in seconds"""
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"format": {"duration": "125.5"}})
+        mock_run.return_value = mock_result
+
+        duration = _get_video_duration("/path/to/video.mp4")
+
+        self.assertEqual(duration, 125.5)
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_calls_ffprobe_with_correct_args(self, mock_run):
+        """Test that ffprobe is called with correct arguments"""
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"format": {"duration": "60.0"}})
+        mock_run.return_value = mock_result
+
+        _get_video_duration("/path/to/video.mp4")
+
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args[0], "ffprobe")
+        self.assertIn("-print_format", args)
+        self.assertIn("json", args)
+        self.assertIn("-show_format", args)
+
+    @patch("subprocess.run")
+    def test_handles_integer_duration(self, mock_run):
+        """Test handling of integer duration values"""
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps({"format": {"duration": "300"}})
+        mock_run.return_value = mock_result
+
+        duration = _get_video_duration("/path/to/video.mp4")
+
+        self.assertEqual(duration, 300.0)
+
+
+class ExtractFullAudioTests(TestCase):
+    """Tests for _extract_full_audio function"""
+
+    @patch("os.path.getsize")
+    @patch("subprocess.run")
+    def test_extracts_audio_as_mp3(self, mock_run, mock_getsize):
+        """Test that audio is extracted as MP3"""
+        mock_getsize.return_value = 1024 * 1024  # 1 MB
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            audio_path, size_mb = _extract_full_audio("/path/to/video.mp4", temp_dir)
+
+            self.assertTrue(audio_path.endswith(".mp3"))
+            self.assertEqual(size_mb, 1.0)
+
+    @patch("os.path.getsize")
+    @patch("subprocess.run")
+    def test_ffmpeg_called_with_correct_args(self, mock_run, mock_getsize):
+        """Test that ffmpeg is called with correct arguments"""
+        mock_getsize.return_value = 1024 * 1024
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _extract_full_audio("/path/to/video.mp4", temp_dir)
+
+            args = mock_run.call_args[0][0]
+            self.assertEqual(args[0], "ffmpeg")
+            self.assertIn("-vn", args)  # No video
+            self.assertIn("-acodec", args)
+            self.assertIn("mp3", args)
+            self.assertIn("-ab", args)
+            self.assertIn("128k", args)
+
+    @patch("os.path.getsize")
+    @patch("subprocess.run")
+    def test_returns_size_in_megabytes(self, mock_run, mock_getsize):
+        """Test that size is returned in megabytes"""
+        mock_getsize.return_value = 5 * 1024 * 1024  # 5 MB
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _, size_mb = _extract_full_audio("/path/to/video.mp4", temp_dir)
+
+            self.assertEqual(size_mb, 5.0)
+
+
+class ExtractAudioSegmentTests(TestCase):
+    """Tests for _extract_audio_segment function"""
+
+    @patch("subprocess.run")
+    def test_extracts_segment_with_correct_timing(self, mock_run):
+        """Test that segment is extracted with correct start and end times"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = _extract_audio_segment(
+                "/path/to/video.mp4", 10.0, 20.0, 0, temp_dir
+            )
+
+            self.assertEqual(result["start_time"], 10.0)
+            self.assertEqual(result["end_time"], 20.0)
+            self.assertIn("audio_segment_0", result["path"])
+
+    @patch("subprocess.run")
+    def test_ffmpeg_called_with_segment_duration(self, mock_run):
+        """Test that ffmpeg is called with correct segment duration"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _extract_audio_segment("/path/to/video.mp4", 10.0, 25.0, 0, temp_dir)
+
+            args = mock_run.call_args[0][0]
+            # Check -ss (start time) and -t (duration)
+            ss_index = args.index("-ss")
+            t_index = args.index("-t")
+            self.assertEqual(args[ss_index + 1], "10.0")
+            self.assertEqual(args[t_index + 1], "15.0")  # 25.0 - 10.0
+
+    @patch("subprocess.run")
+    def test_segment_index_in_filename(self, mock_run):
+        """Test that segment index is included in filename"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = _extract_audio_segment("/path/to/video.mp4", 0, 10, 5, temp_dir)
+
+            self.assertIn("audio_segment_5", result["path"])
+
+
+class SplitAudioIntoSegmentsTests(TestCase):
+    """Tests for _split_audio_into_segments function"""
+
+    @patch("app.tasks.audio_processing._extract_audio_segment")
+    def test_calculates_correct_number_of_segments(self, mock_extract):
+        """Test that correct number of segments is calculated"""
+        mock_extract.return_value = {
+            "path": "/tmp/audio.mp3",
+            "start_time": 0,
+            "end_time": 10,
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # 50 MB audio, 24 MB max -> should split into 3 segments (with 20% margin)
+            segments = _split_audio_into_segments(
+                "/path/to/video.mp4", 100.0, 50.0, 24.0, temp_dir
+            )
+
+            # 50 / (24 * 0.8) = 50 / 19.2 = 2.6 -> 3 segments
+            self.assertEqual(len(segments), 3)
+
+    @patch("app.tasks.audio_processing._extract_audio_segment")
+    def test_segment_timestamps_are_sequential(self, mock_extract):
+        """Test that segment timestamps are sequential"""
+        call_count = [0]
+
+        def mock_extract_segment(input_path, start, end, index, temp_dir):
+            call_count[0] += 1
+            return {
+                "path": f"/tmp/audio_{index}.mp3",
+                "start_time": start,
+                "end_time": end,
+            }
+
+        mock_extract.side_effect = mock_extract_segment
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            segments = _split_audio_into_segments(
+                "/path/to/video.mp4", 60.0, 50.0, 24.0, temp_dir
+            )
+
+            # Verify timestamps are sequential
+            for i in range(len(segments) - 1):
+                self.assertLessEqual(
+                    segments[i]["end_time"], segments[i + 1]["start_time"] + 0.1
+                )
+
+
+class ExtractAndSplitAudioTests(TestCase):
+    """Tests for extract_and_split_audio function"""
+
+    @patch("app.tasks.audio_processing._extract_full_audio")
+    @patch("app.tasks.audio_processing._get_video_duration")
+    def test_no_split_when_within_limit(self, mock_duration, mock_extract):
+        """Test that no splitting occurs when audio is within limit"""
+        mock_duration.return_value = 60.0
+        mock_extract.return_value = ("/tmp/audio.mp3", 20.0)  # 20 MB < 24 MB limit
+
+        segments = extract_and_split_audio("/path/to/video.mp4", max_size_mb=24)
+
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0]["start_time"], 0)
+        self.assertEqual(segments[0]["end_time"], 60.0)
+
+    @patch("os.remove")
+    @patch("app.tasks.audio_processing._split_audio_into_segments")
+    @patch("app.tasks.audio_processing._extract_full_audio")
+    @patch("app.tasks.audio_processing._get_video_duration")
+    def test_splits_when_exceeds_limit(
+        self, mock_duration, mock_extract, mock_split, mock_remove
+    ):
+        """Test that splitting occurs when audio exceeds limit"""
+        mock_duration.return_value = 300.0
+        mock_extract.return_value = ("/tmp/audio.mp3", 50.0)  # 50 MB > 24 MB limit
+        mock_split.return_value = [
+            {"path": "/tmp/seg1.mp3", "start_time": 0, "end_time": 100},
+            {"path": "/tmp/seg2.mp3", "start_time": 100, "end_time": 200},
+            {"path": "/tmp/seg3.mp3", "start_time": 200, "end_time": 300},
+        ]
+
+        segments = extract_and_split_audio("/path/to/video.mp4", max_size_mb=24)
+
+        self.assertEqual(len(segments), 3)
+        mock_remove.assert_called_once_with(
+            "/tmp/audio.mp3"
+        )  # Original should be deleted
+
+    @patch("app.tasks.audio_processing._get_video_duration")
+    def test_handles_ffprobe_error(self, mock_duration):
+        """Test that ffprobe errors are handled gracefully"""
+        mock_duration.side_effect = subprocess.CalledProcessError(
+            1, "ffprobe", stderr="Error"
+        )
+
+        segments = extract_and_split_audio("/path/to/video.mp4")
+
+        self.assertEqual(segments, [])
+
+    @patch("app.tasks.audio_processing._extract_full_audio")
+    @patch("app.tasks.audio_processing._get_video_duration")
+    def test_registers_temp_files_for_cleanup(self, mock_duration, mock_extract):
+        """Test that temp files are registered for cleanup"""
+        mock_duration.return_value = 60.0
+        mock_extract.return_value = ("/tmp/audio.mp3", 20.0)
+
+        with TemporaryFileManager() as temp_manager:
+            segments = extract_and_split_audio(
+                "/path/to/video.mp4", temp_manager=temp_manager
+            )
+
+            self.assertEqual(len(temp_manager.temp_files), 1)
+            self.assertEqual(temp_manager.temp_files[0], "/tmp/audio.mp3")
+
+    @patch("app.tasks.audio_processing._get_video_duration")
+    def test_handles_generic_exception(self, mock_duration):
+        """Test that generic exceptions are handled gracefully"""
+        mock_duration.side_effect = Exception("Unknown error")
+
+        segments = extract_and_split_audio("/path/to/video.mp4")
+
+        self.assertEqual(segments, [])
+
+
+class TranscribeAudioSegmentAsyncTests(TestCase):
+    """Tests for transcribe_audio_segment_async function"""
+
+    def test_successful_transcription(self):
+        """Test successful audio segment transcription"""
+        mock_client = MagicMock()
+        mock_transcription = MagicMock()
+        mock_transcription.segments = []
+
+        async def mock_create(**kwargs):
+            return mock_transcription
+
+        mock_client.audio.transcriptions.create = mock_create
+
+        segment_info = {"path": "/tmp/audio.mp3", "start_time": 0, "end_time": 10}
+
+        with patch("builtins.open", MagicMock()):
+            result = asyncio.run(
+                transcribe_audio_segment_async(mock_client, segment_info, 0)
+            )
+
+            transcription, error, index = result
+            self.assertIsNotNone(transcription)
+            self.assertIsNone(error)
+            self.assertEqual(index, 0)
+
+    def test_handles_transcription_error(self):
+        """Test handling of transcription error"""
+        mock_client = MagicMock()
+
+        async def mock_create(**kwargs):
+            raise Exception("API Error")
+
+        mock_client.audio.transcriptions.create = mock_create
+
+        segment_info = {"path": "/tmp/audio.mp3", "start_time": 0, "end_time": 10}
+
+        with patch("builtins.open", MagicMock()):
+            result = asyncio.run(
+                transcribe_audio_segment_async(mock_client, segment_info, 0)
+            )
+
+            transcription, error, index = result
+            self.assertIsNone(transcription)
+            self.assertIsNotNone(error)
+
+
+class ProcessAudioSegmentsAsyncTests(TestCase):
+    """Tests for process_audio_segments_async function"""
+
+    def test_adjusts_timestamps_for_segments(self):
+        """Test that timestamps are adjusted based on segment start time"""
+        mock_client = MagicMock()
+
+        segment1_transcription = MagicMock()
+        segment1_transcription.segments = [
+            MagicMock(start=0, end=5, text="Hello"),
+            MagicMock(start=5, end=10, text="World"),
+        ]
+
+        async def mock_create(**kwargs):
+            return segment1_transcription
+
+        mock_client.audio.transcriptions.create = mock_create
+
+        audio_segments = [
+            {"path": "/tmp/audio1.mp3", "start_time": 30.0, "end_time": 40.0}
+        ]
+
+        with patch("builtins.open", MagicMock()):
+            result = asyncio.run(
+                process_audio_segments_async(mock_client, audio_segments)
+            )
+
+            # Timestamps should be adjusted by start_time (30.0)
+            self.assertEqual(result[0]["start"], 30.0)
+            self.assertEqual(result[0]["end"], 35.0)
+            self.assertEqual(result[1]["start"], 35.0)
+            self.assertEqual(result[1]["end"], 40.0)
+
+    def test_handles_failed_segments_gracefully(self):
+        """Test that failed segments don't crash the entire process"""
+        mock_client = MagicMock()
+
+        call_count = [0]
+
+        async def mock_create(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise Exception("Segment 1 failed")
+            result = MagicMock()
+            result.segments = [MagicMock(start=0, end=5, text="Success")]
+            return result
+
+        mock_client.audio.transcriptions.create = mock_create
+
+        audio_segments = [
+            {"path": "/tmp/audio1.mp3", "start_time": 0, "end_time": 10},
+            {"path": "/tmp/audio2.mp3", "start_time": 10, "end_time": 20},
+        ]
+
+        with patch("builtins.open", MagicMock()):
+            result = asyncio.run(
+                process_audio_segments_async(mock_client, audio_segments)
+            )
+
+            # Should have results from successful segment only
+            self.assertEqual(len(result), 1)
+
+
+class ProcessAudioSegmentsParallelTests(TestCase):
+    """Tests for process_audio_segments_parallel function"""
+
+    @patch("app.tasks.audio_processing.asyncio.run")
+    @patch("app.tasks.audio_processing.AsyncOpenAI")
+    def test_creates_async_client(self, mock_async_openai, mock_asyncio_run):
+        """Test that async client is created from sync client"""
+        mock_sync_client = MagicMock()
+        mock_sync_client.api_key = "test-key"
+        mock_sync_client._base_url = None
+
+        mock_asyncio_run.return_value = []
+
+        process_audio_segments_parallel(mock_sync_client, [])
+
+        mock_async_openai.assert_called_once_with(api_key="test-key")
+
+    @patch("app.tasks.audio_processing.asyncio.run")
+    @patch("app.tasks.audio_processing.AsyncOpenAI")
+    def test_preserves_base_url_for_local_whisper(
+        self, mock_async_openai, mock_asyncio_run
+    ):
+        """Test that base_url is preserved for local whisper server"""
+        mock_sync_client = MagicMock()
+        mock_sync_client.api_key = "test-key"
+        mock_sync_client._base_url = "http://localhost:8080"
+
+        mock_asyncio_run.return_value = []
+
+        process_audio_segments_parallel(mock_sync_client, [])
+
+        mock_async_openai.assert_called_once_with(
+            api_key="test-key", base_url="http://localhost:8080"
+        )

--- a/backend/app/tasks/tests/test_audio_processing.py
+++ b/backend/app/tasks/tests/test_audio_processing.py
@@ -4,10 +4,9 @@ Tests for audio processing functions
 
 import asyncio
 import json
-import os
 import subprocess
 import tempfile
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
@@ -266,7 +265,7 @@ class ExtractAndSplitAudioTests(TestCase):
         mock_extract.return_value = ("/tmp/audio.mp3", 20.0)
 
         with TemporaryFileManager() as temp_manager:
-            segments = extract_and_split_audio(
+            extract_and_split_audio(
                 "/path/to/video.mp4", temp_manager=temp_manager
             )
 

--- a/backend/app/tasks/tests/test_reindexing.py
+++ b/backend/app/tasks/tests/test_reindexing.py
@@ -2,7 +2,7 @@
 Tests for reindexing task
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -71,9 +71,9 @@ class ReindexAllVideosEmbeddingsTests(TestCase):
         )
         Video.objects.create(
             user=self.user,
-            title="Null Transcript",
+            title="Empty Transcript",
             status="completed",
-            transcript=None,
+            transcript="",
         )
 
         result = reindex_all_videos_embeddings()

--- a/backend/app/tasks/tests/test_reindexing.py
+++ b/backend/app/tasks/tests/test_reindexing.py
@@ -1,0 +1,199 @@
+"""
+Tests for reindexing task
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import Video
+from app.tasks.reindexing import reindex_all_videos_embeddings
+
+User = get_user_model()
+
+
+class ReindexAllVideosEmbeddingsTests(TestCase):
+    """Tests for reindex_all_videos_embeddings task"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+
+    @patch("app.tasks.reindexing.index_scenes_batch")
+    @patch("app.tasks.reindexing.delete_all_vectors")
+    def test_reindexes_completed_videos(self, mock_delete, mock_index):
+        """Test that completed videos with transcripts are reindexed"""
+        mock_delete.return_value = 10
+
+        # Create videos with different statuses
+        Video.objects.create(
+            user=self.user,
+            title="Completed Video",
+            status="completed",
+            transcript="1\n00:00:00,000 --> 00:00:05,000\nHello\n",
+        )
+        Video.objects.create(
+            user=self.user,
+            title="Pending Video",
+            status="pending",
+            transcript="",
+        )
+        Video.objects.create(
+            user=self.user,
+            title="Processing Video",
+            status="processing",
+            transcript="",
+        )
+
+        result = reindex_all_videos_embeddings()
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(result["total_videos"], 1)
+        self.assertEqual(result["successful_count"], 1)
+        self.assertEqual(result["failed_count"], 0)
+
+    @patch("app.tasks.reindexing.index_scenes_batch")
+    @patch("app.tasks.reindexing.delete_all_vectors")
+    def test_skips_videos_without_transcript(self, mock_delete, mock_index):
+        """Test that videos without transcripts are skipped"""
+        mock_delete.return_value = 0
+
+        Video.objects.create(
+            user=self.user,
+            title="No Transcript",
+            status="completed",
+            transcript="",
+        )
+        Video.objects.create(
+            user=self.user,
+            title="Null Transcript",
+            status="completed",
+            transcript=None,
+        )
+
+        result = reindex_all_videos_embeddings()
+
+        self.assertEqual(result["total_videos"], 0)
+        mock_index.assert_not_called()
+
+    @patch("app.tasks.reindexing.index_scenes_batch")
+    @patch("app.tasks.reindexing.delete_all_vectors")
+    def test_handles_empty_video_set(self, mock_delete, mock_index):
+        """Test handling of no videos to reindex"""
+        mock_delete.return_value = 0
+
+        result = reindex_all_videos_embeddings()
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(result["total_videos"], 0)
+        self.assertEqual(result["message"], "No videos to re-index")
+
+    @patch("app.tasks.reindexing.index_scenes_batch")
+    @patch("app.tasks.reindexing.delete_all_vectors")
+    def test_continues_on_individual_video_error(self, mock_delete, mock_index):
+        """Test that processing continues when individual video fails"""
+        mock_delete.return_value = 10
+
+        # First call fails, second succeeds
+        mock_index.side_effect = [Exception("Index failed"), None]
+
+        Video.objects.create(
+            user=self.user,
+            title="Video 1",
+            status="completed",
+            transcript="transcript 1",
+        )
+        Video.objects.create(
+            user=self.user,
+            title="Video 2",
+            status="completed",
+            transcript="transcript 2",
+        )
+
+        result = reindex_all_videos_embeddings()
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(result["total_videos"], 2)
+        self.assertEqual(result["successful_count"], 1)
+        self.assertEqual(result["failed_count"], 1)
+        self.assertEqual(len(result["failed_videos"]), 1)
+
+    @patch("app.tasks.reindexing.index_scenes_batch")
+    @patch("app.tasks.reindexing.delete_all_vectors")
+    def test_deletes_all_vectors_before_reindexing(self, mock_delete, mock_index):
+        """Test that all vectors are deleted before reindexing"""
+        mock_delete.return_value = 50
+
+        Video.objects.create(
+            user=self.user,
+            title="Video",
+            status="completed",
+            transcript="transcript",
+        )
+
+        reindex_all_videos_embeddings()
+
+        mock_delete.assert_called_once()
+        # Delete should be called before index
+        self.assertTrue(mock_delete.call_count == 1)
+
+    @patch("app.tasks.reindexing.delete_all_vectors")
+    def test_handles_delete_error(self, mock_delete):
+        """Test handling of delete_all_vectors error"""
+        mock_delete.side_effect = Exception("Delete failed")
+
+        Video.objects.create(
+            user=self.user,
+            title="Video",
+            status="completed",
+            transcript="transcript",
+        )
+
+        result = reindex_all_videos_embeddings()
+
+        self.assertEqual(result["status"], "failed")
+        self.assertIn("Delete failed", result["error"])
+
+    @patch("app.tasks.reindexing.index_scenes_batch")
+    @patch("app.tasks.reindexing.delete_all_vectors")
+    def test_reports_failed_videos_details(self, mock_delete, mock_index):
+        """Test that failed video details are included in result"""
+        mock_delete.return_value = 0
+        mock_index.side_effect = Exception("Specific error message")
+
+        video = Video.objects.create(
+            user=self.user,
+            title="Failing Video",
+            status="completed",
+            transcript="transcript",
+        )
+
+        result = reindex_all_videos_embeddings()
+
+        self.assertEqual(len(result["failed_videos"]), 1)
+        self.assertEqual(result["failed_videos"][0]["video_id"], video.id)
+        self.assertEqual(result["failed_videos"][0]["title"], "Failing Video")
+        self.assertIn("Specific error message", result["failed_videos"][0]["error"])
+
+    @patch("app.tasks.reindexing.index_scenes_batch")
+    @patch("app.tasks.reindexing.delete_all_vectors")
+    def test_result_message_format(self, mock_delete, mock_index):
+        """Test that result message has correct format"""
+        mock_delete.return_value = 0
+
+        for i in range(5):
+            Video.objects.create(
+                user=self.user,
+                title=f"Video {i}",
+                status="completed",
+                transcript=f"transcript {i}",
+            )
+
+        result = reindex_all_videos_embeddings()
+
+        self.assertEqual(result["message"], "Re-indexed 5/5 videos")

--- a/backend/app/tasks/tests/test_srt_processing.py
+++ b/backend/app/tasks/tests/test_srt_processing.py
@@ -1,0 +1,283 @@
+"""
+Tests for SRT processing functions
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from app.tasks.srt_processing import (apply_scene_splitting, count_scenes,
+                                      create_srt_content, format_time_for_srt,
+                                      parse_srt_scenes,
+                                      transcribe_and_create_srt)
+
+
+class FormatTimeForSrtTests(TestCase):
+    """Tests for format_time_for_srt function"""
+
+    def test_formats_zero_seconds(self):
+        """Test formatting of zero seconds"""
+        result = format_time_for_srt(0)
+        self.assertEqual(result, "00:00:00,000")
+
+    def test_formats_seconds_only(self):
+        """Test formatting of seconds only"""
+        result = format_time_for_srt(45.5)
+        self.assertEqual(result, "00:00:45,500")
+
+    def test_formats_minutes_and_seconds(self):
+        """Test formatting of minutes and seconds"""
+        result = format_time_for_srt(125.75)  # 2 min 5.75 sec
+        self.assertEqual(result, "00:02:05,750")
+
+    def test_formats_hours(self):
+        """Test formatting of hours"""
+        result = format_time_for_srt(3665.123)  # 1 hour, 1 min, 5.123 sec
+        self.assertEqual(result, "01:01:05,123")
+
+    def test_formats_large_hours(self):
+        """Test formatting of large hour values"""
+        result = format_time_for_srt(36000.0)  # 10 hours
+        self.assertEqual(result, "10:00:00,000")
+
+    def test_handles_fractional_milliseconds(self):
+        """Test handling of fractional milliseconds"""
+        result = format_time_for_srt(1.9999)
+        # Should truncate, not round
+        self.assertIn(",999", result)
+
+
+class CreateSrtContentTests(TestCase):
+    """Tests for create_srt_content function"""
+
+    def test_creates_single_segment_srt(self):
+        """Test creating SRT with single segment"""
+        segments = [{"start": 0, "end": 5, "text": "Hello world"}]
+
+        result = create_srt_content(segments)
+
+        self.assertIn("1", result)
+        self.assertIn("00:00:00,000 --> 00:00:05,000", result)
+        self.assertIn("Hello world", result)
+
+    def test_creates_multiple_segments_srt(self):
+        """Test creating SRT with multiple segments"""
+        segments = [
+            {"start": 0, "end": 5, "text": "Hello"},
+            {"start": 5, "end": 10, "text": "World"},
+            {"start": 10, "end": 15, "text": "Test"},
+        ]
+
+        result = create_srt_content(segments)
+
+        self.assertIn("1", result)
+        self.assertIn("2", result)
+        self.assertIn("3", result)
+        self.assertIn("Hello", result)
+        self.assertIn("World", result)
+        self.assertIn("Test", result)
+
+    def test_strips_text_whitespace(self):
+        """Test that text whitespace is stripped"""
+        segments = [{"start": 0, "end": 5, "text": "  Hello world  "}]
+
+        result = create_srt_content(segments)
+
+        self.assertIn("Hello world", result)
+        self.assertNotIn("  Hello", result)
+
+    def test_handles_empty_segments(self):
+        """Test handling of empty segments list"""
+        segments = []
+
+        result = create_srt_content(segments)
+
+        self.assertEqual(result, "")
+
+    def test_sequential_numbering(self):
+        """Test that segments are numbered sequentially starting from 1"""
+        segments = [
+            {"start": i * 5, "end": (i + 1) * 5, "text": f"Segment {i}"}
+            for i in range(5)
+        ]
+
+        result = create_srt_content(segments)
+        lines = result.split("\n")
+
+        # Find all sequence numbers (lines that are just digits)
+        seq_numbers = [line for line in lines if line.strip().isdigit()]
+        self.assertEqual(seq_numbers, ["1", "2", "3", "4", "5"])
+
+
+class CountScenesTests(TestCase):
+    """Tests for count_scenes function"""
+
+    def test_counts_single_scene(self):
+        """Test counting single scene"""
+        srt_content = "1\n00:00:00,000 --> 00:00:05,000\nHello\n"
+
+        result = count_scenes(srt_content)
+
+        self.assertEqual(result, 1)
+
+    def test_counts_multiple_scenes(self):
+        """Test counting multiple scenes"""
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Hello
+
+2
+00:00:05,000 --> 00:00:10,000
+World
+
+3
+00:00:10,000 --> 00:00:15,000
+Test
+"""
+
+        result = count_scenes(srt_content)
+
+        self.assertEqual(result, 3)
+
+    def test_handles_empty_content(self):
+        """Test handling of empty content"""
+        result = count_scenes("")
+
+        self.assertEqual(result, 0)
+
+    def test_ignores_non_numeric_lines(self):
+        """Test that non-numeric lines are ignored"""
+        srt_content = "1\n00:00:00,000 --> 00:00:05,000\nHello123\n"
+
+        result = count_scenes(srt_content)
+
+        self.assertEqual(result, 1)  # Only "1" is counted, not "Hello123"
+
+
+class ParseSrtScenesTests(TestCase):
+    """Tests for parse_srt_scenes function"""
+
+    def test_parses_single_scene(self):
+        """Test parsing single scene"""
+        srt_content = "1\n00:00:00,000 --> 00:00:05,000\nHello world\n"
+
+        result = parse_srt_scenes(srt_content)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["text"], "Hello world")
+        self.assertEqual(result[0]["start_time"], "00:00:00,000")
+        self.assertEqual(result[0]["end_time"], "00:00:05,000")
+
+    def test_parses_multiple_scenes(self):
+        """Test parsing multiple scenes"""
+        srt_content = """1
+00:00:00,000 --> 00:00:05,000
+Hello
+
+2
+00:00:05,000 --> 00:00:10,000
+World
+"""
+
+        result = parse_srt_scenes(srt_content)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["text"], "Hello")
+        self.assertEqual(result[1]["text"], "World")
+
+    def test_includes_timing_in_seconds(self):
+        """Test that timing in seconds is included"""
+        srt_content = "1\n00:01:30,500 --> 00:02:00,000\nTest\n"
+
+        result = parse_srt_scenes(srt_content)
+
+        self.assertEqual(result[0]["start_sec"], 90.5)
+        self.assertEqual(result[0]["end_sec"], 120.0)
+
+
+@override_settings(EMBEDDING_PROVIDER="openai")
+class ApplySceneSplittingTests(TestCase):
+    """Tests for apply_scene_splitting function"""
+
+    @patch("app.tasks.srt_processing.SceneSplitter")
+    def test_applies_scene_splitting(self, mock_splitter_class):
+        """Test that scene splitting is applied"""
+        mock_splitter = MagicMock()
+        mock_splitter.process.return_value = (
+            "1\n00:00:00,000 --> 00:00:10,000\nSplit scene\n"
+        )
+        mock_splitter_class.return_value = mock_splitter
+
+        srt_content = "1\n00:00:00,000 --> 00:00:05,000\nHello\n\n2\n00:00:05,000 --> 00:00:10,000\nWorld\n"
+
+        result_srt, scene_count = apply_scene_splitting(srt_content, "test-api-key", 2)
+
+        self.assertIn("Split scene", result_srt)
+        mock_splitter.process.assert_called_once()
+
+    @patch("app.tasks.srt_processing.SceneSplitter")
+    def test_returns_original_on_error(self, mock_splitter_class):
+        """Test that original SRT is returned on error"""
+        mock_splitter = MagicMock()
+        mock_splitter.process.side_effect = Exception("Splitting failed")
+        mock_splitter_class.return_value = mock_splitter
+
+        srt_content = "1\n00:00:00,000 --> 00:00:05,000\nOriginal content\n"
+
+        result_srt, scene_count = apply_scene_splitting(srt_content, "test-api-key", 1)
+
+        self.assertEqual(result_srt, srt_content)
+        self.assertEqual(scene_count, 1)
+
+    @override_settings(EMBEDDING_PROVIDER="openai")
+    def test_requires_api_key_for_openai(self):
+        """Test that API key is required for OpenAI embeddings"""
+        srt_content = "1\n00:00:00,000 --> 00:00:05,000\nTest\n"
+
+        with self.assertRaises(ValueError):
+            apply_scene_splitting(srt_content, None, 1)
+
+
+class TranscribeAndCreateSrtTests(TestCase):
+    """Tests for transcribe_and_create_srt function"""
+
+    @patch("app.tasks.srt_processing.process_audio_segments_parallel")
+    def test_creates_srt_from_segments(self, mock_process):
+        """Test that SRT is created from audio segments"""
+        mock_process.return_value = [
+            {"start": 0, "end": 5, "text": "Hello"},
+            {"start": 5, "end": 10, "text": "World"},
+        ]
+
+        audio_segments = [{"path": "/tmp/audio.mp3", "start_time": 0, "end_time": 10}]
+
+        result = transcribe_and_create_srt(MagicMock(), audio_segments)
+
+        self.assertIn("Hello", result)
+        self.assertIn("World", result)
+        self.assertIn("00:00:00,000 --> 00:00:05,000", result)
+
+    @patch("app.tasks.srt_processing.process_audio_segments_parallel")
+    def test_returns_none_on_empty_segments(self, mock_process):
+        """Test that None is returned when no segments are transcribed"""
+        mock_process.return_value = []
+
+        audio_segments = [{"path": "/tmp/audio.mp3", "start_time": 0, "end_time": 10}]
+
+        result = transcribe_and_create_srt(MagicMock(), audio_segments)
+
+        self.assertIsNone(result)
+
+    @patch("app.tasks.srt_processing.process_audio_segments_parallel")
+    def test_uses_correct_model(self, mock_process):
+        """Test that correct Whisper model is used"""
+        mock_process.return_value = [{"start": 0, "end": 5, "text": "Test"}]
+
+        mock_client = MagicMock()
+        audio_segments = [{"path": "/tmp/audio.mp3", "start_time": 0, "end_time": 10}]
+
+        transcribe_and_create_srt(mock_client, audio_segments, model="whisper-large")
+
+        mock_process.assert_called_once_with(
+            mock_client, audio_segments, "whisper-large"
+        )

--- a/backend/app/tasks/tests/test_srt_processing.py
+++ b/backend/app/tasks/tests/test_srt_processing.py
@@ -231,11 +231,13 @@ class ApplySceneSplittingTests(TestCase):
 
     @override_settings(EMBEDDING_PROVIDER="openai")
     def test_requires_api_key_for_openai(self):
-        """Test that API key is required for OpenAI embeddings"""
+        """Test that missing API key for OpenAI falls back to original SRT"""
         srt_content = "1\n00:00:00,000 --> 00:00:05,000\nTest\n"
 
-        with self.assertRaises(ValueError):
-            apply_scene_splitting(srt_content, None, 1)
+        result_srt, scene_count = apply_scene_splitting(srt_content, None, 1)
+
+        self.assertEqual(result_srt, srt_content)
+        self.assertEqual(scene_count, 1)
 
 
 class TranscribeAndCreateSrtTests(TestCase):

--- a/backend/app/tasks/tests/test_transcription.py
+++ b/backend/app/tasks/tests/test_transcription.py
@@ -78,9 +78,8 @@ class DownloadVideoFromStorageTests(TestCase):
     def test_attribute_error_triggers_download(self):
         """Test that AttributeError on path also triggers download"""
         with TemporaryFileManager() as temp_manager:
-            mock_file = MagicMock()
+            mock_file = MagicMock(spec=['name', 'open'])
             mock_file.name = "test_video.mp4"
-            type(mock_file).path = PropertyMock(side_effect=AttributeError)
 
             mock_remote_content = b"fake video content"
             mock_file.open.return_value.__enter__ = MagicMock(

--- a/backend/app/tasks/tests/test_transcription.py
+++ b/backend/app/tasks/tests/test_transcription.py
@@ -2,8 +2,6 @@
 Tests for transcription task
 """
 
-import os
-import tempfile
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from django.contrib.auth import get_user_model
@@ -90,14 +88,13 @@ class DownloadVideoFromStorageTests(TestCase):
             )
             mock_file.open.return_value.__exit__ = MagicMock(return_value=False)
 
-            self.video.file = mock_file
+            with patch.object(type(self.video), 'file', new_callable=PropertyMock, return_value=mock_file):
+                with patch("builtins.open", MagicMock()):
+                    path, file_obj = download_video_from_storage(
+                        self.video, self.video.id, temp_manager
+                    )
 
-            with patch("builtins.open", MagicMock()):
-                path, file_obj = download_video_from_storage(
-                    self.video, self.video.id, temp_manager
-                )
-
-                self.assertIn("video_", path)
+                    self.assertIn("video_", path)
 
 
 class CleanupExternalUploadTests(TestCase):
@@ -209,8 +206,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
+    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
     def test_successful_transcription_pipeline(
         self,
+        mock_validate,
         mock_whisper_config,
         mock_get_model,
         mock_create_client,
@@ -247,8 +246,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
+    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
     def test_handles_empty_audio_segments(
         self,
+        mock_validate,
         mock_whisper_config,
         mock_get_model,
         mock_create_client,
@@ -278,8 +279,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
+    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
     def test_handles_transcription_failure(
         self,
+        mock_validate,
         mock_whisper_config,
         mock_get_model,
         mock_create_client,
@@ -320,8 +323,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
+    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
     def test_external_id_triggers_file_cleanup(
         self,
+        mock_validate,
         mock_whisper_config,
         mock_get_model,
         mock_create_client,
@@ -360,8 +365,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
+    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
     def test_no_external_id_keeps_file(
         self,
+        mock_validate,
         mock_whisper_config,
         mock_get_model,
         mock_create_client,

--- a/backend/app/tasks/tests/test_transcription.py
+++ b/backend/app/tasks/tests/test_transcription.py
@@ -1,0 +1,409 @@
+"""
+Tests for transcription task
+"""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+from app.models import Video
+from app.tasks.transcription import (cleanup_external_upload,
+                                     download_video_from_storage,
+                                     handle_transcription_error,
+                                     save_transcription_result,
+                                     transcribe_video)
+from app.utils.task_helpers import TemporaryFileManager
+
+User = get_user_model()
+
+
+class DownloadVideoFromStorageTests(TestCase):
+    """Tests for download_video_from_storage function"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="pending",
+        )
+
+    def test_local_file_returns_path_directly(self):
+        """Test that local files return path directly"""
+        with TemporaryFileManager() as temp_manager:
+            mock_file = MagicMock()
+            mock_file.path = "/local/path/video.mp4"
+            self.video.file = mock_file
+
+            path, file_obj = download_video_from_storage(
+                self.video, self.video.id, temp_manager
+            )
+
+            self.assertEqual(path, "/local/path/video.mp4")
+            self.assertEqual(file_obj, mock_file)
+
+    def test_remote_file_downloads_to_temp(self):
+        """Test that remote files (S3) are downloaded to temp directory"""
+        with TemporaryFileManager() as temp_manager:
+            mock_file = MagicMock()
+            mock_file.path = PropertyMock(side_effect=NotImplementedError)
+            mock_file.name = "test_video.mp4"
+
+            mock_remote_content = b"fake video content"
+            mock_file.open.return_value.__enter__ = MagicMock(
+                return_value=MagicMock(read=MagicMock(return_value=mock_remote_content))
+            )
+            mock_file.open.return_value.__exit__ = MagicMock(return_value=False)
+
+            self.video.file = mock_file
+
+            with patch("builtins.open", MagicMock()):
+                with patch("os.path.basename", return_value="test_video.mp4"):
+                    # Force NotImplementedError on path access
+                    type(mock_file).path = PropertyMock(side_effect=NotImplementedError)
+
+                    path, file_obj = download_video_from_storage(
+                        self.video, self.video.id, temp_manager
+                    )
+
+                    self.assertIn("video_", path)
+                    self.assertEqual(len(temp_manager.temp_files), 1)
+
+    def test_attribute_error_triggers_download(self):
+        """Test that AttributeError on path also triggers download"""
+        with TemporaryFileManager() as temp_manager:
+            mock_file = MagicMock()
+            mock_file.name = "test_video.mp4"
+            type(mock_file).path = PropertyMock(side_effect=AttributeError)
+
+            mock_remote_content = b"fake video content"
+            mock_file.open.return_value.__enter__ = MagicMock(
+                return_value=MagicMock(read=MagicMock(return_value=mock_remote_content))
+            )
+            mock_file.open.return_value.__exit__ = MagicMock(return_value=False)
+
+            self.video.file = mock_file
+
+            with patch("builtins.open", MagicMock()):
+                path, file_obj = download_video_from_storage(
+                    self.video, self.video.id, temp_manager
+                )
+
+                self.assertIn("video_", path)
+
+
+class CleanupExternalUploadTests(TestCase):
+    """Tests for cleanup_external_upload function"""
+
+    def test_deletes_file_successfully(self):
+        """Test that file is deleted successfully"""
+        mock_file = MagicMock()
+
+        cleanup_external_upload(mock_file, 1)
+
+        mock_file.delete.assert_called_once_with(save=False)
+
+    def test_handles_none_file_gracefully(self):
+        """Test that None file is handled gracefully"""
+        # Should not raise any exception
+        cleanup_external_upload(None, 1)
+
+    def test_handles_delete_exception_gracefully(self):
+        """Test that delete exception is logged but not raised"""
+        mock_file = MagicMock()
+        mock_file.delete.side_effect = Exception("Delete failed")
+
+        # Should not raise any exception
+        cleanup_external_upload(mock_file, 1)
+
+
+class SaveTranscriptionResultTests(TestCase):
+    """Tests for save_transcription_result function"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="processing",
+        )
+
+    def test_saves_transcript_and_updates_status(self):
+        """Test that transcript is saved and status is updated"""
+        srt_content = "1\n00:00:00,000 --> 00:00:05,000\nHello world\n"
+
+        save_transcription_result(self.video, srt_content)
+
+        self.video.refresh_from_db()
+        self.assertEqual(self.video.status, "completed")
+        self.assertEqual(self.video.transcript, srt_content)
+
+    def test_clears_error_message(self):
+        """Test that error message is cleared on success"""
+        self.video.error_message = "Previous error"
+        self.video.save()
+
+        save_transcription_result(self.video, "test transcript")
+
+        self.video.refresh_from_db()
+        self.assertEqual(self.video.error_message, "")
+
+
+class HandleTranscriptionErrorTests(TestCase):
+    """Tests for handle_transcription_error function"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="processing",
+        )
+
+    def test_sets_error_status_and_message(self):
+        """Test that error status and message are set"""
+        error_msg = "Transcription failed"
+
+        handle_transcription_error(self.video, error_msg)
+
+        self.video.refresh_from_db()
+        self.assertEqual(self.video.status, "error")
+        self.assertEqual(self.video.error_message, error_msg)
+
+
+@override_settings(OPENAI_API_KEY="test-api-key")
+class TranscribeVideoTaskTests(TestCase):
+    """Tests for transcribe_video Celery task"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+
+    @patch("app.tasks.transcription.index_scenes_batch")
+    @patch("app.tasks.transcription.apply_scene_splitting")
+    @patch("app.tasks.transcription.transcribe_and_create_srt")
+    @patch("app.tasks.transcription.extract_and_split_audio")
+    @patch("app.tasks.transcription.download_video_from_storage")
+    @patch("app.tasks.transcription.create_whisper_client")
+    @patch("app.tasks.transcription.get_whisper_model_name")
+    @patch("app.tasks.transcription.WhisperConfig")
+    def test_successful_transcription_pipeline(
+        self,
+        mock_whisper_config,
+        mock_get_model,
+        mock_create_client,
+        mock_download,
+        mock_extract,
+        mock_transcribe,
+        mock_scene_split,
+        mock_index,
+    ):
+        """Test successful transcription pipeline"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="pending",
+        )
+
+        # Setup mocks
+        mock_get_model.return_value = "whisper-1"
+        mock_download.return_value = ("/tmp/video.mp4", MagicMock())
+        mock_extract.return_value = [
+            {"path": "/tmp/audio.mp3", "start_time": 0, "end_time": 10}
+        ]
+        mock_transcribe.return_value = "1\n00:00:00,000 --> 00:00:10,000\nHello\n"
+        mock_scene_split.return_value = ("1\n00:00:00,000 --> 00:00:10,000\nHello\n", 1)
+
+        result = transcribe_video(video.id)
+
+        video.refresh_from_db()
+        self.assertEqual(video.status, "completed")
+        self.assertIsNotNone(result)
+
+    @patch("app.tasks.transcription.extract_and_split_audio")
+    @patch("app.tasks.transcription.download_video_from_storage")
+    @patch("app.tasks.transcription.create_whisper_client")
+    @patch("app.tasks.transcription.get_whisper_model_name")
+    @patch("app.tasks.transcription.WhisperConfig")
+    def test_handles_empty_audio_segments(
+        self,
+        mock_whisper_config,
+        mock_get_model,
+        mock_create_client,
+        mock_download,
+        mock_extract,
+    ):
+        """Test that empty audio segments result in error status"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="pending",
+        )
+
+        mock_get_model.return_value = "whisper-1"
+        mock_download.return_value = ("/tmp/video.mp4", MagicMock())
+        mock_extract.return_value = []
+
+        transcribe_video(video.id)
+
+        video.refresh_from_db()
+        self.assertEqual(video.status, "error")
+        self.assertIn("Failed to extract audio", video.error_message)
+
+    @patch("app.tasks.transcription.transcribe_and_create_srt")
+    @patch("app.tasks.transcription.extract_and_split_audio")
+    @patch("app.tasks.transcription.download_video_from_storage")
+    @patch("app.tasks.transcription.create_whisper_client")
+    @patch("app.tasks.transcription.get_whisper_model_name")
+    @patch("app.tasks.transcription.WhisperConfig")
+    def test_handles_transcription_failure(
+        self,
+        mock_whisper_config,
+        mock_get_model,
+        mock_create_client,
+        mock_download,
+        mock_extract,
+        mock_transcribe,
+    ):
+        """Test that transcription failure results in error status"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="pending",
+        )
+
+        mock_get_model.return_value = "whisper-1"
+        mock_download.return_value = ("/tmp/video.mp4", MagicMock())
+        mock_extract.return_value = [
+            {"path": "/tmp/audio.mp3", "start_time": 0, "end_time": 10}
+        ]
+        mock_transcribe.return_value = None
+
+        transcribe_video(video.id)
+
+        video.refresh_from_db()
+        self.assertEqual(video.status, "error")
+        self.assertIn("Failed to transcribe", video.error_message)
+
+    def test_handles_nonexistent_video(self):
+        """Test handling of non-existent video ID"""
+        with self.assertRaises(Exception):
+            transcribe_video(99999)
+
+    @patch("app.tasks.transcription.index_scenes_batch")
+    @patch("app.tasks.transcription.apply_scene_splitting")
+    @patch("app.tasks.transcription.transcribe_and_create_srt")
+    @patch("app.tasks.transcription.extract_and_split_audio")
+    @patch("app.tasks.transcription.download_video_from_storage")
+    @patch("app.tasks.transcription.create_whisper_client")
+    @patch("app.tasks.transcription.get_whisper_model_name")
+    @patch("app.tasks.transcription.WhisperConfig")
+    def test_external_id_triggers_file_cleanup(
+        self,
+        mock_whisper_config,
+        mock_get_model,
+        mock_create_client,
+        mock_download,
+        mock_extract,
+        mock_transcribe,
+        mock_scene_split,
+        mock_index,
+    ):
+        """Test that external_id triggers file cleanup after processing"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="pending",
+            external_id="ext-123",
+        )
+
+        mock_file = MagicMock()
+        mock_get_model.return_value = "whisper-1"
+        mock_download.return_value = ("/tmp/video.mp4", mock_file)
+        mock_extract.return_value = [
+            {"path": "/tmp/audio.mp3", "start_time": 0, "end_time": 10}
+        ]
+        mock_transcribe.return_value = "1\n00:00:00,000 --> 00:00:10,000\nHello\n"
+        mock_scene_split.return_value = ("1\n00:00:00,000 --> 00:00:10,000\nHello\n", 1)
+
+        transcribe_video(video.id)
+
+        mock_file.delete.assert_called_once_with(save=False)
+
+    @patch("app.tasks.transcription.index_scenes_batch")
+    @patch("app.tasks.transcription.apply_scene_splitting")
+    @patch("app.tasks.transcription.transcribe_and_create_srt")
+    @patch("app.tasks.transcription.extract_and_split_audio")
+    @patch("app.tasks.transcription.download_video_from_storage")
+    @patch("app.tasks.transcription.create_whisper_client")
+    @patch("app.tasks.transcription.get_whisper_model_name")
+    @patch("app.tasks.transcription.WhisperConfig")
+    def test_no_external_id_keeps_file(
+        self,
+        mock_whisper_config,
+        mock_get_model,
+        mock_create_client,
+        mock_download,
+        mock_extract,
+        mock_transcribe,
+        mock_scene_split,
+        mock_index,
+    ):
+        """Test that videos without external_id keep their files"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="pending",
+            external_id=None,
+        )
+
+        mock_file = MagicMock()
+        mock_get_model.return_value = "whisper-1"
+        mock_download.return_value = ("/tmp/video.mp4", mock_file)
+        mock_extract.return_value = [
+            {"path": "/tmp/audio.mp3", "start_time": 0, "end_time": 10}
+        ]
+        mock_transcribe.return_value = "1\n00:00:00,000 --> 00:00:10,000\nHello\n"
+        mock_scene_split.return_value = ("1\n00:00:00,000 --> 00:00:10,000\nHello\n", 1)
+
+        transcribe_video(video.id)
+
+        mock_file.delete.assert_not_called()
+
+    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing")
+    @patch("app.tasks.transcription.VideoTaskManager.get_video_with_user")
+    def test_invalid_video_raises_error(self, mock_get_video, mock_validate):
+        """Test that invalid video raises error"""
+        video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="pending",
+        )
+
+        mock_get_video.return_value = (video, None)
+        mock_validate.return_value = (False, "Video has no file")
+
+        with self.assertRaises(ValueError):
+            transcribe_video(video.id)

--- a/backend/app/tasks/tests/test_vector_indexing.py
+++ b/backend/app/tasks/tests/test_vector_indexing.py
@@ -1,0 +1,263 @@
+"""
+Tests for vector indexing functions
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import Video
+from app.tasks.vector_indexing import (create_scene_metadata,
+                                       index_scenes_batch,
+                                       index_scenes_to_vectorstore)
+
+User = get_user_model()
+
+
+class CreateSceneMetadataTests(TestCase):
+    """Tests for create_scene_metadata function"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="completed",
+        )
+
+    def test_creates_basic_metadata(self):
+        """Test that basic metadata is created correctly"""
+        scene = {
+            "start_time": "00:00:00,000",
+            "end_time": "00:00:05,000",
+            "start_sec": 0.0,
+            "end_sec": 5.0,
+            "index": 1,
+        }
+
+        result = create_scene_metadata(self.video, scene)
+
+        self.assertEqual(result["video_id"], self.video.id)
+        self.assertEqual(result["user_id"], self.user.id)
+        self.assertEqual(result["video_title"], "Test Video")
+        self.assertEqual(result["start_time"], "00:00:00,000")
+        self.assertEqual(result["end_time"], "00:00:05,000")
+        self.assertEqual(result["start_sec"], 0.0)
+        self.assertEqual(result["end_sec"], 5.0)
+        self.assertEqual(result["scene_index"], 1)
+
+    def test_includes_external_id_when_present(self):
+        """Test that external_id is included when present"""
+        self.video.external_id = "ext-123"
+        self.video.save()
+
+        scene = {
+            "start_time": "00:00:00,000",
+            "end_time": "00:00:05,000",
+            "start_sec": 0.0,
+            "end_sec": 5.0,
+            "index": 1,
+        }
+
+        result = create_scene_metadata(self.video, scene)
+
+        self.assertEqual(result["external_id"], "ext-123")
+
+    def test_excludes_external_id_when_not_present(self):
+        """Test that external_id is not included when not present"""
+        scene = {
+            "start_time": "00:00:00,000",
+            "end_time": "00:00:05,000",
+            "start_sec": 0.0,
+            "end_sec": 5.0,
+            "index": 1,
+        }
+
+        result = create_scene_metadata(self.video, scene)
+
+        self.assertNotIn("external_id", result)
+
+
+class IndexScenesToVectorstoreTests(TestCase):
+    """Tests for index_scenes_to_vectorstore function"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="completed",
+        )
+
+    @patch("app.tasks.vector_indexing.PGVector")
+    @patch("app.tasks.vector_indexing.PGVectorManager")
+    @patch("app.tasks.vector_indexing.get_embeddings")
+    def test_indexes_scenes_successfully(
+        self, mock_get_embeddings, mock_pgvector_manager, mock_pgvector
+    ):
+        """Test successful scene indexing"""
+        mock_pgvector_manager.get_config.return_value = {
+            "collection_name": "test_collection",
+            "database_url": "postgresql://localhost/test",
+        }
+
+        scene_docs = [
+            {"text": "Hello world", "metadata": {"video_id": 1}},
+            {"text": "Test content", "metadata": {"video_id": 1}},
+        ]
+
+        index_scenes_to_vectorstore(scene_docs, self.video, "test-api-key")
+
+        mock_pgvector.from_texts.assert_called_once()
+
+    @patch("app.tasks.vector_indexing.PGVectorManager")
+    @patch("app.tasks.vector_indexing.get_embeddings")
+    def test_skips_empty_texts(self, mock_get_embeddings, mock_pgvector_manager):
+        """Test that empty texts are skipped"""
+        mock_pgvector_manager.get_config.return_value = {
+            "collection_name": "test_collection",
+            "database_url": "postgresql://localhost/test",
+        }
+
+        scene_docs = [
+            {"text": "", "metadata": {"video_id": 1}},
+            {"text": None, "metadata": {"video_id": 1}},
+        ]
+
+        # Should not raise, should just log and skip
+        index_scenes_to_vectorstore(scene_docs, self.video, "test-api-key")
+
+    @patch("app.tasks.vector_indexing.PGVector")
+    @patch("app.tasks.vector_indexing.PGVectorManager")
+    @patch("app.tasks.vector_indexing.get_embeddings")
+    def test_handles_indexing_error(
+        self, mock_get_embeddings, mock_pgvector_manager, mock_pgvector
+    ):
+        """Test that indexing errors are handled gracefully"""
+        mock_pgvector_manager.get_config.return_value = {
+            "collection_name": "test_collection",
+            "database_url": "postgresql://localhost/test",
+        }
+        mock_pgvector.from_texts.side_effect = Exception("Indexing failed")
+
+        scene_docs = [{"text": "Hello world", "metadata": {"video_id": 1}}]
+
+        # Should not raise, should log warning
+        index_scenes_to_vectorstore(scene_docs, self.video, "test-api-key")
+
+    @patch("app.tasks.vector_indexing.PGVector")
+    @patch("app.tasks.vector_indexing.PGVectorManager")
+    @patch("app.tasks.vector_indexing.get_embeddings")
+    def test_converts_connection_string(
+        self, mock_get_embeddings, mock_pgvector_manager, mock_pgvector
+    ):
+        """Test that postgresql:// is converted to postgresql+psycopg://"""
+        mock_pgvector_manager.get_config.return_value = {
+            "collection_name": "test_collection",
+            "database_url": "postgresql://user:pass@localhost/db",
+        }
+
+        scene_docs = [{"text": "Hello world", "metadata": {"video_id": 1}}]
+
+        index_scenes_to_vectorstore(scene_docs, self.video, "test-api-key")
+
+        # Check that the connection string was converted
+        call_kwargs = mock_pgvector.from_texts.call_args[1]
+        self.assertIn("postgresql+psycopg://", call_kwargs["connection"])
+
+
+class IndexScenesBatchTests(TestCase):
+    """Tests for index_scenes_batch function"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            status="completed",
+        )
+
+    @patch("app.tasks.vector_indexing.index_scenes_to_vectorstore")
+    @patch("app.tasks.vector_indexing.parse_srt_scenes")
+    def test_parses_srt_and_indexes(self, mock_parse, mock_index):
+        """Test that SRT is parsed and indexed"""
+        mock_parse.return_value = [
+            {
+                "text": "Hello world",
+                "start_time": "00:00:00,000",
+                "end_time": "00:00:05,000",
+                "start_sec": 0.0,
+                "end_sec": 5.0,
+                "index": 1,
+            }
+        ]
+
+        srt_content = "1\n00:00:00,000 --> 00:00:05,000\nHello world\n"
+
+        index_scenes_batch(srt_content, self.video, "test-api-key")
+
+        mock_parse.assert_called_once_with(srt_content)
+        mock_index.assert_called_once()
+
+    @patch("app.tasks.vector_indexing.index_scenes_to_vectorstore")
+    @patch("app.tasks.vector_indexing.parse_srt_scenes")
+    def test_creates_correct_scene_docs(self, mock_parse, mock_index):
+        """Test that scene documents are created correctly"""
+        mock_parse.return_value = [
+            {
+                "text": "Scene 1",
+                "start_time": "00:00:00,000",
+                "end_time": "00:00:05,000",
+                "start_sec": 0.0,
+                "end_sec": 5.0,
+                "index": 1,
+            },
+            {
+                "text": "Scene 2",
+                "start_time": "00:00:05,000",
+                "end_time": "00:00:10,000",
+                "start_sec": 5.0,
+                "end_sec": 10.0,
+                "index": 2,
+            },
+        ]
+
+        srt_content = "mock srt content"
+
+        index_scenes_batch(srt_content, self.video, "test-api-key")
+
+        # Verify scene docs structure
+        call_args = mock_index.call_args[0]
+        scene_docs = call_args[0]
+
+        self.assertEqual(len(scene_docs), 2)
+        self.assertEqual(scene_docs[0]["text"], "Scene 1")
+        self.assertEqual(scene_docs[1]["text"], "Scene 2")
+        self.assertIn("metadata", scene_docs[0])
+        self.assertEqual(scene_docs[0]["metadata"]["video_id"], self.video.id)
+
+    @patch("app.tasks.vector_indexing.parse_srt_scenes")
+    def test_raises_on_parsing_error(self, mock_parse):
+        """Test that parsing errors are re-raised"""
+        mock_parse.side_effect = Exception("Parse failed")
+
+        srt_content = "invalid srt"
+
+        with self.assertRaises(Exception):
+            index_scenes_batch(srt_content, self.video, "test-api-key")

--- a/backend/app/tasks/tests/test_vector_indexing.py
+++ b/backend/app/tasks/tests/test_vector_indexing.py
@@ -121,9 +121,12 @@ class IndexScenesToVectorstoreTests(TestCase):
 
         mock_pgvector.from_texts.assert_called_once()
 
+    @patch("app.tasks.vector_indexing.PGVector")
     @patch("app.tasks.vector_indexing.PGVectorManager")
     @patch("app.tasks.vector_indexing.get_embeddings")
-    def test_skips_empty_texts(self, mock_get_embeddings, mock_pgvector_manager):
+    def test_skips_empty_texts(
+        self, mock_get_embeddings, mock_pgvector_manager, mock_pgvector
+    ):
         """Test that empty texts are skipped"""
         mock_pgvector_manager.get_config.return_value = {
             "collection_name": "test_collection",
@@ -137,6 +140,7 @@ class IndexScenesToVectorstoreTests(TestCase):
 
         # Should not raise, should just log and skip
         index_scenes_to_vectorstore(scene_docs, self.video, "test-api-key")
+        mock_pgvector.from_texts.assert_not_called()
 
     @patch("app.tasks.vector_indexing.PGVector")
     @patch("app.tasks.vector_indexing.PGVectorManager")

--- a/backend/app/tasks/tests/test_vector_indexing.py
+++ b/backend/app/tasks/tests/test_vector_indexing.py
@@ -2,7 +2,7 @@
 Tests for vector indexing functions
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase

--- a/backend/app/video/tests/test_serializers.py
+++ b/backend/app/video/tests/test_serializers.py
@@ -1,0 +1,448 @@
+"""
+Tests for video serializers
+"""
+
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from app.models import Tag, Video, VideoGroup, VideoGroupMember, VideoTag
+from app.video.serializers import (TagCreateSerializer, TagDetailSerializer,
+                                   TagListSerializer, TagUpdateSerializer,
+                                   VideoCreateSerializer,
+                                   VideoGroupDetailSerializer,
+                                   VideoGroupListSerializer,
+                                   VideoListSerializer, VideoSerializer,
+                                   VideoUpdateSerializer)
+
+User = get_user_model()
+
+
+class VideoCreateSerializerTests(TestCase):
+    """Tests for VideoCreateSerializer"""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+
+    def _create_video_file(self):
+        """Helper to create a test video file"""
+        return SimpleUploadedFile(
+            "test_video.mp4",
+            BytesIO(b"fake video content").read(),
+            content_type="video/mp4",
+        )
+
+    def _get_request_context(self):
+        """Helper to create request context"""
+        request = self.factory.post("/videos/")
+        request.user = self.user
+        return {"request": Request(request)}
+
+    @patch("app.video.serializers.transcribe_video.delay")
+    def test_valid_video_creation(self, mock_task):
+        """Test valid video creation"""
+        data = {
+            "file": self._create_video_file(),
+            "title": "Test Video",
+            "description": "Test Description",
+        }
+
+        serializer = VideoCreateSerializer(
+            data=data, context=self._get_request_context()
+        )
+
+        self.assertTrue(serializer.is_valid())
+
+    @patch("app.video.serializers.transcribe_video.delay")
+    def test_starts_transcription_task_on_create(self, mock_task):
+        """Test that transcription task is started on create"""
+        data = {
+            "file": self._create_video_file(),
+            "title": "Test Video",
+            "description": "Test Description",
+        }
+
+        serializer = VideoCreateSerializer(
+            data=data, context=self._get_request_context()
+        )
+        self.assertTrue(serializer.is_valid())
+        video = serializer.save()
+
+        mock_task.assert_called_once_with(video.id)
+
+    def test_validates_video_limit_zero(self):
+        """Test validation when video_limit is 0"""
+        self.user.video_limit = 0
+        self.user.save()
+
+        data = {
+            "file": self._create_video_file(),
+            "title": "Test Video",
+        }
+
+        serializer = VideoCreateSerializer(
+            data=data, context=self._get_request_context()
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("Video upload limit reached", str(serializer.errors))
+
+    @patch("app.video.serializers.transcribe_video.delay")
+    def test_validates_video_limit_reached(self, mock_task):
+        """Test validation when video_limit is reached"""
+        self.user.video_limit = 2
+        self.user.save()
+
+        # Create 2 videos
+        Video.objects.create(user=self.user, title="Video 1")
+        Video.objects.create(user=self.user, title="Video 2")
+
+        data = {
+            "file": self._create_video_file(),
+            "title": "Video 3",
+        }
+
+        serializer = VideoCreateSerializer(
+            data=data, context=self._get_request_context()
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("Video upload limit reached", str(serializer.errors))
+
+    @patch("app.video.serializers.transcribe_video.delay")
+    def test_allows_upload_when_within_limit(self, mock_task):
+        """Test that upload is allowed when within limit"""
+        self.user.video_limit = 3
+        self.user.save()
+
+        Video.objects.create(user=self.user, title="Video 1")
+
+        data = {
+            "file": self._create_video_file(),
+            "title": "Video 2",
+        }
+
+        serializer = VideoCreateSerializer(
+            data=data, context=self._get_request_context()
+        )
+
+        self.assertTrue(serializer.is_valid())
+
+    @patch("app.video.serializers.transcribe_video.delay")
+    def test_allows_unlimited_uploads(self, mock_task):
+        """Test that unlimited uploads are allowed when video_limit is None"""
+        self.user.video_limit = None
+        self.user.save()
+
+        # Create many videos
+        for i in range(10):
+            Video.objects.create(user=self.user, title=f"Video {i}")
+
+        data = {
+            "file": self._create_video_file(),
+            "title": "Another Video",
+        }
+
+        serializer = VideoCreateSerializer(
+            data=data, context=self._get_request_context()
+        )
+
+        self.assertTrue(serializer.is_valid())
+
+    def test_normalizes_empty_external_id(self):
+        """Test that empty external_id is normalized to None"""
+        data = {
+            "file": self._create_video_file(),
+            "title": "Test Video",
+            "external_id": "",
+        }
+
+        serializer = VideoCreateSerializer(
+            data=data, context=self._get_request_context()
+        )
+
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("external_id"))
+
+    def test_normalizes_whitespace_external_id(self):
+        """Test that whitespace external_id is normalized to None"""
+        data = {
+            "file": self._create_video_file(),
+            "title": "Test Video",
+            "external_id": "   ",
+        }
+
+        serializer = VideoCreateSerializer(
+            data=data, context=self._get_request_context()
+        )
+
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("external_id"))
+
+
+class TagCreateSerializerTests(TestCase):
+    """Tests for TagCreateSerializer"""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+
+    def _get_request_context(self):
+        """Helper to create request context"""
+        request = self.factory.post("/tags/")
+        request.user = self.user
+        return {"request": Request(request)}
+
+    def test_valid_tag_creation(self):
+        """Test valid tag creation"""
+        data = {
+            "name": "Important",
+            "color": "#FF0000",
+        }
+
+        serializer = TagCreateSerializer(data=data, context=self._get_request_context())
+
+        self.assertTrue(serializer.is_valid())
+
+    def test_validates_empty_name(self):
+        """Test that empty name is invalid"""
+        data = {
+            "name": "",
+            "color": "#FF0000",
+        }
+
+        serializer = TagCreateSerializer(data=data, context=self._get_request_context())
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("name", serializer.errors)
+
+    def test_validates_whitespace_name(self):
+        """Test that whitespace-only name is invalid"""
+        data = {
+            "name": "   ",
+            "color": "#FF0000",
+        }
+
+        serializer = TagCreateSerializer(data=data, context=self._get_request_context())
+
+        self.assertFalse(serializer.is_valid())
+
+    def test_strips_name_whitespace(self):
+        """Test that name whitespace is stripped"""
+        data = {
+            "name": "  Important  ",
+            "color": "#FF0000",
+        }
+
+        serializer = TagCreateSerializer(data=data, context=self._get_request_context())
+
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["name"], "Important")
+
+    def test_validates_color_format_valid(self):
+        """Test valid color formats"""
+        valid_colors = ["#FF0000", "#00ff00", "#0000FF", "#123456", "#ABCDEF"]
+
+        for color in valid_colors:
+            data = {"name": "Test", "color": color}
+            serializer = TagCreateSerializer(
+                data=data, context=self._get_request_context()
+            )
+            self.assertTrue(serializer.is_valid(), f"Color {color} should be valid")
+
+    def test_validates_color_format_invalid(self):
+        """Test invalid color formats"""
+        invalid_colors = [
+            "#FFF",  # Too short
+            "#FFFFFFF",  # Too long
+            "FF0000",  # Missing #
+            "#GGGGGG",  # Invalid hex
+            "red",  # Named color
+        ]
+
+        for color in invalid_colors:
+            data = {"name": "Test", "color": color}
+            serializer = TagCreateSerializer(
+                data=data, context=self._get_request_context()
+            )
+            self.assertFalse(serializer.is_valid(), f"Color {color} should be invalid")
+            self.assertIn("color", serializer.errors)
+
+
+class TagUpdateSerializerTests(TestCase):
+    """Tests for TagUpdateSerializer"""
+
+    def test_validates_color_format(self):
+        """Test color format validation on update"""
+        data = {"color": "invalid"}
+
+        serializer = TagUpdateSerializer(data=data, partial=True)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("color", serializer.errors)
+
+    def test_validates_empty_name_on_update(self):
+        """Test that empty name is invalid on update"""
+        data = {"name": ""}
+
+        serializer = TagUpdateSerializer(data=data, partial=True)
+
+        self.assertFalse(serializer.is_valid())
+
+
+class VideoSerializerTests(TestCase):
+    """Tests for VideoSerializer"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test Video",
+            description="Test Description",
+            status="completed",
+        )
+
+    def test_includes_tags(self):
+        """Test that tags are included in serialization"""
+        tag1 = Tag.objects.create(user=self.user, name="Tag1", color="#FF0000")
+        tag2 = Tag.objects.create(user=self.user, name="Tag2", color="#00FF00")
+        VideoTag.objects.create(video=self.video, tag=tag1)
+        VideoTag.objects.create(video=self.video, tag=tag2)
+
+        serializer = VideoSerializer(self.video)
+        data = serializer.data
+
+        self.assertEqual(len(data["tags"]), 2)
+        self.assertIn("id", data["tags"][0])
+        self.assertIn("name", data["tags"][0])
+        self.assertIn("color", data["tags"][0])
+
+
+class VideoGroupDetailSerializerTests(TestCase):
+    """Tests for VideoGroupDetailSerializer"""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+            description="Test Description",
+        )
+
+    def _get_request_context(self):
+        """Helper to create request context"""
+        request = self.factory.get("/groups/")
+        request.user = self.user
+        return {"request": Request(request)}
+
+    def test_includes_videos_with_order(self):
+        """Test that videos include order information"""
+        video1 = Video.objects.create(user=self.user, title="Video 1")
+        video2 = Video.objects.create(user=self.user, title="Video 2")
+        VideoGroupMember.objects.create(group=self.group, video=video1, order=1)
+        VideoGroupMember.objects.create(group=self.group, video=video2, order=0)
+
+        # Add video_count annotation
+        from django.db.models import Count
+
+        group_with_count = VideoGroup.objects.annotate(
+            video_count=Count("members")
+        ).get(pk=self.group.pk)
+
+        serializer = VideoGroupDetailSerializer(
+            group_with_count, context=self._get_request_context()
+        )
+        data = serializer.data
+
+        self.assertEqual(len(data["videos"]), 2)
+        # Videos should be ordered by the members ordering (order, then added_at)
+        orders = [v["order"] for v in data["videos"]]
+        self.assertEqual(orders, [0, 1])
+
+    def test_empty_group_returns_empty_videos(self):
+        """Test that empty group returns empty videos list"""
+        from django.db.models import Count
+
+        group_with_count = VideoGroup.objects.annotate(
+            video_count=Count("members")
+        ).get(pk=self.group.pk)
+
+        serializer = VideoGroupDetailSerializer(
+            group_with_count, context=self._get_request_context()
+        )
+        data = serializer.data
+
+        self.assertEqual(data["videos"], [])
+        self.assertEqual(data["video_count"], 0)
+
+
+class TagDetailSerializerTests(TestCase):
+    """Tests for TagDetailSerializer"""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+            video_limit=None,
+        )
+        self.tag = Tag.objects.create(
+            user=self.user,
+            name="Test Tag",
+            color="#FF0000",
+        )
+
+    def _get_request_context(self):
+        """Helper to create request context"""
+        request = self.factory.get("/tags/")
+        request.user = self.user
+        return {"request": Request(request)}
+
+    def test_includes_videos_with_tag(self):
+        """Test that videos with this tag are included"""
+        video1 = Video.objects.create(user=self.user, title="Video 1")
+        video2 = Video.objects.create(user=self.user, title="Video 2")
+        VideoTag.objects.create(video=video1, tag=self.tag)
+        VideoTag.objects.create(video=video2, tag=self.tag)
+
+        # Add video_count annotation
+        from django.db.models import Count
+
+        tag_with_count = Tag.objects.annotate(video_count=Count("video_tags")).get(
+            pk=self.tag.pk
+        )
+
+        serializer = TagDetailSerializer(
+            tag_with_count, context=self._get_request_context()
+        )
+        data = serializer.data
+
+        self.assertEqual(len(data["videos"]), 2)
+        self.assertEqual(data["video_count"], 2)

--- a/backend/app/video/tests/test_serializers.py
+++ b/backend/app/video/tests/test_serializers.py
@@ -3,22 +3,20 @@ Tests for video serializers
 """
 
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from rest_framework.request import Request
-from rest_framework.test import APIRequestFactory
+from rest_framework.test import APIRequestFactory, force_authenticate
 
 from app.models import Tag, Video, VideoGroup, VideoGroupMember, VideoTag
 from app.video.serializers import (TagCreateSerializer, TagDetailSerializer,
-                                   TagListSerializer, TagUpdateSerializer,
+                                   TagUpdateSerializer,
                                    VideoCreateSerializer,
                                    VideoGroupDetailSerializer,
-                                   VideoGroupListSerializer,
-                                   VideoListSerializer, VideoSerializer,
-                                   VideoUpdateSerializer)
+                                   VideoSerializer)
 
 User = get_user_model()
 
@@ -46,8 +44,10 @@ class VideoCreateSerializerTests(TestCase):
     def _get_request_context(self):
         """Helper to create request context"""
         request = self.factory.post("/videos/")
-        request.user = self.user
-        return {"request": Request(request)}
+        force_authenticate(request, user=self.user)
+        drf_request = Request(request)
+        drf_request._user = self.user
+        return {"request": drf_request}
 
     @patch("app.video.serializers.transcribe_video.delay")
     def test_valid_video_creation(self, mock_task):

--- a/frontend/src/lib/utils/__tests__/errorHandling.test.ts
+++ b/frontend/src/lib/utils/__tests__/errorHandling.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { handleAsyncError } from '../errorHandling'
+
+describe('handleAsyncError', () => {
+  let mockSetError: ReturnType<typeof vi.fn>
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    mockSetError = vi.fn()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('should use error message when error is an Error instance with message', () => {
+    const error = new Error('Specific error message')
+    const defaultMessage = 'Default message'
+
+    handleAsyncError(error, defaultMessage, mockSetError)
+
+    expect(mockSetError).toHaveBeenCalledWith('Specific error message')
+  })
+
+  it('should use default message when error is not an Error instance', () => {
+    const error = 'string error'
+    const defaultMessage = 'Default message'
+
+    handleAsyncError(error, defaultMessage, mockSetError)
+
+    expect(mockSetError).toHaveBeenCalledWith('Default message')
+  })
+
+  it('should use default message when error is null', () => {
+    const error = null
+    const defaultMessage = 'Default message'
+
+    handleAsyncError(error, defaultMessage, mockSetError)
+
+    expect(mockSetError).toHaveBeenCalledWith('Default message')
+  })
+
+  it('should use default message when error is undefined', () => {
+    const error = undefined
+    const defaultMessage = 'Default message'
+
+    handleAsyncError(error, defaultMessage, mockSetError)
+
+    expect(mockSetError).toHaveBeenCalledWith('Default message')
+  })
+
+  it('should use default message when Error has empty message', () => {
+    const error = new Error('')
+    const defaultMessage = 'Default message'
+
+    handleAsyncError(error, defaultMessage, mockSetError)
+
+    expect(mockSetError).toHaveBeenCalledWith('Default message')
+  })
+
+  it('should log error to console', () => {
+    const error = new Error('Test error')
+    const defaultMessage = 'Default message'
+
+    handleAsyncError(error, defaultMessage, mockSetError)
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Default message', error)
+  })
+
+  it('should handle object as error', () => {
+    const error = { code: 'ERR_001', details: 'Some details' }
+    const defaultMessage = 'Default message'
+
+    handleAsyncError(error, defaultMessage, mockSetError)
+
+    expect(mockSetError).toHaveBeenCalledWith('Default message')
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Default message', error)
+  })
+})

--- a/frontend/src/lib/utils/__tests__/errorHandling.test.ts
+++ b/frontend/src/lib/utils/__tests__/errorHandling.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { handleAsyncError } from '../errorHandling'
 
 describe('handleAsyncError', () => {

--- a/frontend/src/lib/utils/__tests__/videoConversion.test.ts
+++ b/frontend/src/lib/utils/__tests__/videoConversion.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest'
+import {
+  convertVideoInGroupToSelectedVideo,
+  convertVideoListToSelectedVideo,
+  createVideoIdSet,
+  extractVideoIds,
+} from '../videoConversion'
+import type { VideoInGroup, VideoList } from '@/lib/api'
+
+describe('convertVideoInGroupToSelectedVideo', () => {
+  it('should convert VideoInGroup to SelectedVideo', () => {
+    const videoInGroup: VideoInGroup = {
+      id: 1,
+      title: 'Test Video',
+      description: 'Test Description',
+      file: 'video.mp4',
+      status: 'completed',
+      order: 0,
+    }
+
+    const result = convertVideoInGroupToSelectedVideo(videoInGroup)
+
+    expect(result).toEqual({
+      id: 1,
+      title: 'Test Video',
+      description: 'Test Description',
+      file: 'video.mp4',
+      status: 'completed',
+    })
+  })
+
+  it('should handle null file', () => {
+    const videoInGroup: VideoInGroup = {
+      id: 2,
+      title: 'No File Video',
+      description: '',
+      file: null,
+      status: 'pending',
+      order: 1,
+    }
+
+    const result = convertVideoInGroupToSelectedVideo(videoInGroup)
+
+    expect(result.file).toBeNull()
+  })
+
+  it('should handle empty description', () => {
+    const videoInGroup: VideoInGroup = {
+      id: 3,
+      title: 'Video',
+      description: '',
+      file: 'video.mp4',
+      status: 'processing',
+      order: 2,
+    }
+
+    const result = convertVideoInGroupToSelectedVideo(videoInGroup)
+
+    expect(result.description).toBe('')
+  })
+})
+
+describe('convertVideoListToSelectedVideo', () => {
+  it('should convert VideoList to SelectedVideo', () => {
+    const videoList: VideoList = {
+      id: 1,
+      title: 'List Video',
+      description: 'List Description',
+      file: 'list-video.mp4',
+      status: 'completed',
+      uploaded_at: '2024-01-01T00:00:00Z',
+    }
+
+    const result = convertVideoListToSelectedVideo(videoList)
+
+    expect(result).toEqual({
+      id: 1,
+      title: 'List Video',
+      description: 'List Description',
+      file: 'list-video.mp4',
+      status: 'completed',
+    })
+  })
+
+  it('should not include uploaded_at in result', () => {
+    const videoList: VideoList = {
+      id: 2,
+      title: 'Video',
+      description: 'Desc',
+      file: 'video.mp4',
+      status: 'completed',
+      uploaded_at: '2024-01-01T00:00:00Z',
+    }
+
+    const result = convertVideoListToSelectedVideo(videoList)
+
+    expect(result).not.toHaveProperty('uploaded_at')
+  })
+})
+
+describe('createVideoIdSet', () => {
+  it('should create Set from array of video IDs', () => {
+    const ids = [1, 2, 3, 4, 5]
+
+    const result = createVideoIdSet(ids)
+
+    expect(result).toBeInstanceOf(Set)
+    expect(result.size).toBe(5)
+    expect(result.has(1)).toBe(true)
+    expect(result.has(3)).toBe(true)
+    expect(result.has(5)).toBe(true)
+  })
+
+  it('should create empty Set from empty array', () => {
+    const ids: number[] = []
+
+    const result = createVideoIdSet(ids)
+
+    expect(result.size).toBe(0)
+  })
+
+  it('should deduplicate IDs', () => {
+    const ids = [1, 2, 2, 3, 3, 3]
+
+    const result = createVideoIdSet(ids)
+
+    expect(result.size).toBe(3)
+  })
+
+  it('should allow checking membership efficiently', () => {
+    const ids = [10, 20, 30]
+    const idSet = createVideoIdSet(ids)
+
+    expect(idSet.has(10)).toBe(true)
+    expect(idSet.has(20)).toBe(true)
+    expect(idSet.has(40)).toBe(false)
+  })
+})
+
+describe('extractVideoIds', () => {
+  it('should extract IDs from VideoInGroup array', () => {
+    const videos: VideoInGroup[] = [
+      { id: 1, title: 'V1', description: '', file: null, status: 'completed', order: 0 },
+      { id: 2, title: 'V2', description: '', file: null, status: 'completed', order: 1 },
+      { id: 3, title: 'V3', description: '', file: null, status: 'completed', order: 2 },
+    ]
+
+    const result = extractVideoIds(videos)
+
+    expect(result).toEqual([1, 2, 3])
+  })
+
+  it('should extract IDs from VideoList array', () => {
+    const videos: VideoList[] = [
+      { id: 10, title: 'V1', description: '', file: null, status: 'completed', uploaded_at: '' },
+      { id: 20, title: 'V2', description: '', file: null, status: 'completed', uploaded_at: '' },
+    ]
+
+    const result = extractVideoIds(videos)
+
+    expect(result).toEqual([10, 20])
+  })
+
+  it('should return empty array for empty input', () => {
+    const videos: VideoInGroup[] = []
+
+    const result = extractVideoIds(videos)
+
+    expect(result).toEqual([])
+  })
+
+  it('should preserve order of IDs', () => {
+    const videos: VideoInGroup[] = [
+      { id: 5, title: 'V5', description: '', file: null, status: 'completed', order: 0 },
+      { id: 1, title: 'V1', description: '', file: null, status: 'completed', order: 1 },
+      { id: 3, title: 'V3', description: '', file: null, status: 'completed', order: 2 },
+    ]
+
+    const result = extractVideoIds(videos)
+
+    expect(result).toEqual([5, 1, 3])
+  })
+})

--- a/frontend/src/lib/utils/__tests__/videoConversion.test.ts
+++ b/frontend/src/lib/utils/__tests__/videoConversion.test.ts
@@ -16,6 +16,7 @@ describe('convertVideoInGroupToSelectedVideo', () => {
       file: 'video.mp4',
       status: 'completed',
       order: 0,
+      uploaded_at: '2024-01-01T00:00:00Z',
     }
 
     const result = convertVideoInGroupToSelectedVideo(videoInGroup)
@@ -37,6 +38,7 @@ describe('convertVideoInGroupToSelectedVideo', () => {
       file: null,
       status: 'pending',
       order: 1,
+      uploaded_at: '2024-01-01T00:00:00Z',
     }
 
     const result = convertVideoInGroupToSelectedVideo(videoInGroup)
@@ -52,6 +54,7 @@ describe('convertVideoInGroupToSelectedVideo', () => {
       file: 'video.mp4',
       status: 'processing',
       order: 2,
+      uploaded_at: '2024-01-01T00:00:00Z',
     }
 
     const result = convertVideoInGroupToSelectedVideo(videoInGroup)
@@ -140,9 +143,9 @@ describe('createVideoIdSet', () => {
 describe('extractVideoIds', () => {
   it('should extract IDs from VideoInGroup array', () => {
     const videos: VideoInGroup[] = [
-      { id: 1, title: 'V1', description: '', file: null, status: 'completed', order: 0 },
-      { id: 2, title: 'V2', description: '', file: null, status: 'completed', order: 1 },
-      { id: 3, title: 'V3', description: '', file: null, status: 'completed', order: 2 },
+      { id: 1, title: 'V1', description: '', file: null, status: 'completed', order: 0, uploaded_at: '2024-01-01T00:00:00Z' },
+      { id: 2, title: 'V2', description: '', file: null, status: 'completed', order: 1, uploaded_at: '2024-01-01T00:00:00Z' },
+      { id: 3, title: 'V3', description: '', file: null, status: 'completed', order: 2, uploaded_at: '2024-01-01T00:00:00Z' },
     ]
 
     const result = extractVideoIds(videos)
@@ -171,9 +174,9 @@ describe('extractVideoIds', () => {
 
   it('should preserve order of IDs', () => {
     const videos: VideoInGroup[] = [
-      { id: 5, title: 'V5', description: '', file: null, status: 'completed', order: 0 },
-      { id: 1, title: 'V1', description: '', file: null, status: 'completed', order: 1 },
-      { id: 3, title: 'V3', description: '', file: null, status: 'completed', order: 2 },
+      { id: 5, title: 'V5', description: '', file: null, status: 'completed', order: 0, uploaded_at: '2024-01-01T00:00:00Z' },
+      { id: 1, title: 'V1', description: '', file: null, status: 'completed', order: 1, uploaded_at: '2024-01-01T00:00:00Z' },
+      { id: 3, title: 'V3', description: '', file: null, status: 'completed', order: 2, uploaded_at: '2024-01-01T00:00:00Z' },
     ]
 
     const result = extractVideoIds(videos)

--- a/frontend/src/pages/__tests__/ForgotPasswordPage.test.tsx
+++ b/frontend/src/pages/__tests__/ForgotPasswordPage.test.tsx
@@ -4,6 +4,7 @@ import { apiClient } from '@/lib/api'
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     requestPasswordReset: vi.fn(),
   },
 }))
@@ -45,7 +46,7 @@ describe('ForgotPasswordPage', () => {
   })
 
   it('should call requestPasswordReset on submit', async () => {
-    ;(apiClient.requestPasswordReset as ReturnType<typeof vi.fn>).mockResolvedValue({})
+    ; (apiClient.requestPasswordReset as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<ForgotPasswordPage />)
 
@@ -61,7 +62,7 @@ describe('ForgotPasswordPage', () => {
   })
 
   it('should show success message after successful submission', async () => {
-    ;(apiClient.requestPasswordReset as ReturnType<typeof vi.fn>).mockResolvedValue({})
+    ; (apiClient.requestPasswordReset as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<ForgotPasswordPage />)
 
@@ -77,7 +78,7 @@ describe('ForgotPasswordPage', () => {
   })
 
   it('should show loading state while submitting', async () => {
-    ;(apiClient.requestPasswordReset as ReturnType<typeof vi.fn>).mockImplementation(
+    ; (apiClient.requestPasswordReset as ReturnType<typeof vi.fn>).mockImplementation(
       () => new Promise((resolve) => setTimeout(resolve, 100))
     )
 

--- a/frontend/src/pages/__tests__/ForgotPasswordPage.test.tsx
+++ b/frontend/src/pages/__tests__/ForgotPasswordPage.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ForgotPasswordPage from '../ForgotPasswordPage'
+import { apiClient } from '@/lib/api'
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    requestPasswordReset: vi.fn(),
+  },
+}))
+
+describe('ForgotPasswordPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render page title', () => {
+    render(<ForgotPasswordPage />)
+
+    expect(screen.getByText('auth.forgotPassword.title')).toBeInTheDocument()
+  })
+
+  it('should render description', () => {
+    render(<ForgotPasswordPage />)
+
+    expect(screen.getByText('auth.forgotPassword.description')).toBeInTheDocument()
+  })
+
+  it('should render email input', () => {
+    render(<ForgotPasswordPage />)
+
+    expect(screen.getByText('auth.fields.email.label')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('auth.fields.email.placeholder')).toBeInTheDocument()
+  })
+
+  it('should render submit button', () => {
+    render(<ForgotPasswordPage />)
+
+    expect(screen.getByText('auth.forgotPassword.submit')).toBeInTheDocument()
+  })
+
+  it('should render back to login link', () => {
+    render(<ForgotPasswordPage />)
+
+    expect(screen.getByText('auth.forgotPassword.backToLogin')).toBeInTheDocument()
+  })
+
+  it('should call requestPasswordReset on submit', async () => {
+    ;(apiClient.requestPasswordReset as ReturnType<typeof vi.fn>).mockResolvedValue({})
+
+    render(<ForgotPasswordPage />)
+
+    const emailInput = screen.getByPlaceholderText('auth.fields.email.placeholder')
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+
+    const submitButton = screen.getByText('auth.forgotPassword.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(apiClient.requestPasswordReset).toHaveBeenCalledWith({ email: 'test@example.com' })
+    })
+  })
+
+  it('should show success message after successful submission', async () => {
+    ;(apiClient.requestPasswordReset as ReturnType<typeof vi.fn>).mockResolvedValue({})
+
+    render(<ForgotPasswordPage />)
+
+    const emailInput = screen.getByPlaceholderText('auth.fields.email.placeholder')
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+
+    const submitButton = screen.getByText('auth.forgotPassword.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('auth.forgotPassword.success')).toBeInTheDocument()
+    })
+  })
+
+  it('should show loading state while submitting', async () => {
+    ;(apiClient.requestPasswordReset as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise((resolve) => setTimeout(resolve, 100))
+    )
+
+    render(<ForgotPasswordPage />)
+
+    const emailInput = screen.getByPlaceholderText('auth.fields.email.placeholder')
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+
+    const submitButton = screen.getByText('auth.forgotPassword.submit')
+    fireEvent.click(submitButton)
+
+    expect(screen.getByText('auth.forgotPassword.submitting')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -3,6 +3,8 @@ import HomePage from '../HomePage'
 import { apiClient } from '@/lib/api'
 import { useI18nNavigate } from '@/lib/i18n'
 
+let mockNavigate: ReturnType<typeof vi.fn>
+
 const mockVideos = [
   { id: 1, title: 'Video 1', status: 'completed' },
   { id: 2, title: 'Video 2', status: 'pending' },
@@ -32,6 +34,7 @@ vi.mock('@/hooks/useAuth', () => ({
 describe('HomePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockNavigate = useI18nNavigate() as ReturnType<typeof vi.fn>
     ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue(mockVideos)
     ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
   })
@@ -48,7 +51,7 @@ describe('HomePage', () => {
     render(<HomePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('home.welcome.subtitle')).toBeInTheDocument()
+      expect(screen.getByText(/home\.welcome\.subtitle.*testuser/)).toBeInTheDocument()
     })
   })
 
@@ -89,15 +92,13 @@ describe('HomePage', () => {
   })
 
   it('should navigate to videos page with upload param when upload card is clicked', async () => {
-    const mockNavigate = useI18nNavigate()
-
     render(<HomePage />)
 
     await waitFor(() => {
       expect(screen.getByText('home.actions.upload.title')).toBeInTheDocument()
     })
 
-    const uploadCard = screen.getByText('home.actions.upload.title').closest('[class*="Card"]')
+    const uploadCard = screen.getByText('home.actions.upload.title').closest('[data-slot="card"]')
     if (uploadCard) {
       fireEvent.click(uploadCard)
     }
@@ -108,15 +109,13 @@ describe('HomePage', () => {
   })
 
   it('should navigate to videos page when library card is clicked', async () => {
-    const mockNavigate = useI18nNavigate()
-
     render(<HomePage />)
 
     await waitFor(() => {
       expect(screen.getByText('home.actions.library.title')).toBeInTheDocument()
     })
 
-    const libraryCard = screen.getByText('home.actions.library.title').closest('[class*="Card"]')
+    const libraryCard = screen.getByText('home.actions.library.title').closest('[data-slot="card"]')
     if (libraryCard) {
       fireEvent.click(libraryCard)
     }
@@ -127,15 +126,13 @@ describe('HomePage', () => {
   })
 
   it('should navigate to groups page when groups card is clicked', async () => {
-    const mockNavigate = useI18nNavigate()
-
     render(<HomePage />)
 
     await waitFor(() => {
       expect(screen.getByText('home.actions.groups.title')).toBeInTheDocument()
     })
 
-    const groupsCard = screen.getByText('home.actions.groups.title').closest('[class*="Card"]')
+    const groupsCard = screen.getByText('home.actions.groups.title').closest('[data-slot="card"]')
     if (groupsCard) {
       fireEvent.click(groupsCard)
     }

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -19,6 +19,7 @@ const mockGroups = [
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     getVideos: vi.fn(),
     getVideoGroups: vi.fn(),
   },

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import HomePage from '../HomePage'
+import { apiClient } from '@/lib/api'
+import { useI18nNavigate } from '@/lib/i18n'
+
+const mockVideos = [
+  { id: 1, title: 'Video 1', status: 'completed' },
+  { id: 2, title: 'Video 2', status: 'pending' },
+  { id: 3, title: 'Video 3', status: 'processing' },
+  { id: 4, title: 'Video 4', status: 'error' },
+]
+
+const mockGroups = [
+  { id: 1, name: 'Group 1', video_count: 2 },
+  { id: 2, name: 'Group 2', video_count: 3 },
+]
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    getVideos: vi.fn(),
+    getVideoGroups: vi.fn(),
+  },
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 1, username: 'testuser' },
+    loading: false,
+  }),
+}))
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue(mockVideos)
+    ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
+  })
+
+  it('should render welcome title', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('home.welcome.title')).toBeInTheDocument()
+    })
+  })
+
+  it('should render welcome subtitle with username', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('home.welcome.subtitle')).toBeInTheDocument()
+    })
+  })
+
+  it('should render upload action card', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('home.actions.upload.title')).toBeInTheDocument()
+      expect(screen.getByText('home.actions.upload.description')).toBeInTheDocument()
+    })
+  })
+
+  it('should render library action card', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('home.actions.library.title')).toBeInTheDocument()
+    })
+  })
+
+  it('should render groups action card', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('home.actions.groups.title')).toBeInTheDocument()
+    })
+  })
+
+  it('should render stats cards', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('home.stats.completed')).toBeInTheDocument()
+      expect(screen.getByText('home.stats.pending')).toBeInTheDocument()
+      expect(screen.getByText('home.stats.processing')).toBeInTheDocument()
+      expect(screen.getByText('home.stats.error')).toBeInTheDocument()
+    })
+  })
+
+  it('should navigate to videos page with upload param when upload card is clicked', async () => {
+    const mockNavigate = useI18nNavigate()
+
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('home.actions.upload.title')).toBeInTheDocument()
+    })
+
+    const uploadCard = screen.getByText('home.actions.upload.title').closest('[class*="Card"]')
+    if (uploadCard) {
+      fireEvent.click(uploadCard)
+    }
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/videos?upload=true')
+    })
+  })
+
+  it('should navigate to videos page when library card is clicked', async () => {
+    const mockNavigate = useI18nNavigate()
+
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('home.actions.library.title')).toBeInTheDocument()
+    })
+
+    const libraryCard = screen.getByText('home.actions.library.title').closest('[class*="Card"]')
+    if (libraryCard) {
+      fireEvent.click(libraryCard)
+    }
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/videos')
+    })
+  })
+
+  it('should navigate to groups page when groups card is clicked', async () => {
+    const mockNavigate = useI18nNavigate()
+
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('home.actions.groups.title')).toBeInTheDocument()
+    })
+
+    const groupsCard = screen.getByText('home.actions.groups.title').closest('[class*="Card"]')
+    if (groupsCard) {
+      fireEvent.click(groupsCard)
+    }
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/videos/groups')
+    })
+  })
+
+  it('should load videos and groups on mount', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(apiClient.getVideos).toHaveBeenCalled()
+      expect(apiClient.getVideoGroups).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('HomePage - Data Loading', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue(mockVideos)
+    ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
+  })
+
+  it('should handle API errors gracefully', async () => {
+    ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'))
+    ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'))
+
+    render(<HomePage />)
+
+    // Should still render the page
+    await waitFor(() => {
+      expect(screen.getByText('home.welcome.title')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -28,8 +28,8 @@ describe('LoginPage', () => {
   it('should render username and password fields', () => {
     render(<LoginPage />)
 
-    // Fields are rendered through AuthForm component
-    expect(screen.getByText('auth.login.description')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('auth.fields.username.placeholder')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('auth.fields.password.placeholder')).toBeInTheDocument()
   })
 
   it('should render forgot password link', () => {
@@ -86,8 +86,8 @@ describe('LoginPage', () => {
   it('should have centered layout', () => {
     render(<LoginPage />)
 
-    // Check that PageLayout with centered prop is used
-    const container = screen.getByText('auth.login.title').closest('div')
+    const container = screen.getByText('auth.login.title').closest('main')
     expect(container).toBeInTheDocument()
+    expect(container).toHaveClass('flex', 'flex-1', 'items-center', 'justify-center', 'px-4')
   })
 })

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -3,29 +3,18 @@ import LoginPage from '../LoginPage'
 import { apiClient } from '@/lib/api'
 import { useI18nNavigate } from '@/lib/i18n'
 
+let mockNavigate: ReturnType<typeof vi.fn>
+
 vi.mock('@/lib/api', () => ({
   apiClient: {
     login: vi.fn(),
   },
 }))
 
-vi.mock('@/hooks/useAuthForm', () => ({
-  useAuthForm: ({ onSubmit, onSuccessRedirect }: { onSubmit: (data: unknown) => Promise<void>, onSuccessRedirect: () => void }) => ({
-    formData: { username: '', password: '' },
-    error: null,
-    loading: false,
-    handleChange: vi.fn(),
-    handleSubmit: async (e: Event) => {
-      e.preventDefault()
-      await onSubmit({ username: 'test', password: 'test123' })
-      onSuccessRedirect()
-    },
-  }),
-}))
-
 describe('LoginPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockNavigate = useI18nNavigate() as ReturnType<typeof vi.fn>
   })
 
   it('should render login form', () => {
@@ -56,24 +45,34 @@ describe('LoginPage', () => {
   })
 
   it('should call apiClient.login on submit', async () => {
-    const mockLogin = vi.fn().mockResolvedValue({})
-    ;(apiClient.login as ReturnType<typeof vi.fn>).mockImplementation(mockLogin)
+    ;(apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<LoginPage />)
+
+    const usernameInput = screen.getByPlaceholderText('auth.fields.username.placeholder')
+    fireEvent.change(usernameInput, { target: { value: 'test' } })
+
+    const passwordInput = screen.getByPlaceholderText('auth.fields.password.placeholder')
+    fireEvent.change(passwordInput, { target: { value: 'test123' } })
 
     const submitButton = screen.getByText('auth.login.submit')
     fireEvent.click(submitButton)
 
     await waitFor(() => {
-      expect(mockLogin).toHaveBeenCalled()
+      expect(apiClient.login).toHaveBeenCalledWith({ username: 'test', password: 'test123' })
     })
   })
 
   it('should navigate to home on successful login', async () => {
-    const mockNavigate = useI18nNavigate()
     ;(apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<LoginPage />)
+
+    const usernameInput = screen.getByPlaceholderText('auth.fields.username.placeholder')
+    fireEvent.change(usernameInput, { target: { value: 'test' } })
+
+    const passwordInput = screen.getByPlaceholderText('auth.fields.password.placeholder')
+    fireEvent.change(passwordInput, { target: { value: 'test123' } })
 
     const submitButton = screen.getByText('auth.login.submit')
     fireEvent.click(submitButton)

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -7,6 +7,7 @@ let mockNavigate: ReturnType<typeof vi.fn>
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     login: vi.fn(),
   },
 }))
@@ -45,7 +46,7 @@ describe('LoginPage', () => {
   })
 
   it('should call apiClient.login on submit', async () => {
-    ;(apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
+    ; (apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<LoginPage />)
 
@@ -64,7 +65,7 @@ describe('LoginPage', () => {
   })
 
   it('should navigate to home on successful login', async () => {
-    ;(apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
+    ; (apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<LoginPage />)
 

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import LoginPage from '../LoginPage'
+import { apiClient } from '@/lib/api'
+import { useI18nNavigate } from '@/lib/i18n'
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    login: vi.fn(),
+  },
+}))
+
+vi.mock('@/hooks/useAuthForm', () => ({
+  useAuthForm: ({ onSubmit, onSuccessRedirect }: { onSubmit: (data: unknown) => Promise<void>, onSuccessRedirect: () => void }) => ({
+    formData: { username: '', password: '' },
+    error: null,
+    loading: false,
+    handleChange: vi.fn(),
+    handleSubmit: async (e: Event) => {
+      e.preventDefault()
+      await onSubmit({ username: 'test', password: 'test123' })
+      onSuccessRedirect()
+    },
+  }),
+}))
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render login form', () => {
+    render(<LoginPage />)
+
+    expect(screen.getByText('auth.login.title')).toBeInTheDocument()
+    expect(screen.getByText('auth.login.submit')).toBeInTheDocument()
+  })
+
+  it('should render username and password fields', () => {
+    render(<LoginPage />)
+
+    // Fields are rendered through AuthForm component
+    expect(screen.getByText('auth.login.description')).toBeInTheDocument()
+  })
+
+  it('should render forgot password link', () => {
+    render(<LoginPage />)
+
+    const forgotLink = screen.getByText('auth.login.forgotPassword')
+    expect(forgotLink).toBeInTheDocument()
+  })
+
+  it('should render signup link', () => {
+    render(<LoginPage />)
+
+    expect(screen.getByText('auth.login.footerLink')).toBeInTheDocument()
+  })
+
+  it('should call apiClient.login on submit', async () => {
+    const mockLogin = vi.fn().mockResolvedValue({})
+    ;(apiClient.login as ReturnType<typeof vi.fn>).mockImplementation(mockLogin)
+
+    render(<LoginPage />)
+
+    const submitButton = screen.getByText('auth.login.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalled()
+    })
+  })
+
+  it('should navigate to home on successful login', async () => {
+    const mockNavigate = useI18nNavigate()
+    ;(apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
+
+    render(<LoginPage />)
+
+    const submitButton = screen.getByText('auth.login.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/')
+    })
+  })
+
+  it('should have centered layout', () => {
+    render(<LoginPage />)
+
+    // Check that PageLayout with centered prop is used
+    const container = screen.getByText('auth.login.title').closest('div')
+    expect(container).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/ResetPasswordPage.test.tsx
+++ b/frontend/src/pages/__tests__/ResetPasswordPage.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ResetPasswordPage from '../ResetPasswordPage'
+import { apiClient } from '@/lib/api'
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    confirmPasswordReset: vi.fn(),
+  },
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useSearchParams: () => [new URLSearchParams('uid=test-uid&token=test-token')],
+  }
+})
+
+describe('ResetPasswordPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render page title', () => {
+    render(<ResetPasswordPage />)
+
+    expect(screen.getByText('auth.resetPassword.title')).toBeInTheDocument()
+  })
+
+  it('should render description', () => {
+    render(<ResetPasswordPage />)
+
+    expect(screen.getByText('auth.resetPassword.description')).toBeInTheDocument()
+  })
+
+  it('should render password input', () => {
+    render(<ResetPasswordPage />)
+
+    expect(screen.getByText('auth.resetPassword.newPassword')).toBeInTheDocument()
+  })
+
+  it('should render confirm password input', () => {
+    render(<ResetPasswordPage />)
+
+    expect(screen.getByText('auth.resetPassword.confirmPassword')).toBeInTheDocument()
+  })
+
+  it('should render submit button', () => {
+    render(<ResetPasswordPage />)
+
+    expect(screen.getByText('auth.resetPassword.submit')).toBeInTheDocument()
+  })
+
+  it('should render back to login link', () => {
+    render(<ResetPasswordPage />)
+
+    expect(screen.getByText('auth.resetPassword.backToLogin')).toBeInTheDocument()
+  })
+
+  it('should call confirmPasswordReset on submit', async () => {
+    ;(apiClient.confirmPasswordReset as ReturnType<typeof vi.fn>).mockResolvedValue({})
+
+    render(<ResetPasswordPage />)
+
+    const passwordInput = screen.getByPlaceholderText('auth.resetPassword.newPasswordPlaceholder')
+    const confirmInput = screen.getByPlaceholderText('auth.resetPassword.confirmPasswordPlaceholder')
+
+    fireEvent.change(passwordInput, { target: { value: 'newpassword123' } })
+    fireEvent.change(confirmInput, { target: { value: 'newpassword123' } })
+
+    const submitButton = screen.getByText('auth.resetPassword.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(apiClient.confirmPasswordReset).toHaveBeenCalledWith({
+        uid: 'test-uid',
+        token: 'test-token',
+        new_password: 'newpassword123',
+      })
+    })
+  })
+
+  it('should show success message after successful reset', async () => {
+    ;(apiClient.confirmPasswordReset as ReturnType<typeof vi.fn>).mockResolvedValue({})
+
+    render(<ResetPasswordPage />)
+
+    const passwordInput = screen.getByPlaceholderText('auth.resetPassword.newPasswordPlaceholder')
+    const confirmInput = screen.getByPlaceholderText('auth.resetPassword.confirmPasswordPlaceholder')
+
+    fireEvent.change(passwordInput, { target: { value: 'newpassword123' } })
+    fireEvent.change(confirmInput, { target: { value: 'newpassword123' } })
+
+    const submitButton = screen.getByText('auth.resetPassword.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('auth.resetPassword.success')).toBeInTheDocument()
+    })
+  })
+
+  it('should show error when passwords do not match', async () => {
+    render(<ResetPasswordPage />)
+
+    const passwordInput = screen.getByPlaceholderText('auth.resetPassword.newPasswordPlaceholder')
+    const confirmInput = screen.getByPlaceholderText('auth.resetPassword.confirmPasswordPlaceholder')
+
+    fireEvent.change(passwordInput, { target: { value: 'password123' } })
+    fireEvent.change(confirmInput, { target: { value: 'different456' } })
+
+    const submitButton = screen.getByText('auth.resetPassword.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('auth.resetPassword.passwordMismatch')).toBeInTheDocument()
+    })
+
+    expect(apiClient.confirmPasswordReset).not.toHaveBeenCalled()
+  })
+})
+
+describe('ResetPasswordPage - Validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should not call API when passwords do not match', async () => {
+    render(<ResetPasswordPage />)
+
+    const passwordInput = screen.getByPlaceholderText('auth.resetPassword.newPasswordPlaceholder')
+    const confirmInput = screen.getByPlaceholderText('auth.resetPassword.confirmPasswordPlaceholder')
+
+    fireEvent.change(passwordInput, { target: { value: 'password1' } })
+    fireEvent.change(confirmInput, { target: { value: 'password2' } })
+
+    const submitButton = screen.getByText('auth.resetPassword.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(apiClient.confirmPasswordReset).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/ResetPasswordPage.test.tsx
+++ b/frontend/src/pages/__tests__/ResetPasswordPage.test.tsx
@@ -4,6 +4,7 @@ import { apiClient } from '@/lib/api'
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     confirmPasswordReset: vi.fn(),
   },
 }))

--- a/frontend/src/pages/__tests__/SharePage.test.tsx
+++ b/frontend/src/pages/__tests__/SharePage.test.tsx
@@ -22,6 +22,7 @@ vi.mock('react-router-dom', async () => {
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     getSharedGroup: vi.fn(),
     getSharedVideoUrl: vi.fn((url, token) => `${url}?token=${token}`),
   },
@@ -34,7 +35,7 @@ vi.mock('@/components/chat/ChatPanel', () => ({
 describe('SharePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
+      ; (apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
   })
 
   it('should render group name', async () => {
@@ -57,8 +58,8 @@ describe('SharePage', () => {
     render(<SharePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Shared Video 1')).toBeInTheDocument()
-      expect(screen.getByText('Shared Video 2')).toBeInTheDocument()
+      expect(screen.getAllByText('Shared Video 1').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Shared Video 2').length).toBeGreaterThan(0)
     })
   })
 
@@ -95,7 +96,7 @@ describe('SharePage - Error Handling', () => {
   })
 
   it('should display error message when share link is invalid', async () => {
-    ;(apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Not found'))
+    ; (apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Not found'))
 
     render(<SharePage />)
 
@@ -109,7 +110,7 @@ describe('SharePage - Empty Group', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     const emptyGroup = { ...mockGroup, videos: [] }
-    ;(apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockResolvedValue(emptyGroup)
+      ; (apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockResolvedValue(emptyGroup)
   })
 
   it('should display no videos message when group is empty', async () => {

--- a/frontend/src/pages/__tests__/SharePage.test.tsx
+++ b/frontend/src/pages/__tests__/SharePage.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import SharePage from '../SharePage'
+import { apiClient } from '@/lib/api'
+
+const mockGroup = {
+  id: 1,
+  name: 'Shared Group',
+  description: 'Shared Description',
+  videos: [
+    { id: 1, title: 'Shared Video 1', description: 'Desc 1', status: 'completed', file: 'video1.mp4', order: 0 },
+    { id: 2, title: 'Shared Video 2', description: '', status: 'completed', file: 'video2.mp4', order: 1 },
+  ],
+}
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ token: 'test-share-token' }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    getSharedGroup: vi.fn(),
+    getSharedVideoUrl: vi.fn((url, token) => `${url}?token=${token}`),
+  },
+}))
+
+vi.mock('@/components/chat/ChatPanel', () => ({
+  ChatPanel: () => <div data-testid="chat-panel">Chat Panel</div>,
+}))
+
+describe('SharePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
+  })
+
+  it('should render group name', async () => {
+    render(<SharePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Group')).toBeInTheDocument()
+    })
+  })
+
+  it('should render group description', async () => {
+    render(<SharePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Description')).toBeInTheDocument()
+    })
+  })
+
+  it('should render video list', async () => {
+    render(<SharePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Video 1')).toBeInTheDocument()
+      expect(screen.getByText('Shared Video 2')).toBeInTheDocument()
+    })
+  })
+
+  it('should render chat panel', async () => {
+    render(<SharePage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-panel')).toBeInTheDocument()
+    })
+  })
+
+  it('should select first video by default', async () => {
+    render(<SharePage />)
+
+    await waitFor(() => {
+      // First video title should appear in player header
+      const titles = screen.getAllByText('Shared Video 1')
+      expect(titles.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('should load shared group on mount', async () => {
+    render(<SharePage />)
+
+    await waitFor(() => {
+      expect(apiClient.getSharedGroup).toHaveBeenCalledWith('test-share-token')
+    })
+  })
+})
+
+describe('SharePage - Error Handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should display error message when share link is invalid', async () => {
+    ;(apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Not found'))
+
+    render(<SharePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('common.messages.shareLoadFailed')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('SharePage - Empty Group', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const emptyGroup = { ...mockGroup, videos: [] }
+    ;(apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockResolvedValue(emptyGroup)
+  })
+
+  it('should display no videos message when group is empty', async () => {
+    render(<SharePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.shared.noVideos')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/SignupCheckEmailPage.test.tsx
+++ b/frontend/src/pages/__tests__/SignupCheckEmailPage.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import SignupCheckEmailPage from '../SignupCheckEmailPage'
+
+describe('SignupCheckEmailPage', () => {
+  it('should render page title', () => {
+    render(<SignupCheckEmailPage />)
+
+    expect(screen.getByText('auth.checkEmail.title')).toBeInTheDocument()
+  })
+
+  it('should render description', () => {
+    render(<SignupCheckEmailPage />)
+
+    expect(screen.getByText('auth.checkEmail.description')).toBeInTheDocument()
+  })
+
+  it('should render success alert', () => {
+    render(<SignupCheckEmailPage />)
+
+    expect(screen.getByText('auth.checkEmail.alert')).toBeInTheDocument()
+  })
+
+  it('should render help text', () => {
+    render(<SignupCheckEmailPage />)
+
+    expect(screen.getByText('auth.checkEmail.help')).toBeInTheDocument()
+  })
+
+  it('should render back to login link', () => {
+    render(<SignupCheckEmailPage />)
+
+    expect(screen.getByText('auth.checkEmail.backToLogin')).toBeInTheDocument()
+  })
+
+  it('should have centered layout', () => {
+    render(<SignupCheckEmailPage />)
+
+    const container = screen.getByText('auth.checkEmail.title').closest('div')
+    expect(container).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/SignupPage.test.tsx
+++ b/frontend/src/pages/__tests__/SignupPage.test.tsx
@@ -42,6 +42,10 @@ describe('SignupPage', () => {
     render(<SignupPage />)
 
     expect(screen.getByText('auth.signup.description')).toBeInTheDocument()
+    expect(screen.getByLabelText('auth.email.label')).toBeInTheDocument()
+    expect(screen.getByLabelText('auth.username.label')).toBeInTheDocument()
+    expect(screen.getByLabelText('auth.password.label')).toBeInTheDocument()
+    expect(screen.getByLabelText('auth.confirmPassword.label')).toBeInTheDocument()
   })
 
   it('should render login link', () => {
@@ -80,8 +84,9 @@ describe('SignupPage', () => {
   it('should have centered layout', () => {
     render(<SignupPage />)
 
-    const container = screen.getByText('auth.signup.title').closest('div')
+    const container = screen.getByText('auth.signup.title').closest('main')
     expect(container).toBeInTheDocument()
+    expect(container).toHaveClass('flex', 'flex-1', 'items-center', 'justify-center', 'px-4')
   })
 
   it('should display footer question text', () => {

--- a/frontend/src/pages/__tests__/SignupPage.test.tsx
+++ b/frontend/src/pages/__tests__/SignupPage.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import SignupPage from '../SignupPage'
+import { apiClient } from '@/lib/api'
+import { useI18nNavigate } from '@/lib/i18n'
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    signup: vi.fn(),
+  },
+}))
+
+vi.mock('@/hooks/useAuthForm', () => ({
+  useAuthForm: ({ onSubmit, onSuccessRedirect }: { onSubmit: (data: unknown) => Promise<void>, onSuccessRedirect: () => void }) => ({
+    formData: { username: '', email: '', password: '', confirmPassword: '' },
+    error: null,
+    loading: false,
+    handleChange: vi.fn(),
+    handleSubmit: async (e: Event) => {
+      e.preventDefault()
+      await onSubmit({ username: 'test', email: 'test@example.com', password: 'test123', confirmPassword: 'test123' })
+      onSuccessRedirect()
+    },
+  }),
+}))
+
+describe('SignupPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render signup form', () => {
+    render(<SignupPage />)
+
+    expect(screen.getByText('auth.signup.title')).toBeInTheDocument()
+    expect(screen.getByText('auth.signup.submit')).toBeInTheDocument()
+  })
+
+  it('should render all required fields', () => {
+    render(<SignupPage />)
+
+    expect(screen.getByText('auth.signup.description')).toBeInTheDocument()
+  })
+
+  it('should render login link', () => {
+    render(<SignupPage />)
+
+    expect(screen.getByText('auth.signup.footerLink')).toBeInTheDocument()
+  })
+
+  it('should call apiClient.signup on submit', async () => {
+    const mockSignup = vi.fn().mockResolvedValue({})
+    ;(apiClient.signup as ReturnType<typeof vi.fn>).mockImplementation(mockSignup)
+
+    render(<SignupPage />)
+
+    const submitButton = screen.getByText('auth.signup.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockSignup).toHaveBeenCalled()
+    })
+  })
+
+  it('should navigate to check email page on successful signup', async () => {
+    const mockNavigate = useI18nNavigate()
+    ;(apiClient.signup as ReturnType<typeof vi.fn>).mockResolvedValue({})
+
+    render(<SignupPage />)
+
+    const submitButton = screen.getByText('auth.signup.submit')
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/signup/check-email')
+    })
+  })
+
+  it('should have centered layout', () => {
+    render(<SignupPage />)
+
+    const container = screen.getByText('auth.signup.title').closest('div')
+    expect(container).toBeInTheDocument()
+  })
+
+  it('should display footer question text', () => {
+    render(<SignupPage />)
+
+    expect(screen.getByText('auth.signup.footerQuestion')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/SignupPage.test.tsx
+++ b/frontend/src/pages/__tests__/SignupPage.test.tsx
@@ -7,22 +7,9 @@ let mockNavigate: ReturnType<typeof vi.fn>
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     signup: vi.fn(),
   },
-}))
-
-vi.mock('@/hooks/useAuthForm', () => ({
-  useAuthForm: ({ onSubmit, onSuccessRedirect }: { onSubmit: (data: unknown) => Promise<void>, onSuccessRedirect: () => void }) => ({
-    formData: { username: '', email: '', password: '', confirmPassword: '' },
-    error: null,
-    loading: false,
-    handleChange: vi.fn(),
-    handleSubmit: async (e: Event) => {
-      e.preventDefault()
-      await onSubmit({ username: 'test', email: 'test@example.com', password: 'test123', confirmPassword: 'test123' })
-      onSuccessRedirect()
-    },
-  }),
 }))
 
 describe('SignupPage', () => {
@@ -42,10 +29,10 @@ describe('SignupPage', () => {
     render(<SignupPage />)
 
     expect(screen.getByText('auth.signup.description')).toBeInTheDocument()
-    expect(screen.getByLabelText('auth.email.label')).toBeInTheDocument()
-    expect(screen.getByLabelText('auth.username.label')).toBeInTheDocument()
-    expect(screen.getByLabelText('auth.password.label')).toBeInTheDocument()
-    expect(screen.getByLabelText('auth.confirmPassword.label')).toBeInTheDocument()
+    expect(screen.getByText('auth.fields.email.label')).toBeInTheDocument()
+    expect(screen.getByText('auth.fields.username.label')).toBeInTheDocument()
+    expect(screen.getByText('auth.fields.password.label')).toBeInTheDocument()
+    expect(screen.getByText('auth.fields.passwordConfirmation.label')).toBeInTheDocument()
   })
 
   it('should render login link', () => {
@@ -56,22 +43,46 @@ describe('SignupPage', () => {
 
   it('should call apiClient.signup on submit', async () => {
     const mockSignup = vi.fn().mockResolvedValue({})
-    ;(apiClient.signup as ReturnType<typeof vi.fn>).mockImplementation(mockSignup)
+      ; (apiClient.signup as ReturnType<typeof vi.fn>).mockImplementation(mockSignup)
 
     render(<SignupPage />)
+
+    const emailInput = screen.getByPlaceholderText('auth.fields.email.placeholder')
+    const usernameInput = screen.getByPlaceholderText('auth.fields.username.placeholder')
+    const passwordInput = screen.getByPlaceholderText('auth.fields.password.placeholder')
+    const confirmPasswordInput = screen.getByPlaceholderText('auth.fields.passwordConfirmation.placeholder')
+
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+    fireEvent.change(usernameInput, { target: { value: 'testuser' } })
+    fireEvent.change(passwordInput, { target: { value: 'test1234' } })
+    fireEvent.change(confirmPasswordInput, { target: { value: 'test1234' } })
 
     const submitButton = screen.getByText('auth.signup.submit')
     fireEvent.click(submitButton)
 
     await waitFor(() => {
-      expect(mockSignup).toHaveBeenCalled()
+      expect(mockSignup).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        username: 'testuser',
+        password: 'test1234',
+      })
     })
   })
 
   it('should navigate to check email page on successful signup', async () => {
-    ;(apiClient.signup as ReturnType<typeof vi.fn>).mockResolvedValue({})
+    ; (apiClient.signup as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<SignupPage />)
+
+    const emailInput = screen.getByPlaceholderText('auth.fields.email.placeholder')
+    const usernameInput = screen.getByPlaceholderText('auth.fields.username.placeholder')
+    const passwordInput = screen.getByPlaceholderText('auth.fields.password.placeholder')
+    const confirmPasswordInput = screen.getByPlaceholderText('auth.fields.passwordConfirmation.placeholder')
+
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+    fireEvent.change(usernameInput, { target: { value: 'testuser' } })
+    fireEvent.change(passwordInput, { target: { value: 'test1234' } })
+    fireEvent.change(confirmPasswordInput, { target: { value: 'test1234' } })
 
     const submitButton = screen.getByText('auth.signup.submit')
     fireEvent.click(submitButton)

--- a/frontend/src/pages/__tests__/SignupPage.test.tsx
+++ b/frontend/src/pages/__tests__/SignupPage.test.tsx
@@ -3,6 +3,8 @@ import SignupPage from '../SignupPage'
 import { apiClient } from '@/lib/api'
 import { useI18nNavigate } from '@/lib/i18n'
 
+let mockNavigate: ReturnType<typeof vi.fn>
+
 vi.mock('@/lib/api', () => ({
   apiClient: {
     signup: vi.fn(),
@@ -26,6 +28,7 @@ vi.mock('@/hooks/useAuthForm', () => ({
 describe('SignupPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockNavigate = useI18nNavigate() as ReturnType<typeof vi.fn>
   })
 
   it('should render signup form', () => {
@@ -62,7 +65,6 @@ describe('SignupPage', () => {
   })
 
   it('should navigate to check email page on successful signup', async () => {
-    const mockNavigate = useI18nNavigate()
     ;(apiClient.signup as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<SignupPage />)

--- a/frontend/src/pages/__tests__/VerifyEmailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VerifyEmailPage.test.tsx
@@ -20,11 +20,6 @@ vi.mock('react-router-dom', async () => {
 describe('VerifyEmailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('should render page title', () => {
@@ -81,6 +76,7 @@ describe('VerifyEmailPage', () => {
   })
 
   it('should redirect to login after successful verification', async () => {
+    vi.useFakeTimers()
     const mockNavigate = useI18nNavigate()
     ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockResolvedValue({ detail: 'Verified' })
 
@@ -90,11 +86,12 @@ describe('VerifyEmailPage', () => {
       expect(screen.getByText('Verified')).toBeInTheDocument()
     })
 
-    vi.advanceTimersByTime(2000)
+    await vi.advanceTimersByTimeAsync(2000)
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true })
     })
+    vi.useRealTimers()
   })
 
   it('should show error message on verification failure', async () => {

--- a/frontend/src/pages/__tests__/VerifyEmailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VerifyEmailPage.test.tsx
@@ -3,11 +3,16 @@ import VerifyEmailPage from '../VerifyEmailPage'
 import { apiClient } from '@/lib/api'
 import { useI18nNavigate } from '@/lib/i18n'
 
-vi.mock('@/lib/api', () => ({
-  apiClient: {
-    verifyEmail: vi.fn(),
-  },
-}))
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>();
+  return {
+    ...actual, // Spread the actual module to retain global mocks
+    apiClient: {
+      ...actual.apiClient, // Spread actual apiClient methods
+      verifyEmail: vi.fn(), // Override verifyEmail
+    },
+  };
+});
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')

--- a/frontend/src/pages/__tests__/VerifyEmailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VerifyEmailPage.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import VerifyEmailPage from '../VerifyEmailPage'
+import { apiClient } from '@/lib/api'
+import { useI18nNavigate } from '@/lib/i18n'
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    verifyEmail: vi.fn(),
+  },
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useSearchParams: () => [new URLSearchParams('uid=test-uid&token=test-token')],
+  }
+})
+
+describe('VerifyEmailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should render page title', () => {
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {})
+    )
+
+    render(<VerifyEmailPage />)
+
+    expect(screen.getByText('auth.verifyEmail.title')).toBeInTheDocument()
+  })
+
+  it('should render description', () => {
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {})
+    )
+
+    render(<VerifyEmailPage />)
+
+    expect(screen.getByText('auth.verifyEmail.description')).toBeInTheDocument()
+  })
+
+  it('should show loading state initially', () => {
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {})
+    )
+
+    render(<VerifyEmailPage />)
+
+    expect(screen.getByText('auth.verifyEmail.loading')).toBeInTheDocument()
+  })
+
+  it('should call verifyEmail on mount', async () => {
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockResolvedValue({ detail: 'Verified' })
+
+    render(<VerifyEmailPage />)
+
+    await waitFor(() => {
+      expect(apiClient.verifyEmail).toHaveBeenCalledWith({
+        uid: 'test-uid',
+        token: 'test-token',
+      })
+    })
+  })
+
+  it('should show success message on successful verification', async () => {
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockResolvedValue({ detail: 'Email verified successfully' })
+
+    render(<VerifyEmailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Email verified successfully')).toBeInTheDocument()
+    })
+  })
+
+  it('should redirect to login after successful verification', async () => {
+    const mockNavigate = useI18nNavigate()
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockResolvedValue({ detail: 'Verified' })
+
+    render(<VerifyEmailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Verified')).toBeInTheDocument()
+    })
+
+    vi.advanceTimersByTime(2000)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true })
+    })
+  })
+
+  it('should show error message on verification failure', async () => {
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Invalid token'))
+
+    render(<VerifyEmailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid token')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('VerifyEmailPage - API Calls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should handle API error correctly', async () => {
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Token expired'))
+
+    render(<VerifyEmailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Token expired')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import VideoDetailPage from '../VideoDetailPage'
 import { apiClient } from '@/lib/api'
-import { useI18nNavigate } from '@/lib/i18n'
 
 const mockVideo = {
   id: 1,

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import VideoDetailPage from '../VideoDetailPage'
+import { apiClient } from '@/lib/api'
+import { useI18nNavigate } from '@/lib/i18n'
+
+const mockVideo = {
+  id: 1,
+  title: 'Test Video',
+  description: 'Test Description',
+  status: 'completed',
+  file: 'test.mp4',
+  uploaded_at: '2024-01-01T00:00:00Z',
+  transcript: '1\n00:00:00,000 --> 00:00:05,000\nHello world',
+  tags: [{ id: 1, name: 'Tag1', color: '#FF0000' }],
+  external_id: null,
+  error_message: '',
+}
+
+const mockLoadVideo = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ id: '1' }),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  }
+})
+
+vi.mock('@/hooks/useVideos', () => ({
+  useVideo: () => ({
+    video: mockVideo,
+    isLoading: false,
+    error: null,
+    loadVideo: mockLoadVideo,
+  }),
+}))
+
+vi.mock('@/hooks/useTags', () => ({
+  useTags: () => ({
+    tags: [{ id: 1, name: 'Tag1', color: '#FF0000' }],
+    createTag: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    updateVideo: vi.fn(),
+    deleteVideo: vi.fn(),
+    getVideoUrl: vi.fn((url) => url),
+    addTagsToVideo: vi.fn(),
+    removeTagFromVideo: vi.fn(),
+  },
+}))
+
+describe('VideoDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render video title', () => {
+    render(<VideoDetailPage />)
+
+    expect(screen.getByText('Test Video')).toBeInTheDocument()
+  })
+
+  it('should render video description', () => {
+    render(<VideoDetailPage />)
+
+    expect(screen.getByText('Test Description')).toBeInTheDocument()
+  })
+
+  it('should render video status', () => {
+    render(<VideoDetailPage />)
+
+    expect(screen.getByText('videos.detail.labels.status')).toBeInTheDocument()
+  })
+
+  it('should render edit button', () => {
+    render(<VideoDetailPage />)
+
+    expect(screen.getByText('videos.detail.edit')).toBeInTheDocument()
+  })
+
+  it('should render delete button', () => {
+    render(<VideoDetailPage />)
+
+    expect(screen.getByText('common.actions.delete')).toBeInTheDocument()
+  })
+
+  it('should render back to list button', () => {
+    render(<VideoDetailPage />)
+
+    expect(screen.getByText('common.actions.backToList')).toBeInTheDocument()
+  })
+
+  it('should render transcript when available', () => {
+    render(<VideoDetailPage />)
+
+    expect(screen.getByText('videos.detail.transcript')).toBeInTheDocument()
+    expect(screen.getByText(/Hello world/)).toBeInTheDocument()
+  })
+
+  it('should enter edit mode when edit button is clicked', () => {
+    render(<VideoDetailPage />)
+
+    const editButton = screen.getByText('videos.detail.edit')
+    fireEvent.click(editButton)
+
+    expect(screen.getByText('videos.detail.save')).toBeInTheDocument()
+    expect(screen.getByText('videos.detail.cancel')).toBeInTheDocument()
+  })
+
+  it('should load video on mount', () => {
+    render(<VideoDetailPage />)
+
+    expect(mockLoadVideo).toHaveBeenCalled()
+  })
+})
+
+describe('VideoDetailPage - Delete', () => {
+  it('should call deleteVideo when delete is confirmed', async () => {
+    window.confirm = vi.fn(() => true)
+    ;(apiClient.deleteVideo as ReturnType<typeof vi.fn>).mockResolvedValue({})
+
+    render(<VideoDetailPage />)
+
+    const deleteButton = screen.getByText('common.actions.delete')
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(apiClient.deleteVideo).toHaveBeenCalledWith(1)
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -44,6 +44,7 @@ vi.mock('@/hooks/useTags', () => ({
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     updateVideo: vi.fn(),
     deleteVideo: vi.fn(),
     getVideoUrl: vi.fn((url) => url),
@@ -60,7 +61,7 @@ describe('VideoDetailPage', () => {
   it('should render video title', () => {
     render(<VideoDetailPage />)
 
-    expect(screen.getByText('Test Video')).toBeInTheDocument()
+    expect(screen.getAllByText('Test Video').length).toBeGreaterThan(0)
   })
 
   it('should render video description', () => {
@@ -120,7 +121,7 @@ describe('VideoDetailPage', () => {
 describe('VideoDetailPage - Delete', () => {
   it('should call deleteVideo when delete is confirmed', async () => {
     window.confirm = vi.fn(() => true)
-    ;(apiClient.deleteVideo as ReturnType<typeof vi.fn>).mockResolvedValue({})
+      ; (apiClient.deleteVideo as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<VideoDetailPage />)
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -174,11 +174,17 @@ describe('VideoGroupDetailPage - Share Link', () => {
 })
 
 describe('VideoGroupDetailPage - Delete', () => {
+  const originalConfirm = window.confirm
+
   beforeEach(() => {
     vi.clearAllMocks()
     ;(apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
     ;(apiClient.deleteVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({})
     window.confirm = vi.fn(() => true)
+  })
+
+  afterEach(() => {
+    window.confirm = originalConfirm
   })
 
   it('should call deleteVideoGroup when delete is confirmed', async () => {

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import VideoGroupDetailPage from '../VideoGroupDetailPage'
+import { apiClient } from '@/lib/api'
+
+const mockGroup = {
+  id: 1,
+  name: 'Test Group',
+  description: 'Test Description',
+  share_token: null,
+  videos: [
+    { id: 1, title: 'Video 1', description: 'Desc 1', status: 'completed', file: 'video1.mp4', order: 0 },
+    { id: 2, title: 'Video 2', description: 'Desc 2', status: 'processing', file: 'video2.mp4', order: 1 },
+  ],
+}
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ id: '1' }),
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    getVideoGroup: vi.fn(),
+    getVideos: vi.fn(),
+    updateVideoGroup: vi.fn(),
+    deleteVideoGroup: vi.fn(),
+    addVideosToGroup: vi.fn(),
+    removeVideoFromGroup: vi.fn(),
+    reorderVideosInGroup: vi.fn(),
+    createShareLink: vi.fn(),
+    deleteShareLink: vi.fn(),
+    getVideoUrl: vi.fn((url) => url),
+  },
+}))
+
+vi.mock('@/hooks/useTags', () => ({
+  useTags: () => ({
+    tags: [],
+  }),
+}))
+
+vi.mock('@/components/chat/ChatPanel', () => ({
+  ChatPanel: () => <div data-testid="chat-panel">Chat Panel</div>,
+}))
+
+vi.mock('@/components/video/TagFilterPanel', () => ({
+  TagFilterPanel: () => <div data-testid="tag-filter-panel" />,
+}))
+
+vi.mock('@/components/video/TagManagementModal', () => ({
+  TagManagementModal: () => null,
+}))
+
+describe('VideoGroupDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
+    ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue([])
+  })
+
+  it('should render group name', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Group')).toBeInTheDocument()
+    })
+  })
+
+  it('should render group description', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Description')).toBeInTheDocument()
+    })
+  })
+
+  it('should render edit button', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groupDetail.edit')).toBeInTheDocument()
+    })
+  })
+
+  it('should render add videos button', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groupDetail.addVideos')).toBeInTheDocument()
+    })
+  })
+
+  it('should render back to list button', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('common.actions.backToList')).toBeInTheDocument()
+    })
+  })
+
+  it('should render delete button', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groupDetail.delete')).toBeInTheDocument()
+    })
+  })
+
+  it('should render video list', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Video 1')).toBeInTheDocument()
+      expect(screen.getByText('Video 2')).toBeInTheDocument()
+    })
+  })
+
+  it('should render chat panel', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-panel')).toBeInTheDocument()
+    })
+  })
+
+  it('should enter edit mode when edit button is clicked', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groupDetail.edit')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('videos.groupDetail.edit'))
+
+    expect(screen.getByText('common.actions.save')).toBeInTheDocument()
+    expect(screen.getByText('common.actions.cancel')).toBeInTheDocument()
+  })
+
+  it('should show share section', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groupDetail.share.title')).toBeInTheDocument()
+    })
+  })
+
+  it('should show generate share link button when no share token', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groupDetail.generate')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('VideoGroupDetailPage - Share Link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const groupWithShare = { ...mockGroup, share_token: 'test-token-123' }
+    ;(apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(groupWithShare)
+  })
+
+  it('should show share link when token exists', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groupDetail.copy')).toBeInTheDocument()
+      expect(screen.getByText('videos.groupDetail.disable')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('VideoGroupDetailPage - Delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
+    ;(apiClient.deleteVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({})
+    window.confirm = vi.fn(() => true)
+  })
+
+  it('should call deleteVideoGroup when delete is confirmed', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groupDetail.delete')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('videos.groupDetail.delete'))
+
+    await waitFor(() => {
+      expect(apiClient.deleteVideoGroup).toHaveBeenCalledWith(1)
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -23,6 +23,7 @@ vi.mock('react-router-dom', async () => {
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     getVideoGroup: vi.fn(),
     getVideos: vi.fn(),
     updateVideoGroup: vi.fn(),
@@ -57,8 +58,8 @@ vi.mock('@/components/video/TagManagementModal', () => ({
 describe('VideoGroupDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
-    ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue([])
+      ; (apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
+      ; (apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue([])
   })
 
   it('should render group name', async () => {
@@ -113,8 +114,8 @@ describe('VideoGroupDetailPage', () => {
     render(<VideoGroupDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Video 1')).toBeInTheDocument()
-      expect(screen.getByText('Video 2')).toBeInTheDocument()
+      expect(screen.getAllByText('Video 1').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Video 2').length).toBeGreaterThan(0)
     })
   })
 
@@ -160,7 +161,7 @@ describe('VideoGroupDetailPage - Share Link', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     const groupWithShare = { ...mockGroup, share_token: 'test-token-123' }
-    ;(apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(groupWithShare)
+      ; (apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(groupWithShare)
   })
 
   it('should show share link when token exists', async () => {
@@ -178,8 +179,8 @@ describe('VideoGroupDetailPage - Delete', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
-    ;(apiClient.deleteVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({})
+      ; (apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
+      ; (apiClient.deleteVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({})
     window.confirm = vi.fn(() => true)
   })
 

--- a/frontend/src/pages/__tests__/VideoGroupsPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupsPage.test.tsx
@@ -9,6 +9,7 @@ const mockGroups = [
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     getVideoGroups: vi.fn(),
     createVideoGroup: vi.fn(),
   },
@@ -24,7 +25,7 @@ vi.mock('@/hooks/useAuth', () => ({
 describe('VideoGroupsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
+      ; (apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
   })
 
   it('should render page title', async () => {
@@ -56,12 +57,12 @@ describe('VideoGroupsPage', () => {
     render(<VideoGroupsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText(/videos\.groups\.videoCount/)).toBeInTheDocument()
+      expect(screen.getAllByText(/videos\.groups\.videoCount/).length).toBeGreaterThan(0)
     })
   })
 
   it('should display empty message when no groups', async () => {
-    ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    ; (apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue([])
 
     render(<VideoGroupsPage />)
 
@@ -98,7 +99,7 @@ describe('VideoGroupsPage', () => {
   })
 
   it('should call createVideoGroup on form submit', async () => {
-    ;(apiClient.createVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 3 })
+    ; (apiClient.createVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 3 })
 
     render(<VideoGroupsPage />)
 
@@ -146,12 +147,12 @@ describe('VideoGroupsPage - Error Handling', () => {
   })
 
   it('should display error message on load failure', async () => {
-    ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Load failed'))
+    ; (apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Load failed'))
 
     render(<VideoGroupsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText(/videos.groups.loadError/)).toBeInTheDocument()
+      expect(screen.getByText('Load failed')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/__tests__/VideoGroupsPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupsPage.test.tsx
@@ -56,7 +56,7 @@ describe('VideoGroupsPage', () => {
     render(<VideoGroupsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('videos.groups.videoCount')).toBeInTheDocument()
+      expect(screen.getByText(/videos\.groups\.videoCount/)).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/__tests__/VideoGroupsPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupsPage.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import VideoGroupsPage from '../VideoGroupsPage'
+import { apiClient } from '@/lib/api'
+
+const mockGroups = [
+  { id: 1, name: 'Group 1', description: 'Description 1', video_count: 5 },
+  { id: 2, name: 'Group 2', description: '', video_count: 0 },
+]
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    getVideoGroups: vi.fn(),
+    createVideoGroup: vi.fn(),
+  },
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 1, username: 'testuser' },
+    loading: false,
+  }),
+}))
+
+describe('VideoGroupsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
+  })
+
+  it('should render page title', async () => {
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groups.title')).toBeInTheDocument()
+    })
+  })
+
+  it('should render create button', async () => {
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groups.create')).toBeInTheDocument()
+    })
+  })
+
+  it('should load and display groups', async () => {
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Group 1')).toBeInTheDocument()
+      expect(screen.getByText('Group 2')).toBeInTheDocument()
+    })
+  })
+
+  it('should display video count for each group', async () => {
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groups.videoCount')).toBeInTheDocument()
+    })
+  })
+
+  it('should display empty message when no groups', async () => {
+    ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue([])
+
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groups.empty')).toBeInTheDocument()
+    })
+  })
+
+  it('should open create modal when create button is clicked', async () => {
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groups.create')).toBeInTheDocument()
+    })
+
+    const createButton = screen.getByText('videos.groups.create')
+    fireEvent.click(createButton)
+
+    expect(screen.getByText('videos.groups.createTitle')).toBeInTheDocument()
+    expect(screen.getByText('videos.groups.createDescription')).toBeInTheDocument()
+  })
+
+  it('should show name and description inputs in create modal', async () => {
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groups.create')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('videos.groups.create'))
+
+    expect(screen.getByText('videos.groups.nameLabel')).toBeInTheDocument()
+    expect(screen.getByText('videos.groups.descriptionLabel')).toBeInTheDocument()
+  })
+
+  it('should call createVideoGroup on form submit', async () => {
+    ;(apiClient.createVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 3 })
+
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groups.create')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('videos.groups.create'))
+
+    const nameInput = screen.getByPlaceholderText('videos.groups.namePlaceholder')
+    fireEvent.change(nameInput, { target: { value: 'New Group' } })
+
+    const createSubmitButton = screen.getByText('common.actions.create')
+    fireEvent.click(createSubmitButton)
+
+    await waitFor(() => {
+      expect(apiClient.createVideoGroup).toHaveBeenCalledWith({
+        name: 'New Group',
+        description: '',
+      })
+    })
+  })
+
+  it('should close create modal on cancel', async () => {
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('videos.groups.create')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('videos.groups.create'))
+    expect(screen.getByText('videos.groups.createTitle')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('common.actions.cancel'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('videos.groups.createTitle')).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('VideoGroupsPage - Error Handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should display error message on load failure', async () => {
+    ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Load failed'))
+
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/videos.groups.loadError/)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/VideosPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideosPage.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import VideosPage from '../VideosPage'
+
+const mockVideos = [
+  { id: 1, title: 'Video 1', status: 'completed', file: 'test1.mp4', uploaded_at: '2024-01-01' },
+  { id: 2, title: 'Video 2', status: 'pending', file: 'test2.mp4', uploaded_at: '2024-01-02' },
+  { id: 3, title: 'Video 3', status: 'processing', file: 'test3.mp4', uploaded_at: '2024-01-03' },
+]
+
+const mockLoadVideos = vi.fn()
+
+vi.mock('@/hooks/useVideos', () => ({
+  useVideos: () => ({
+    videos: mockVideos,
+    isLoading: false,
+    error: null,
+    loadVideos: mockLoadVideos,
+  }),
+}))
+
+vi.mock('@/hooks/useVideoStats', () => ({
+  useVideoStats: () => ({
+    total: 3,
+    completed: 1,
+    pending: 1,
+    processing: 1,
+    error: 0,
+  }),
+}))
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 1, username: 'testuser', video_limit: 10, video_count: 3 },
+    loading: false,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/useTags', () => ({
+  useTags: () => ({
+    tags: [],
+  }),
+}))
+
+vi.mock('@/components/video/VideoUploadModal', () => ({
+  VideoUploadModal: ({ isOpen, onClose }: { isOpen: boolean, onClose: () => void }) =>
+    isOpen ? <div data-testid="upload-modal"><button onClick={onClose}>Close</button></div> : null,
+}))
+
+vi.mock('@/components/video/VideoList', () => ({
+  VideoList: ({ videos }: { videos: typeof mockVideos }) => (
+    <div data-testid="video-list">
+      {videos.map(v => <div key={v.id}>{v.title}</div>)}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/video/TagFilterPanel', () => ({
+  TagFilterPanel: () => <div data-testid="tag-filter-panel" />,
+}))
+
+vi.mock('@/components/video/TagManagementModal', () => ({
+  TagManagementModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="tag-modal" /> : null,
+}))
+
+describe('VideosPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLoadVideos.mockClear()
+  })
+
+  it('should render page title', () => {
+    render(<VideosPage />)
+
+    expect(screen.getByText('videos.list.title')).toBeInTheDocument()
+  })
+
+  it('should render video count subtitle', () => {
+    render(<VideosPage />)
+
+    expect(screen.getByText(/videos.list.subtitle/)).toBeInTheDocument()
+  })
+
+  it('should render upload button', () => {
+    render(<VideosPage />)
+
+    expect(screen.getByText('videos.list.uploadButton')).toBeInTheDocument()
+  })
+
+  it('should render stats cards', () => {
+    render(<VideosPage />)
+
+    expect(screen.getByText('videos.list.stats.total')).toBeInTheDocument()
+    expect(screen.getByText('videos.list.stats.completed')).toBeInTheDocument()
+    expect(screen.getByText('videos.list.stats.pending')).toBeInTheDocument()
+    expect(screen.getByText('videos.list.stats.processing')).toBeInTheDocument()
+  })
+
+  it('should render video list', () => {
+    render(<VideosPage />)
+
+    expect(screen.getByTestId('video-list')).toBeInTheDocument()
+    expect(screen.getByText('Video 1')).toBeInTheDocument()
+    expect(screen.getByText('Video 2')).toBeInTheDocument()
+    expect(screen.getByText('Video 3')).toBeInTheDocument()
+  })
+
+  it('should render tag filter panel', () => {
+    render(<VideosPage />)
+
+    expect(screen.getByTestId('tag-filter-panel')).toBeInTheDocument()
+  })
+
+  it('should load videos on mount', () => {
+    render(<VideosPage />)
+
+    expect(mockLoadVideos).toHaveBeenCalled()
+  })
+
+  it('should open upload modal when upload button is clicked', () => {
+    render(<VideosPage />)
+
+    const uploadButton = screen.getByText('videos.list.uploadButton')
+    fireEvent.click(uploadButton)
+
+    expect(screen.getByTestId('upload-modal')).toBeInTheDocument()
+  })
+
+  it('should close upload modal when close is clicked', async () => {
+    render(<VideosPage />)
+
+    const uploadButton = screen.getByText('videos.list.uploadButton')
+    fireEvent.click(uploadButton)
+
+    expect(screen.getByTestId('upload-modal')).toBeInTheDocument()
+
+    const closeButton = screen.getByText('Close')
+    fireEvent.click(closeButton)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('upload-modal')).not.toBeInTheDocument()
+    })
+  })
+
+  it('should display stat values correctly', () => {
+    render(<VideosPage />)
+
+    // Check stat values are displayed
+    const statCards = screen.getAllByText(/^\d+$/)
+    expect(statCards.length).toBeGreaterThan(0)
+  })
+})
+
+describe('VideosPage - Upload Limit', () => {
+  it('should show upload limit in button when limit exists', () => {
+    render(<VideosPage />)
+
+    // The upload button should be rendered
+    const uploadButton = screen.getByText('videos.list.uploadButton')
+    expect(uploadButton).toBeInTheDocument()
+  })
+})

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -69,9 +69,10 @@ vi.mock('@/lib/i18n', () => ({
   useI18nNavigate: () => mockNavigate,
   useI18nLocation: () => mockLocation,
   removeLocalePrefix: (pathname: string) => pathname,
+  addLocalePrefix: (pathname: string) => pathname,
   useLocale: () => 'en',
-  Link: ({ children, to, ...props }: { children?: React.ReactNode; to?: unknown } & Record<string, unknown>) =>
-    React.createElement('a', { href: typeof to === 'string' ? to : '', ...props }, children),
+  Link: ({ children, to, href, ...props }: { children?: React.ReactNode; to?: unknown; href?: string } & Record<string, unknown>) =>
+    React.createElement('a', { href: href || (typeof to === 'string' ? to : ''), ...props }, children),
   i18nConfig: {
     locales: ['en', 'ja'],
     defaultLocale: 'en',

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -78,3 +78,45 @@ vi.mock('@/lib/i18n', () => ({
     defaultLocale: 'en',
   },
 }))
+
+// Helper function for getVideoUrl within the mock
+const mockGetVideoUrl = (videoFilePath: string | null): string => {
+  if (!videoFilePath) return '';
+  if (videoFilePath.startsWith('http://') || videoFilePath.startsWith('https://')) return videoFilePath;
+  // Prevent double /api/ when path already starts with /api/
+  if (videoFilePath.startsWith('/api/')) {
+    return `http://localhost:8000${videoFilePath}`;
+  }
+  return `http://localhost:8000/api/${videoFilePath}`;
+};
+
+// Helper function for getSharedVideoUrl within the mock
+const mockGetSharedVideoUrl = (videoFilePath: string | null, shareToken: string): string => {
+  if (!videoFilePath) return '';
+  const baseUrl = mockGetVideoUrl(videoFilePath); // Use the local helper
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}share_token=${shareToken}`;
+};
+
+// Mock the API client
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
+    signup: vi.fn(() => Promise.resolve()),
+    verifyEmail: vi.fn(() => Promise.resolve()),
+    requestPasswordReset: vi.fn(() => Promise.resolve()),
+    confirmPasswordReset: vi.fn(() => Promise.resolve()),
+    login: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
+    getVideoGroups: vi.fn(() => Promise.resolve([])),
+    getSharedVideoGroup: vi.fn(() => Promise.resolve(null)),
+    createVideoGroup: vi.fn(() => Promise.resolve({ id: '1', name: 'New Group', description: 'Description', videos: [] })),
+    updateVideoGroup: vi.fn(() => Promise.resolve()),
+    deleteVideoGroup: vi.fn(() => Promise.resolve()),
+    getVideos: vi.fn(() => Promise.resolve([])),
+    updateVideo: vi.fn(() => Promise.resolve()),
+    deleteVideo: vi.fn(() => Promise.resolve()),
+    chat: vi.fn(() => Promise.resolve({ response: 'Mock chat response' })),
+    getVideoUrl: vi.fn(mockGetVideoUrl),
+    getSharedVideoUrl: vi.fn(mockGetSharedVideoUrl),
+  },
+}));


### PR DESCRIPTION
## Summary

- Add comprehensive test coverage for backend Celery tasks (transcription, audio processing, SRT, vector indexing, reindexing)
- Add tests for backend models (User, Video, VideoGroup, Tag, Chat, signals)
- Add tests for backend Scene Otsu module (splitter, parsers, embedders, utils)
- Add tests for backend serializers (VideoCreateSerializer, TagCreateSerializer, etc.)
- Add tests for frontend pages (Login, Signup, Videos, VideoDetail, VideoGroups, SharePage, etc.)
- Add tests for frontend utilities (errorHandling, videoConversion)
- Update vitest.setup.ts to include addLocalePrefix mock

## Test plan

- [ ] Run backend tests: `cd backend && python manage.py test`
- [ ] Run frontend tests: `cd frontend && npm run test`
- [ ] Verify no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broadly expanded test coverage across backend and frontend (models, signals, tasks, scene processing, indexing, serializers, pages, utilities) and added test package initializers.
* **Bug Fixes**
  * Improved subtitle/timestamp handling by using rounded milliseconds with proper carry-over for more accurate timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->