### PR TITLE
Rename 'Review Shorts' to 'Short Videos'

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -511,7 +511,7 @@
     }
   },
   "shorts": {
-    "button": "Review Shorts",
+    "button": "Short Videos",
     "noScenes": "No scenes to display",
     "referenceCount": "{{count}} references",
     "tapToPlay": "Tap to play"

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -517,7 +517,7 @@
     }
   },
   "shorts": {
-    "button": "復習ショート",
+    "button": "ショート動画",
     "noScenes": "表示するシーンがありません",
     "referenceCount": "{{count}}回参照",
     "tapToPlay": "タップして再生"


### PR DESCRIPTION
Renamed 'Review Shorts' to 'Short Videos' in English and '復習ショート' to 'ショート動画' in Japanese translation files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated button label text for the shorts feature in English and Japanese locales to improve clarity and consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->