### PR TITLE
perf: optimize shorts video loading with lazy loading and caching

### DIFF
--- a/backend/app/chat/tests/test_views.py
+++ b/backend/app/chat/tests/test_views.py
@@ -741,3 +741,65 @@ class PopularScenesViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # file field should be present (may be None if no file uploaded)
         self.assertIn("file", response.data[0])
+
+    def test_get_popular_scenes_returns_cached_result(self):
+        """Test that popular scenes are cached and returned from cache on second request"""
+        url = reverse("popular-scenes")
+        url += f"?group_id={self.group.id}"
+
+        response1 = self.client.get(url)
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+
+        # Add a new chat log after first request
+        ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="New question",
+            answer="New answer",
+            related_videos=[
+                {
+                    "video_id": self.video2.id,
+                    "title": "Test Video 2",
+                    "start_time": "00:05:00",
+                    "end_time": "00:06:00",
+                },
+            ],
+        )
+
+        # Second request should return cached result (same as first)
+        response2 = self.client.get(url)
+        self.assertEqual(response2.status_code, status.HTTP_200_OK)
+        self.assertEqual(response1.data, response2.data)
+
+    def test_get_popular_scenes_cache_invalidated_after_ttl(self):
+        """Test that cache is invalidated after TTL expires"""
+        from django.core.cache import cache
+
+        url = reverse("popular-scenes")
+        url += f"?group_id={self.group.id}"
+
+        self.client.get(url)
+
+        # Manually clear cache to simulate TTL expiry
+        cache.clear()
+
+        # Add a new chat log
+        ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="New question",
+            answer="New answer",
+            related_videos=[
+                {
+                    "video_id": self.video2.id,
+                    "title": "Test Video 2",
+                    "start_time": "00:05:00",
+                    "end_time": "00:06:00",
+                },
+            ],
+        )
+
+        # After cache clear, should return fresh data including new scene
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)

--- a/backend/app/chat/views.py
+++ b/backend/app/chat/views.py
@@ -2,6 +2,7 @@ import csv
 import json
 from collections import Counter
 
+from django.core.cache import cache
 from django.db.models import Prefetch
 from django.http import HttpResponse
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -390,6 +391,12 @@ class PopularScenesView(APIView):
                 "Specified group not found", status.HTTP_404_NOT_FOUND
             )
 
+        # Try cache first (5 minute TTL)
+        cache_key = f"popular_scenes_{group_id}_{limit}"
+        result = cache.get(cache_key)
+        if result is not None:
+            return Response(result)
+
         # Get all chat logs for the group
         chat_logs = ChatLog.objects.filter(group=group).values_list(
             "related_videos", flat=True
@@ -450,5 +457,7 @@ class PopularScenesView(APIView):
                     "file": video_file_map.get(video_id),
                 }
             )
+
+        cache.set(cache_key, result, timeout=300)
 
         return Response(result)

