### PR TITLE
fix: prevent share_token from appending to external (S3) URLs

### DIFF
--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -615,11 +615,22 @@ describe('ApiClient', () => {
   });
 
   describe('getSharedVideoUrl', () => {
-    it('should add share_token parameter to absolute URL', () => {
-      const videoFile = 'http://example.com/video.mp4';
+    it('should add share_token parameter if URL origin matches API base URL', () => {
+      // Mock baseUrl to match the video URL origin
+      // Default baseUrl is http://localhost:8000/api
+      const videoFile = 'http://localhost:8000/api/media/video.mp4';
       const shareToken = 'abc123';
       const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
-      expect(result).toBe('http://example.com/video.mp4?share_token=abc123');
+      expect(result).toBe('http://localhost:8000/api/media/video.mp4?share_token=abc123');
+    });
+
+    it('should NOT add share_token parameter if URL origin differs (e.g. S3)', () => {
+      // API is http://localhost:8000, Video is S3
+      const videoFile = 'https://my-bucket.s3.amazonaws.com/video.mp4?Sign=123';
+      const shareToken = 'abc123';
+      const result = apiClient.getSharedVideoUrl(videoFile, shareToken);
+      // Result should be exactly the input URL, without additional query params
+      expect(result).toBe(videoFile);
     });
 
     it('should return empty if url is empty', () => {


### PR DESCRIPTION
## Description
When using S3 storage, the backend generates presigned URLs which already contain authentication signatures in query parameters. Appending an additional  parameter on the frontend causes S3 to reject the request with a  error.

## Changes
- Modified  to check if the video URL origin matches the API base URL origin.
- Only append  if the origins match (local/protected media).
- Leave the URL as-is if it points to an external origin (S3).

## Verification
- Added automated tests in  to verify both local and external URL cases.
- All tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shared video URL generation to properly handle videos from external sources.
  * Added error handling for URL parsing to gracefully fall back when URLs cannot be processed.

* **Tests**
  * Enhanced test coverage for shared video URL functionality across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->