### PR TITLE
fix: resolve logout not clearing cookies

### DIFF
--- a/backend/app/auth/views.py
+++ b/backend/app/auth/views.py
@@ -117,12 +117,10 @@ class LogoutView(AuthenticatedAPIView):
         response.delete_cookie(
             key="access_token",
             samesite=samesite_value,
-            secure=settings.SECURE_COOKIES,
         )
         response.delete_cookie(
             key="refresh_token",
             samesite=samesite_value,
-            secure=settings.SECURE_COOKIES,
         )
 
         return response

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -16,8 +16,8 @@ export function Header({ children }: HeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const { t } = useTranslation();
 
-  const handleLogout = () => {
-    apiClient.logout();
+  const handleLogout = async () => {
+    await apiClient.logout();
     navigate('/login');
   };
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -17,8 +17,13 @@ export function Header({ children }: HeaderProps) {
   const { t } = useTranslation();
 
   const handleLogout = async () => {
-    await apiClient.logout();
-    navigate('/login');
+    try {
+      await apiClient.logout();
+    } catch (error) {
+      console.error('Logout failed:', error);
+    } finally {
+      navigate('/login');
+    }
   };
 
   const toggleMobileMenu = () => {


### PR DESCRIPTION
## Summary
- Django の `delete_cookie()` に無効な `secure` パラメータを渡していたことで `TypeError` が発生し、ログアウトAPIが毎回500エラーを返していた問題を修正
- フロントエンドの `handleLogout` で `apiClient.logout()` を `await` していなかった問題を修正

## Test plan
- [x] バックエンドのログアウトテスト通過確認済み (`app.auth.tests.test_views.LogoutViewTests`)
- [x] フロントエンドの全テスト通過確認済み (49ファイル, 435テスト)
- [x] ブラウザでログアウト後にCookie (`access_token`, `refresh_token`) が削除されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logout now waits for the logout request to complete and always redirects to the login page, improving reliability.
  * Adjusted cookie handling during logout for improved compatibility and behavior across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->