### PR TITLE
docs: standardize license headers to MIT License

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -118,7 +118,7 @@
   },
   "layout": {
     "footer": {
-      "copyright": "© {{year}} VideoQ. All rights reserved."
+      "copyright": "© {{year}} VideoQ. Released under the MIT License."
     }
   },
   "home": {

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -124,7 +124,7 @@
   },
   "layout": {
     "footer": {
-      "copyright": "© {{year}} VideoQ. All rights reserved."
+      "copyright": "© {{year}} VideoQ. Released under the MIT License."
     }
   },
   "home": {


### PR DESCRIPTION
Update copyright notice from 'All rights reserved' to 'Released under the MIT License' to align with MIT License principles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated footer copyright notice to reflect MIT License release in English and Japanese versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->