--- a/frontend/src/components/shorts/ShortsButton.tsx
+++ b/frontend/src/components/shorts/ShortsButton.tsx
@@ -19,11 +19,11 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
   const [isOpen, setIsOpen] = useState(false);
   const [scenes, setScenes] = useState<PopularScene[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const cacheRef = useRef<{ data: PopularScene[]; fetchedAt: number } | null>(null);
+  const cacheRef = useRef<{ groupId: number; data: PopularScene[]; fetchedAt: number } | null>(null);
 
   const handleOpen = async () => {
     const cached = cacheRef.current;
-    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) {
+    if (cached && cached.groupId === groupId && Date.now() - cached.fetchedAt < CACHE_TTL) {
       setScenes(cached.data);
       setIsOpen(true);
       return;
@@ -32,7 +32,7 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
     setIsLoading(true);
     try {
       const popularScenes = await apiClient.getPopularScenes(groupId, shareToken);
-      cacheRef.current = { data: popularScenes, fetchedAt: Date.now() };
+      cacheRef.current = { groupId, data: popularScenes, fetchedAt: Date.now() };
       setScenes(popularScenes);
       setIsOpen(true);
     } catch (error) {

--- a/frontend/src/components/shorts/ShortsButton.tsx
+++ b/frontend/src/components/shorts/ShortsButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Play } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -12,7 +12,6 @@ interface ShortsButtonProps {
   size?: 'sm' | 'default';
 }
 
-/** Client-side cache TTL in milliseconds (5 minutes) */
 const CACHE_TTL = 5 * 60 * 1000;
 
 export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: ShortsButtonProps) {
@@ -22,8 +21,7 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
   const [isLoading, setIsLoading] = useState(false);
   const cacheRef = useRef<{ data: PopularScene[]; fetchedAt: number } | null>(null);
 
-  const handleOpen = useCallback(async () => {
-    // Use cached data if still fresh
+  const handleOpen = async () => {
     const cached = cacheRef.current;
     if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) {
       setScenes(cached.data);
@@ -42,11 +40,7 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
     } finally {
       setIsLoading(false);
     }
-  }, [groupId, shareToken]);
-
-  const handleClose = useCallback(() => {
-    setIsOpen(false);
-  }, []);
+  };
 
   if (!videos || videos.length === 0) {
     return null;
@@ -54,23 +48,13 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
 
   return (
     <>
-      <Button
-        variant="outline"
-        size={size}
-        onClick={handleOpen}
-        disabled={isLoading}
-        className="gap-2"
-      >
+      <Button variant="outline" size={size} onClick={handleOpen} disabled={isLoading} className="gap-2">
         <Play className="h-4 w-4" />
         {isLoading ? t('common.loading') : t('shorts.button')}
       </Button>
 
       {isOpen && (
-        <ShortsPlayer
-          scenes={scenes}
-          shareToken={shareToken}
-          onClose={handleClose}
-        />
+        <ShortsPlayer scenes={scenes} shareToken={shareToken} onClose={() => setIsOpen(false)} />
       )}
     </>
   );

--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, Volume2, VolumeX } from 'lucide-react';
+import { X, Volume2, VolumeX, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { apiClient, type PopularScene } from '@/lib/api';
 import { timeStringToSeconds } from '@/lib/utils/video';
@@ -11,20 +11,26 @@ interface ShortsPlayerProps {
   onClose: () => void;
 }
 
+/** Number of adjacent videos to preload in each direction */
+const PRELOAD_RANGE = 1;
+
 export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
-  const videoElementsRef = useRef<(HTMLVideoElement | null)[]>([]);
+  const videoElementsRef = useRef<Map<number, HTMLVideoElement>>(new Map());
+  const slideRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [isReady, setIsReady] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
 
-  const getVideoUrl = useCallback((file: string | null): string => {
-    if (!file) return '';
-    if (shareToken) {
-      return apiClient.getSharedVideoUrl(file, shareToken);
-    }
-    return apiClient.getVideoUrl(file);
+  const getVideoSrc = useCallback((scene: PopularScene): string => {
+    if (!scene.file) return '';
+    const baseUrl = shareToken
+      ? apiClient.getSharedVideoUrl(scene.file, shareToken)
+      : apiClient.getVideoUrl(scene.file);
+    // Use media fragment to limit buffering to the clip range
+    const start = timeStringToSeconds(scene.start_time);
+    const end = timeStringToSeconds(scene.end_time);
+    return `${baseUrl}#t=${start},${end}`;
   }, [shareToken]);
 
   const handleTimeUpdate = useCallback((scene: PopularScene, video: HTMLVideoElement) => {
@@ -42,7 +48,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
   }, []);
 
   const playVideo = useCallback((index: number) => {
-    const video = videoElementsRef.current[index];
+    const video = videoElementsRef.current.get(index);
     if (video) {
       const scene = scenes[index];
       const startSeconds = timeStringToSeconds(scene.start_time);
@@ -51,70 +57,54 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
     }
   }, [scenes]);
 
-  const pauseVideo = useCallback((index: number) => {
-    const video = videoElementsRef.current[index];
-    if (video) {
-      video.pause();
-    }
-  }, []);
-
-  // Initialize video refs array
+  // Set up IntersectionObserver on slide containers
   useEffect(() => {
-    videoElementsRef.current = new Array(scenes.length).fill(null);
-  }, [scenes.length]);
-
-  // Set up IntersectionObserver after videos are mounted
-  useEffect(() => {
-    if (!isReady || scenes.length === 0) return;
+    if (scenes.length === 0) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          const video = entry.target as HTMLVideoElement;
-          const index = Number(video.dataset.index);
+          const index = Number((entry.target as HTMLElement).dataset.index);
 
           if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
             setCurrentIndex(index);
-            playVideo(index);
-          } else {
-            pauseVideo(index);
           }
         });
       },
       {
         threshold: 0.5,
-        root: containerRef.current
+        root: containerRef.current,
       }
     );
 
-    videoElementsRef.current.forEach((video) => {
-      if (video) {
-        observer.observe(video);
-      }
+    // Observe after DOM is committed
+    requestAnimationFrame(() => {
+      slideRefs.current.forEach((slide) => {
+        observer.observe(slide);
+      });
     });
-
-    // Auto-play first video
-    playVideo(0);
 
     return () => {
       observer.disconnect();
     };
-  }, [isReady, scenes.length, playVideo, pauseVideo]);
+  }, [scenes.length]);
 
-  // Mark as ready after initial render
+  // Play/pause based on currentIndex changes
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsReady(true);
-    }, 100);
-    return () => clearTimeout(timer);
-  }, []);
+    // Pause all videos except current
+    videoElementsRef.current.forEach((video, i) => {
+      if (i !== currentIndex) {
+        video.pause();
+      }
+    });
+    // Play current video
+    playVideo(currentIndex);
+  }, [currentIndex, playVideo]);
 
-  // Update muted state for all videos
+  // Update muted state for loaded videos
   useEffect(() => {
     videoElementsRef.current.forEach((video) => {
-      if (video) {
-        video.muted = isMuted;
-      }
+      video.muted = isMuted;
     });
   }, [isMuted]);
 
