### PR TITLE
fix(mobile): optimize shorts playback for stability

### DIFF
--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -152,7 +152,9 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
                     }}
                     onTimeUpdate={(e) => {
                       const video = e.currentTarget;
-                      if (video.currentTime >= meta.endSeconds) {
+                      // Loop back to start if we exceed end time
+                      // Use a small buffer (0.3s) to avoid micro-loops if update frequency is high
+                      if (video.currentTime >= meta.endSeconds - 0.1 && video.currentTime < meta.endSeconds + 1) {
                         video.currentTime = meta.startSeconds;
                         video.play().catch(() => { });
                       }

--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -261,16 +261,8 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
     );
   }
 
-  // Next scene metadata for preloading
-  const nextMeta = currentIndex < sceneMeta.length - 1 ? sceneMeta[currentIndex + 1] : null;
-
   return (
     <div className="fixed inset-0 z-50 bg-black overflow-hidden">
-      {/* Preload next video */}
-      {nextMeta?.src && (
-        <link rel="preload" as="video" href={nextMeta.src} />
-      )}
-
       {/* Single video element that follows scroll */}
       <div
         className="absolute inset-0 flex items-center justify-center pointer-events-none"

--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -21,7 +21,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
   const [showPlayOverlay, setShowPlayOverlay] = useState(true);
   const [videoOffset, setVideoOffset] = useState(0);  // For smooth scroll following
   const currentIndexRef = useRef(currentIndex);
-  const isScrollingRef = useRef(false);
+  const [isScrolling, setIsScrolling] = useState(false);
 
   // Keep ref in sync
   useEffect(() => {
@@ -80,7 +80,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
     if (!video || !currentMeta?.src || showPlayOverlay) return;
 
     // Don't change during scroll animation
-    if (isScrollingRef.current) return;
+    if (isScrolling) return;
 
     // Change source and play
     if (video.src !== currentMeta.src) {
@@ -91,7 +91,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
     video.muted = isMuted;
 
     video.play().catch(() => { });
-  }, [currentIndex, currentMeta, isMuted, showPlayOverlay]);
+  }, [currentIndex, currentMeta, isMuted, showPlayOverlay, isScrolling]);
 
   // IntersectionObserver for scroll-based slide detection
   useEffect(() => {
@@ -126,7 +126,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
     let scrollTimeout: ReturnType<typeof setTimeout>;
 
     const handleScroll = () => {
-      isScrollingRef.current = true;
+      setIsScrolling(true);
       clearTimeout(scrollTimeout);
 
       const scrollTop = container.scrollTop;
@@ -138,7 +138,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
       setVideoOffset(-offset);  // Negative because we want video to move opposite to scroll
 
       scrollTimeout = setTimeout(() => {
-        isScrollingRef.current = false;
+        setIsScrolling(false);
         setVideoOffset(0);  // Reset offset after scroll ends
 
         // Ensure video is playing
@@ -260,7 +260,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
         className="absolute inset-0 flex items-center justify-center pointer-events-none"
         style={{
           transform: `translateY(${videoOffset}px)`,
-          transition: isScrollingRef.current ? 'none' : 'transform 0.1s ease-out',
+          transition: isScrolling ? 'none' : 'transform 0.1s ease-out',
           zIndex: 5
         }}
       >

--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -144,7 +144,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
                     playsInline
                     webkit-playsinline="true"
                     muted={isMuted}
-                    preload={preload}
+                    preload={index === currentIndex || index === currentIndex + 1 ? 'auto' : 'metadata'}
                     onLoadedMetadata={(e) => {
                       const v = e.currentTarget;
                       if (v.currentTime < meta.startSeconds) {

--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -146,15 +146,13 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
                     preload={index === currentIndex || index === currentIndex + 1 ? 'auto' : 'metadata'}
                     onLoadedMetadata={(e) => {
                       const v = e.currentTarget;
-                      if (v.currentTime < meta.startSeconds) {
+                      if (v.currentTime < meta.startSeconds || v.currentTime > meta.endSeconds) {
                         v.currentTime = meta.startSeconds;
                       }
                     }}
                     onTimeUpdate={(e) => {
                       const video = e.currentTarget;
-                      // Loop back to start if we exceed end time
-                      // Use a small buffer (0.3s) to avoid micro-loops if update frequency is high
-                      if (video.currentTime >= meta.endSeconds - 0.1 && video.currentTime < meta.endSeconds + 1) {
+                      if (video.currentTime >= meta.endSeconds) {
                         video.currentTime = meta.startSeconds;
                         video.play().catch(() => { });
                       }

--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -125,7 +125,6 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
           const distance = Math.abs(index - currentIndex);
           const shouldLoad = distance <= PRELOAD_RANGE;
           // Only preload the current video aggressively
-          const preload = index === currentIndex ? 'auto' : 'metadata';
           const meta = sceneMeta[index];
 
           return (

--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -57,8 +57,8 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
     const video = videoRef.current;
     if (!video || !currentMeta) return;
 
-    // With media fragments, video starts at 0 (relative to fragment start)
-    video.currentTime = 0;
+    // Set to start time of the scene
+    video.currentTime = currentMeta.startSeconds;
     video.play().catch(() => {
       // Fallback: try muted
       video.muted = true;
@@ -92,8 +92,8 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
       video.src = currentMeta.src;
       video.load();
     }
-    // With media fragments, video starts at 0 (relative to fragment start)
-    video.currentTime = 0;
+    // Set to start time of the scene
+    video.currentTime = currentMeta.startSeconds;
     video.muted = isMuted;
 
     video.play().catch(() => { });
@@ -230,11 +230,9 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
     const video = videoRef.current;
     if (!video || !currentMeta) return;
 
-    // With media fragments, the duration is (endSeconds - startSeconds)
-    // Video time is relative to fragment start (0 = startSeconds)
-    const fragmentDuration = currentMeta.endSeconds - currentMeta.startSeconds;
-    if (video.currentTime >= fragmentDuration) {
-      video.currentTime = 0;
+    // Loop back to start when reaching end time
+    if (video.currentTime >= currentMeta.endSeconds) {
+      video.currentTime = currentMeta.startSeconds;
       video.play().catch(() => { });
     }
   }, [currentMeta]);
@@ -244,8 +242,10 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
     const video = videoRef.current;
     if (!video || !currentMeta) return;
 
-    // With media fragments, video should start at 0
-    video.currentTime = 0;
+    // Ensure video starts at the correct position
+    if (video.currentTime < currentMeta.startSeconds || video.currentTime > currentMeta.endSeconds) {
+      video.currentTime = currentMeta.startSeconds;
+    }
   }, [currentMeta]);
 
   if (scenes.length === 0) {

--- a/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
@@ -188,43 +188,43 @@ describe('ShortsPlayer', () => {
     expect(video?.preload).toBe('auto')
   })
 
-  it('should set currentTime to 0 on loadedMetadata (media fragment relative)', () => {
+  it('should set currentTime to startSeconds on loadedMetadata', () => {
     render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
 
     const video = document.querySelector('video')!
-    Object.defineProperty(video, 'currentTime', { value: 10, writable: true })
+    Object.defineProperty(video, 'currentTime', { value: 0, writable: true })
 
     fireEvent.loadedMetadata(video)
 
-    // With media fragments, video starts at 0 (relative to fragment start)
-    expect(video.currentTime).toBe(0)
+    // start_time 00:01:00 = 60s
+    expect(video.currentTime).toBe(60)
   })
 
-  it('should loop and call play() when reaching fragment duration', () => {
+  it('should loop and call play() when reaching end_time', () => {
     render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
 
     const video = document.querySelector('video')!
-    // Fragment duration = 120 - 60 = 60s
-    Object.defineProperty(video, 'currentTime', { value: 60, writable: true })
+    // end_time 00:02:00 = 120s
+    Object.defineProperty(video, 'currentTime', { value: 120, writable: true })
 
     fireEvent.timeUpdate(video)
 
-    // Should seek back to 0 (start of fragment) and call play()
-    expect(video.currentTime).toBe(0)
+    // Should seek back to start_time (60s) and call play()
+    expect(video.currentTime).toBe(60)
     expect(video.play).toHaveBeenCalled()
   })
 
-  it('should not loop when currentTime is before fragment duration', () => {
+  it('should not loop when currentTime is before end_time', () => {
     render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
 
     const video = document.querySelector('video')!
-    // Fragment duration = 60s, current time = 30s (still playing)
-    Object.defineProperty(video, 'currentTime', { value: 30, writable: true })
+    // current time = 90s (still between start 60s and end 120s)
+    Object.defineProperty(video, 'currentTime', { value: 90, writable: true })
 
     fireEvent.timeUpdate(video)
 
     // Should not change currentTime
-    expect(video.currentTime).toBe(30)
+    expect(video.currentTime).toBe(90)
   })
 
   it('should disconnect IntersectionObserver on unmount', async () => {

--- a/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
@@ -43,16 +43,6 @@ const mockScenes: PopularScene[] = [
   },
 ]
 
-const createManyScenes = (count: number): PopularScene[] =>
-  Array.from({ length: count }, (_, i) => ({
-    video_id: i + 1,
-    title: `Test Video ${i + 1}`,
-    start_time: '00:01:00',
-    end_time: '00:02:00',
-    reference_count: count - i,
-    file: `videos/${i + 1}/test.mp4`,
-  }))
-
 describe('ShortsPlayer', () => {
   const mockOnClose = vi.fn()
 

--- a/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
@@ -186,23 +186,23 @@ describe('ShortsPlayer', () => {
     expect(spinners.length).toBe(3)
   })
 
-  it('should include media fragment #t= in video src', () => {
+  it('should not include media fragment #t= in video src', () => {
     render(<ShortsPlayer scenes={mockScenes} onClose={mockOnClose} />)
 
     const video = document.querySelector('video')
     expect(video).not.toBeNull()
     // start_time 00:01:00 = 60s, end_time 00:02:00 = 120s
-    expect(video!.src).toContain('#t=60,120')
+    expect(video!.src).not.toContain('#t=60,120')
   })
 
-  it('should set preload="auto" for current and ±1, "metadata" for ±2', () => {
+  it('should set preload="auto" for current only, "metadata" for others', () => {
     const scenes = createManyScenes(6)
     render(<ShortsPlayer scenes={scenes} onClose={mockOnClose} />)
 
     const videos = document.querySelectorAll('video')
-    // currentIndex=0: index 0 (current) → auto, index 1 (±1) → auto, index 2 (±2) → metadata
+    // currentIndex=0: index 0 (current) → auto, others → metadata
     expect(videos[0].preload).toBe('auto')
-    expect(videos[1].preload).toBe('auto')
+    expect(videos[1].preload).toBe('metadata')
     expect(videos[2].preload).toBe('metadata')
   })
 

--- a/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
@@ -195,14 +195,14 @@ describe('ShortsPlayer', () => {
     expect(video!.src).not.toContain('#t=60,120')
   })
 
-  it('should set preload="auto" for current only, "metadata" for others', () => {
+  it('should set preload="auto" for current and next video, "metadata" for others', () => {
     const scenes = createManyScenes(6)
     render(<ShortsPlayer scenes={scenes} onClose={mockOnClose} />)
 
     const videos = document.querySelectorAll('video')
-    // currentIndex=0: index 0 (current) → auto, others → metadata
+    // currentIndex=0: index 0 (current) → auto, index 1 (next) → auto, others → metadata
     expect(videos[0].preload).toBe('auto')
-    expect(videos[1].preload).toBe('metadata')
+    expect(videos[1].preload).toBe('auto')
     expect(videos[2].preload).toBe('metadata')
   })
 

--- a/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx
@@ -174,16 +174,16 @@ describe('ShortsPlayer', () => {
   // --- New tests for lazy loading, media fragments, and loop fix ---
 
   it('should only render video elements within PRELOAD_RANGE', () => {
-    const scenes = createManyScenes(6)
+    const scenes = createManyScenes(10)
     render(<ShortsPlayer scenes={scenes} onClose={mockOnClose} />)
 
-    // currentIndex=0, PRELOAD_RANGE=2 → indices 0, 1, 2 should have <video>
+    // currentIndex=0, PRELOAD_RANGE=5 → indices 0-5 should have <video>
     const videos = document.querySelectorAll('video')
-    expect(videos.length).toBe(3)
+    expect(videos.length).toBe(6)
 
-    // Indices 3, 4, 5 should show loading placeholder (animate-spin)
+    // Indices 6-9 should show loading placeholder (animate-spin)
     const spinners = document.querySelectorAll('.animate-spin')
-    expect(spinners.length).toBe(3)
+    expect(spinners.length).toBe(4)
   })
 
   it('should not include media fragment #t= in video src', () => {
@@ -195,15 +195,15 @@ describe('ShortsPlayer', () => {
     expect(video!.src).not.toContain('#t=60,120')
   })
 
-  it('should set preload="auto" for current and next video, "metadata" for others', () => {
+  it('should set preload="auto" for all videos within range', () => {
     const scenes = createManyScenes(6)
     render(<ShortsPlayer scenes={scenes} onClose={mockOnClose} />)
 
     const videos = document.querySelectorAll('video')
-    // currentIndex=0: index 0 (current) → auto, index 1 (next) → auto, others → metadata
-    expect(videos[0].preload).toBe('auto')
-    expect(videos[1].preload).toBe('auto')
-    expect(videos[2].preload).toBe('metadata')
+    // PRELOAD_RANGE=5: all 6 videos are within range, all use preload="auto"
+    videos.forEach((video) => {
+      expect(video.preload).toBe('auto')
+    })
   })
 
   it('should set currentTime on loadedMetadata', () => {

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -513,6 +513,7 @@
   "shorts": {
     "button": "Review Shorts",
     "noScenes": "No scenes to display",
-    "referenceCount": "{{count}} references"
+    "referenceCount": "{{count}} references",
+    "tapToPlay": "Tap to play"
   }
 }

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -519,6 +519,7 @@
   "shorts": {
     "button": "復習ショート",
     "noScenes": "表示するシーンがありません",
-    "referenceCount": "{{count}}回参照"
+    "referenceCount": "{{count}}回参照",
+    "tapToPlay": "タップして再生"
   }
 }


### PR DESCRIPTION
Fix mobile playback issues by removing media fragments from URL and optimizing preload strategy to reduce bandwidth usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tap-to-play overlay with play icon, click-to-play, mute toggle and close controls; updated counter display and iOS inline playback tweaks.
  * Added localized "Tap to play" strings (English, Japanese).

* **Bug Fixes**
  * Improved playback start/looping to respect scene start/end and resume after gestures.
  * More reliable scroll detection for correct playback.

* **Performance**
  * Preloads next scene and consolidates rendering to a single video element to reduce overhead.

* **Tests**
  * Updated tests for single-video rendering, overlay behavior, preload and loop timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->