### PR TITLE
feat: add review shorts feature for frequently referenced scenes

### DIFF
--- a/backend/app/chat/urls.py
+++ b/backend/app/chat/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from .views import (ChatFeedbackView, ChatHistoryExportView, ChatHistoryView,
-                    ChatView)
+                    ChatView, PopularScenesView)
 
 urlpatterns = [
     path("", ChatView.as_view(), name="chat"),
@@ -10,4 +10,5 @@ urlpatterns = [
         "history/export/", ChatHistoryExportView.as_view(), name="chat-history-export"
     ),
     path("feedback/", ChatFeedbackView.as_view(), name="chat-feedback"),
+    path("popular-scenes/", PopularScenesView.as_view(), name="popular-scenes"),
 ]

--- a/frontend/src/components/shorts/ShortsButton.tsx
+++ b/frontend/src/components/shorts/ShortsButton.tsx
@@ -1,0 +1,64 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Play } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { apiClient, type PopularScene, type VideoInGroup } from '@/lib/api';
+import { ShortsPlayer } from './ShortsPlayer';
+
+interface ShortsButtonProps {
+  groupId: number;
+  videos: VideoInGroup[];
+  shareToken?: string;
+  size?: 'sm' | 'default';
+}
+
+export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: ShortsButtonProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [scenes, setScenes] = useState<PopularScene[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleOpen = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const popularScenes = await apiClient.getPopularScenes(groupId, shareToken);
+      setScenes(popularScenes);
+      setIsOpen(true);
+    } catch (error) {
+      console.error('Failed to load popular scenes:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [groupId, shareToken]);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  if (!videos || videos.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size={size}
+        onClick={handleOpen}
+        disabled={isLoading}
+        className="gap-2"
+      >
+        <Play className="h-4 w-4" />
+        {isLoading ? t('common.loading') : t('shorts.button')}
+      </Button>
+
+      {isOpen && (
+        <ShortsPlayer
+          scenes={scenes}
+          shareToken={shareToken}
+          onClose={handleClose}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -1,0 +1,227 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X, Volume2, VolumeX } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { apiClient, type PopularScene } from '@/lib/api';
+import { timeStringToSeconds } from '@/lib/utils/video';
+
+interface ShortsPlayerProps {
+  scenes: PopularScene[];
+  shareToken?: string;
+  onClose: () => void;
+}
+
+export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps) {
+  const { t } = useTranslation();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const videoElementsRef = useRef<(HTMLVideoElement | null)[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isReady, setIsReady] = useState(false);
+  const [isMuted, setIsMuted] = useState(false);
+
+  const getVideoUrl = useCallback((file: string | null): string => {
+    if (!file) return '';
+    if (shareToken) {
+      return apiClient.getSharedVideoUrl(file, shareToken);
+    }
+    return apiClient.getVideoUrl(file);
+  }, [shareToken]);
+
+  const handleTimeUpdate = useCallback((scene: PopularScene, video: HTMLVideoElement) => {
+    const endSeconds = timeStringToSeconds(scene.end_time);
+    const startSeconds = timeStringToSeconds(scene.start_time);
+
+    if (video.currentTime >= endSeconds) {
+      video.currentTime = startSeconds;
+    }
+  }, []);
+
+  const handleLoadedMetadata = useCallback((scene: PopularScene, video: HTMLVideoElement) => {
+    const startSeconds = timeStringToSeconds(scene.start_time);
+    video.currentTime = startSeconds;
+  }, []);
+
+  const playVideo = useCallback((index: number) => {
+    const video = videoElementsRef.current[index];
+    if (video) {
+      const scene = scenes[index];
+      const startSeconds = timeStringToSeconds(scene.start_time);
+      video.currentTime = startSeconds;
+      void video.play();
+    }
+  }, [scenes]);
+
+  const pauseVideo = useCallback((index: number) => {
+    const video = videoElementsRef.current[index];
+    if (video) {
+      video.pause();
+    }
+  }, []);
+
+  // Initialize video refs array
+  useEffect(() => {
+    videoElementsRef.current = new Array(scenes.length).fill(null);
+  }, [scenes.length]);
+
+  // Set up IntersectionObserver after videos are mounted
+  useEffect(() => {
+    if (!isReady || scenes.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const video = entry.target as HTMLVideoElement;
+          const index = Number(video.dataset.index);
+
+          if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+            setCurrentIndex(index);
+            playVideo(index);
+          } else {
+            pauseVideo(index);
+          }
+        });
+      },
+      {
+        threshold: 0.5,
+        root: containerRef.current
+      }
+    );
+
+    videoElementsRef.current.forEach((video) => {
+      if (video) {
+        observer.observe(video);
+      }
+    });
+
+    // Auto-play first video
+    playVideo(0);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isReady, scenes.length, playVideo, pauseVideo]);
+
+  // Mark as ready after initial render
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsReady(true);
+    }, 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Update muted state for all videos
+  useEffect(() => {
+    videoElementsRef.current.forEach((video) => {
+      if (video) {
+        video.muted = isMuted;
+      }
+    });
+  }, [isMuted]);
+
+  const toggleMute = useCallback(() => {
+    setIsMuted((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  const setVideoRef = useCallback((index: number) => (el: HTMLVideoElement | null) => {
+    videoElementsRef.current[index] = el;
+  }, []);
+
+  if (scenes.length === 0) {
+    return (
+      <div className="fixed inset-0 z-50 bg-black flex items-center justify-center">
+        <div className="text-white text-center">
+          <p className="text-lg">{t('shorts.noScenes')}</p>
+          <Button variant="outline" className="mt-4" onClick={onClose}>
+            {t('common.actions.close')}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black">
+      <div className="absolute top-4 right-4 z-10 flex gap-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-white hover:bg-white/20"
+          onClick={toggleMute}
+        >
+          {isMuted ? <VolumeX className="h-6 w-6" /> : <Volume2 className="h-6 w-6" />}
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-white hover:bg-white/20"
+          onClick={onClose}
+        >
+          <X className="h-6 w-6" />
+        </Button>
+      </div>
+
+      <div className="absolute top-4 left-4 z-10 text-white/70 text-sm">
+        {currentIndex + 1} / {scenes.length}
+      </div>
+
+      <div
+        ref={containerRef}
+        className="h-full w-full overflow-y-scroll snap-y snap-mandatory"
+        style={{ scrollSnapType: 'y mandatory' }}
+      >
+        {scenes.map((scene, index) => (
+          <div
+            key={`${scene.video_id}-${scene.start_time}`}
+            className="h-full w-full snap-start snap-always relative flex items-center justify-center"
+          >
+            {scene.file ? (
+              <video
+                ref={setVideoRef(index)}
+                data-index={index}
+                className="max-h-full max-w-full object-contain"
+                src={getVideoUrl(scene.file)}
+                playsInline
+                muted={isMuted}
+                loop={false}
+                preload="auto"
+                onLoadedMetadata={(e) => handleLoadedMetadata(scene, e.currentTarget)}
+                onTimeUpdate={(e) => handleTimeUpdate(scene, e.currentTarget)}
+              />
+            ) : (
+              <div className="text-white/50">
+                {t('videos.shared.videoNoFile')}
+              </div>
+            )}
+
+            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-6 pb-8">
+              <h3 className="text-white text-lg font-semibold mb-1 line-clamp-2">
+                {scene.title}
+              </h3>
+              <div className="flex items-center gap-4 text-white/70 text-sm">
+                <span>{scene.start_time} - {scene.end_time}</span>
+                <span>{t('shorts.referenceCount', { count: scene.reference_count })}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shorts/__tests__/ShortsButton.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsButton.test.tsx
@@ -1,0 +1,211 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { ShortsButton } from '../ShortsButton'
+import { apiClient, type VideoInGroup, type PopularScene } from '@/lib/api'
+
+// Mock apiClient
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    getPopularScenes: vi.fn(),
+    getVideoUrl: vi.fn((file: string) => `http://localhost/media/${file}`),
+    getSharedVideoUrl: vi.fn((file: string, token: string) => `http://localhost/media/${file}?share_token=${token}`),
+  },
+}))
+
+// Mock IntersectionObserver
+const mockIntersectionObserver = vi.fn()
+mockIntersectionObserver.mockReturnValue({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+})
+window.IntersectionObserver = mockIntersectionObserver
+
+// Mock HTMLMediaElement
+window.HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined)
+window.HTMLMediaElement.prototype.pause = vi.fn()
+
+const mockVideos: VideoInGroup[] = [
+  {
+    id: 1,
+    title: 'Test Video 1',
+    description: 'Description 1',
+    file: 'videos/1/test1.mp4',
+    uploaded_at: '2024-01-01T00:00:00Z',
+    status: 'completed',
+    order: 0,
+  },
+  {
+    id: 2,
+    title: 'Test Video 2',
+    description: 'Description 2',
+    file: 'videos/2/test2.mp4',
+    uploaded_at: '2024-01-02T00:00:00Z',
+    status: 'completed',
+    order: 1,
+  },
+]
+
+const mockPopularScenes: PopularScene[] = [
+  {
+    video_id: 1,
+    title: 'Test Video 1',
+    start_time: '00:01:00',
+    end_time: '00:02:00',
+    reference_count: 5,
+    file: 'videos/1/test1.mp4',
+  },
+]
+
+describe('ShortsButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getPopularScenes as any).mockResolvedValue(mockPopularScenes)
+  })
+
+  it('should render button with correct text', () => {
+    render(<ShortsButton groupId={1} videos={mockVideos} />)
+
+    expect(screen.getByText(/shorts.button/)).toBeInTheDocument()
+  })
+
+  it('should not render when videos is empty', () => {
+    const { container } = render(<ShortsButton groupId={1} videos={[]} />)
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should call getPopularScenes when button is clicked', async () => {
+    render(<ShortsButton groupId={1} videos={mockVideos} />)
+
+    const button = screen.getByText(/shorts.button/)
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    await waitFor(() => {
+      expect(apiClient.getPopularScenes).toHaveBeenCalledWith(1, undefined)
+    })
+  })
+
+  it('should call getPopularScenes with shareToken when provided', async () => {
+    render(<ShortsButton groupId={1} videos={mockVideos} shareToken="test-token" />)
+
+    const button = screen.getByText(/shorts.button/)
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    await waitFor(() => {
+      expect(apiClient.getPopularScenes).toHaveBeenCalledWith(1, 'test-token')
+    })
+  })
+
+  it('should open ShortsPlayer when button is clicked', async () => {
+    render(<ShortsButton groupId={1} videos={mockVideos} />)
+
+    const button = screen.getByText(/shorts.button/)
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Video 1')).toBeInTheDocument()
+      expect(screen.getByText('00:01:00 - 00:02:00')).toBeInTheDocument()
+    })
+  })
+
+  it('should handle API error gracefully', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(apiClient.getPopularScenes as any).mockRejectedValue(new Error('API Error'))
+
+    render(<ShortsButton groupId={1} videos={mockVideos} />)
+
+    const button = screen.getByText(/shorts.button/)
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to load popular scenes:', expect.any(Error))
+    })
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('should show loading state while fetching', async () => {
+    let resolvePromise: (value: PopularScene[]) => void
+    const pendingPromise = new Promise<PopularScene[]>((resolve) => {
+      resolvePromise = resolve
+    })
+    ;(apiClient.getPopularScenes as any).mockReturnValue(pendingPromise)
+
+    render(<ShortsButton groupId={1} videos={mockVideos} />)
+
+    const button = screen.getByRole('button')
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    // Button should be disabled during loading
+    expect(button).toBeDisabled()
+
+    // Resolve the promise
+    await act(async () => {
+      resolvePromise!(mockPopularScenes)
+    })
+
+    // Button should be enabled after loading
+    await waitFor(() => {
+      expect(button).not.toBeDisabled()
+    })
+  })
+
+  it('should close ShortsPlayer when close button is clicked', async () => {
+    render(<ShortsButton groupId={1} videos={mockVideos} />)
+
+    const button = screen.getByText(/shorts.button/)
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Video 1')).toBeInTheDocument()
+    })
+
+    // Find and click the close button (X icon)
+    const allButtons = screen.getAllByRole('button')
+    const closeButton = allButtons.find(btn => btn.querySelector('svg.lucide-x'))
+
+    if (closeButton) {
+      await act(async () => {
+        fireEvent.click(closeButton)
+      })
+    }
+
+    await waitFor(() => {
+      // ShortsPlayer should be closed, so the scene title should not be visible
+      // But the ShortsButton should still be there
+      expect(screen.getByText(/shorts.button/)).toBeInTheDocument()
+    })
+  })
+
+  it('should render with sm size', () => {
+    render(<ShortsButton groupId={1} videos={mockVideos} size="sm" />)
+
+    const button = screen.getByRole('button')
+    expect(button).toBeInTheDocument()
+  })
+
+  it('should render with default size', () => {
+    render(<ShortsButton groupId={1} videos={mockVideos} size="default" />)
+
+    const button = screen.getByRole('button')
+    expect(button).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { ShortsPlayer } from '../ShortsPlayer'
 import { apiClient, type PopularScene } from '@/lib/api'
 
@@ -153,12 +153,12 @@ describe('ShortsPlayer', () => {
     expect(document.body.style.overflow).toBe('')
   })
 
-  it('should set up IntersectionObserver', () => {
+  it('should set up IntersectionObserver', async () => {
     render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
 
-    // Wait for isReady to be true
-    setTimeout(() => {
+    // Wait for isReady to be true and IntersectionObserver to be set up
+    await waitFor(() => {
       expect(mockIntersectionObserver).toHaveBeenCalled()
-    }, 150)
+    }, { timeout: 200 })
   })
 })

--- a/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ShortsPlayer } from '../ShortsPlayer'
+import { apiClient, type PopularScene } from '@/lib/api'
+
+// Mock apiClient
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    getVideoUrl: vi.fn((file: string) => `http://localhost/media/${file}`),
+    getSharedVideoUrl: vi.fn((file: string, token: string) => `http://localhost/media/${file}?share_token=${token}`),
+  },
+}))
+
+// Mock IntersectionObserver
+const mockIntersectionObserver = vi.fn()
+mockIntersectionObserver.mockReturnValue({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+})
+window.IntersectionObserver = mockIntersectionObserver
+
+// Mock HTMLMediaElement
+window.HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined)
+window.HTMLMediaElement.prototype.pause = vi.fn()
+
+const mockScenes: PopularScene[] = [
+  {
+    video_id: 1,
+    title: 'Test Video 1',
+    start_time: '00:01:00',
+    end_time: '00:02:00',
+    reference_count: 5,
+    file: 'videos/1/test1.mp4',
+  },
+  {
+    video_id: 2,
+    title: 'Test Video 2',
+    start_time: '00:03:00',
+    end_time: '00:04:00',
+    reference_count: 3,
+    file: 'videos/2/test2.mp4',
+  },
+]
+
+describe('ShortsPlayer', () => {
+  const mockOnClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.style.overflow = ''
+  })
+
+  afterEach(() => {
+    document.body.style.overflow = ''
+  })
+
+  it('should render scenes', () => {
+    render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
+
+    expect(screen.getByText('Test Video 1')).toBeInTheDocument()
+    expect(screen.getByText('00:01:00 - 00:02:00')).toBeInTheDocument()
+    expect(screen.getByText(/5/)).toBeInTheDocument()
+  })
+
+  it('should display scene counter', () => {
+    render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
+
+    expect(screen.getByText('1 / 2')).toBeInTheDocument()
+  })
+
+  it('should call onClose when close button is clicked', () => {
+    render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
+
+    const closeButtons = screen.getAllByRole('button')
+    const closeButton = closeButtons.find(btn => btn.querySelector('svg.lucide-x'))
+    if (closeButton) {
+      fireEvent.click(closeButton)
+    }
+
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('should call onClose when Escape key is pressed', () => {
+    render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('should display no scenes message when scenes is empty', () => {
+    render(<ShortsPlayer scenes={[]} onClose={mockOnClose} />)
+
+    expect(screen.getByText(/shorts.noScenes/)).toBeInTheDocument()
+  })
+
+  it('should toggle mute when mute button is clicked', () => {
+    render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
+
+    const buttons = screen.getAllByRole('button')
+    const muteButton = buttons.find(btn =>
+      btn.querySelector('svg.lucide-volume-2') || btn.querySelector('svg.lucide-volume-x')
+    )
+
+    expect(muteButton).toBeInTheDocument()
+    if (muteButton) {
+      fireEvent.click(muteButton)
+    }
+  })
+
+  it('should use getVideoUrl for regular access', () => {
+    render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
+
+    expect(apiClient.getVideoUrl).toHaveBeenCalledWith('videos/1/test1.mp4')
+  })
+
+  it('should use getSharedVideoUrl when shareToken is provided', () => {
+    render(<ShortsPlayer scenes={mockScenes} shareToken="test-token" onClose={mockOnClose} />)
+
+    expect(apiClient.getSharedVideoUrl).toHaveBeenCalledWith('videos/1/test1.mp4', 'test-token')
+  })
+
+  it('should display video unavailable message when file is null', () => {
+    const scenesWithNullFile: PopularScene[] = [
+      {
+        video_id: 1,
+        title: 'Test Video',
+        start_time: '00:01:00',
+        end_time: '00:02:00',
+        reference_count: 5,
+        file: null,
+      },
+    ]
+
+    render(<ShortsPlayer scenes={scenesWithNullFile} onClose={mockOnClose} />)
+
+    expect(screen.getByText(/videos.shared.videoNoFile/)).toBeInTheDocument()
+  })
+
+  it('should hide body overflow when mounted', () => {
+    render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
+
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('should restore body overflow when unmounted', () => {
+    const { unmount } = render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
+
+    expect(document.body.style.overflow).toBe('hidden')
+
+    unmount()
+
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('should set up IntersectionObserver', () => {
+    render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
+
+    // Wait for isReady to be true
+    setTimeout(() => {
+      expect(mockIntersectionObserver).toHaveBeenCalled()
+    }, 150)
+  })
+})

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -509,5 +509,10 @@
       "message": "To use transcription and chat features, please set your OpenAI API key in Settings.",
       "settingsLink": "Go to Settings"
     }
+  },
+  "shorts": {
+    "button": "Review Shorts",
+    "noScenes": "No scenes to display",
+    "referenceCount": "{{count}} references"
   }
 }

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -515,5 +515,10 @@
       "message": "文字起こし・チャット機能を利用するには、設定画面でOpenAI APIキーを設定してください。",
       "settingsLink": "設定画面へ"
     }
+  },
+  "shorts": {
+    "button": "復習ショート",
+    "noScenes": "表示するシーンがありません",
+    "referenceCount": "{{count}}回参照"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,6 +56,15 @@ export interface RelatedVideo {
   end_time: string;
 }
 
+export interface PopularScene {
+  video_id: number;
+  title: string;
+  start_time: string;
+  end_time: string;
+  reference_count: number;
+  file: string | null;
+}
+
 export interface ChatHistoryItem {
   id: number;
   group: number;
@@ -775,6 +784,17 @@ class ApiClient {
     return this.request<void>(`/videos/${videoId}/tags/${tagId}/remove/`, {
       method: 'DELETE',
     });
+  }
+
+  async getPopularScenes(groupId: number, shareToken?: string, limit?: number): Promise<PopularScene[]> {
+    const params = new URLSearchParams({ group_id: String(groupId) });
+    if (shareToken) {
+      params.set('share_token', shareToken);
+    }
+    if (limit) {
+      params.set('limit', String(limit));
+    }
+    return this.request<PopularScene[]>(`/chat/popular-scenes/?${params.toString()}`);
   }
 
 }

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { apiClient, type VideoGroup, type VideoInGroup } from '@/lib/api';
+import { ShortsButton } from '@/components/shorts/ShortsButton';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { MessageAlert } from '@/components/common/MessageAlert';
@@ -153,6 +154,14 @@ export default function SharePage() {
                 {group.description || t('videos.shared.descriptionFallback')}
               </p>
             </div>
+            {group.videos && group.videos.length > 0 && (
+              <ShortsButton
+                groupId={group.id}
+                videos={group.videos}
+                shareToken={shareToken}
+                size="sm"
+              />
+            )}
           </div>
  
           {error && <MessageAlert type="error" message={error} />}

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -23,6 +23,7 @@ import { CSS } from '@dnd-kit/utilities';
 
 import { apiClient, type VideoGroup, type VideoInGroup, type VideoList } from '@/lib/api';
 import { ChatPanel } from '@/components/chat/ChatPanel';
+import { ShortsButton } from '@/components/shorts/ShortsButton';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -701,6 +702,14 @@ export default function VideoGroupDetailPage() {
                       </DialogFooter>
                     </DialogContent>
                   </Dialog>
+                )}
+
+                {!isEditing && group.videos && group.videos.length > 0 && groupId && (
+                  <ShortsButton
+                    groupId={groupId}
+                    videos={group.videos}
+                    size="sm"
+                  />
                 )}
 
                 {!isEditing && (


### PR DESCRIPTION
## Summary
- ChatLogのrelated_videosを集計し、頻繁に参照されるシーンをTikTok/YouTube Shorts風の縦スクロールUIで表示する「復習ショート」機能を実装
- PopularScenesView APIを追加（share_token対応）
- ShortsPlayer/ShortsButtonコンポーネントを追加
- VideoGroupDetailPageとSharePageに統合

## Changes
- `backend/app/chat/views.py` - PopularScenesView追加
- `backend/app/chat/urls.py` - popular-scenesルート追加
- `backend/app/chat/tests/test_views.py` - テスト追加（10件）
- `frontend/src/lib/api.ts` - PopularScene型、getPopularScenes追加
- `frontend/src/components/shorts/ShortsPlayer.tsx` - 縦スクロールショートプレイヤー
- `frontend/src/components/shorts/ShortsButton.tsx` - ショート起動ボタン
- `frontend/src/components/shorts/__tests__/` - フロントエンドテスト（22件）
- `frontend/src/pages/VideoGroupDetailPage.tsx` - ShortsButton統合
- `frontend/src/pages/SharePage.tsx` - ShortsButton統合（shareToken付き）
- `frontend/src/i18n/locales/ja/translation.json` - 日本語翻訳追加
- `frontend/src/i18n/locales/en/translation.json` - 英語翻訳追加

## Test plan
- [x] `GET /api/chat/popular-scenes/?group_id=X` でシーン一覧が返却される
- [x] share_token付きでも同様にアクセス可能
- [x] VideoGroupDetailPageで「復習ショート」ボタンが表示される
- [x] SharePageでも同ボタンが表示される
- [x] ボタンクリックで全画面ショートプレイヤーが開く
- [x] 縦スクロールでシーンが切り替わる
- [x] 各シーンがstart_time〜end_timeの範囲でループ再生される
- [x] ミュートボタンで音声ON/OFF切り替え可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Popular Scenes ("Review Shorts") to browse top-referenced video clips with title, time range, reference count, and file playback; supports access via share links and mute toggle.
  * Integrated Shorts player modal and a trigger button across group pages.

* **Localization**
  * Added English and Japanese translations for shorts UI text.

* **Tests**
  * Added comprehensive API and UI tests covering endpoint, player, and button behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->