@@ -140,7 +130,19 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
   }, []);
 
   const setVideoRef = useCallback((index: number) => (el: HTMLVideoElement | null) => {
-    videoElementsRef.current[index] = el;
+    if (el) {
+      videoElementsRef.current.set(index, el);
+    } else {
+      videoElementsRef.current.delete(index);
+    }
+  }, []);
+
+  const setSlideRef = useCallback((index: number) => (el: HTMLDivElement | null) => {
+    if (el) {
+      slideRefs.current.set(index, el);
+    } else {
+      slideRefs.current.delete(index);
+    }
   }, []);
 
   if (scenes.length === 0) {
@@ -186,41 +188,53 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
         className="h-full w-full overflow-y-scroll snap-y snap-mandatory"
         style={{ scrollSnapType: 'y mandatory' }}
       >
-        {scenes.map((scene, index) => (
-          <div
-            key={`${scene.video_id}-${scene.start_time}`}
-            className="h-full w-full snap-start snap-always relative flex items-center justify-center"
-          >
-            {scene.file ? (
-              <video
-                ref={setVideoRef(index)}
-                data-index={index}
-                className="max-h-full max-w-full object-contain"
-                src={getVideoUrl(scene.file)}
-                playsInline
-                muted={isMuted}
-                loop={false}
-                preload="auto"
-                onLoadedMetadata={(e) => handleLoadedMetadata(scene, e.currentTarget)}
-                onTimeUpdate={(e) => handleTimeUpdate(scene, e.currentTarget)}
-              />
-            ) : (
-              <div className="text-white/50">
-                {t('videos.shared.videoNoFile')}
-              </div>
-            )}
+        {scenes.map((scene, index) => {
+          const shouldLoad = Math.abs(index - currentIndex) <= PRELOAD_RANGE;
 
-            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-6 pb-8">
-              <h3 className="text-white text-lg font-semibold mb-1 line-clamp-2">
-                {scene.title}
-              </h3>
-              <div className="flex items-center gap-4 text-white/70 text-sm">
-                <span>{scene.start_time} - {scene.end_time}</span>
-                <span>{t('shorts.referenceCount', { count: scene.reference_count })}</span>
+          return (
+            <div
+              key={`${scene.video_id}-${scene.start_time}`}
+              ref={setSlideRef(index)}
+              data-index={index}
+              className="h-full w-full snap-start snap-always relative flex items-center justify-center"
+            >
+              {scene.file ? (
+                shouldLoad ? (
+                  <video
+                    ref={setVideoRef(index)}
+                    data-index={index}
+                    className="max-h-full max-w-full object-contain"
+                    src={getVideoSrc(scene)}
+                    playsInline
+                    muted={isMuted}
+                    loop={false}
+                    preload={index === currentIndex ? 'auto' : 'metadata'}
+                    onLoadedMetadata={(e) => handleLoadedMetadata(scene, e.currentTarget)}
+                    onTimeUpdate={(e) => handleTimeUpdate(scene, e.currentTarget)}
+                  />
+                ) : (
+                  <div className="flex items-center justify-center text-white/40">
+                    <Loader2 className="h-8 w-8 animate-spin" />
+                  </div>
+                )
+              ) : (
+                <div className="text-white/50">
+                  {t('videos.shared.videoNoFile')}
+                </div>
+              )}
+
+              <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-6 pb-8">
+                <h3 className="text-white text-lg font-semibold mb-1 line-clamp-2">
+                  {scene.title}
+                </h3>
+                <div className="flex items-center gap-4 text-white/70 text-sm">
+                  <span>{scene.start_time} - {scene.end_time}</span>
+                  <span>{t('shorts.referenceCount', { count: scene.reference_count })}</span>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- ShortsPlayerにlazy loadingを導入し、現在±1の動画のみロードするように変更（20本同時→最大3本）
- `#t=start,end` メディアフラグメントでクリップ区間のみバッファリング
- バックエンド（PopularScenesView）とフロントエンド（ShortsButton）の両方に5分間キャッシュを追加
- 不要なuseCallback/useEffect削除によるコード簡素化（-70行）
- ループ再生がメディアフラグメント終端で停止する問題を修正

## Test plan
- [x] `docker compose build` ビルド成功
- [x] バックエンドテスト（PopularScenesViewTests 10件）パス
- [x] ショート動画の初回読み込みが高速化されていることを確認
- [x] スクロールで次の動画がスムーズに読み込まれることを確認
- [x] ループ再生が止まらないことを確認
- [x] 閉じて再度開いた時にキャッシュから即時表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Escape key closes the shorts player; page scrolling is disabled while open.

* **Performance Improvements**
  * Time-limited caching for popular scenes to reduce repeated API calls.
  * Improved video preloading and loading behavior for smoother playback and transitions.

* **Tests**
  * Added tests validating caching behavior, preload/looping behavior, and observer lifecycle for shorts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->