### PR TITLE
feat: ショート動画に質問をフラッシュカード表示

### DIFF
--- a/backend/app/chat/services/tests/test_llm.py
+++ b/backend/app/chat/services/tests/test_llm.py
@@ -25,7 +25,9 @@ class GetLangchainLLMTests(TestCase):
         )
 
     @patch("app.chat.services.llm.ChatOpenAI")
-    @override_settings(LLM_PROVIDER="openai", OPENAI_API_KEY="test-api-key", LLM_MODEL="gpt-4o-mini")
+    @override_settings(
+        LLM_PROVIDER="openai", OPENAI_API_KEY="test-api-key", LLM_MODEL="gpt-4o-mini"
+    )
     def test_get_langchain_llm_with_api_key(self, mock_chat_openai):
         """Test get_langchain_llm when API key is configured via environment"""
         llm, error_response = get_langchain_llm(self.user)
@@ -39,7 +41,9 @@ class GetLangchainLLMTests(TestCase):
         )
 
     @patch("app.chat.services.llm.ChatOpenAI")
-    @override_settings(LLM_PROVIDER="openai", OPENAI_API_KEY="test-api-key", LLM_MODEL="gpt-4o")
+    @override_settings(
+        LLM_PROVIDER="openai", OPENAI_API_KEY="test-api-key", LLM_MODEL="gpt-4o"
+    )
     def test_get_langchain_llm_with_custom_model(self, mock_chat_openai):
         """Test get_langchain_llm with custom LLM model from environment"""
         llm, error_response = get_langchain_llm(self.user)
@@ -52,7 +56,9 @@ class GetLangchainLLMTests(TestCase):
             temperature=0.0,
         )
 
-    @override_settings(LLM_PROVIDER="openai", OPENAI_API_KEY="", LLM_MODEL="gpt-4o-mini")
+    @override_settings(
+        LLM_PROVIDER="openai", OPENAI_API_KEY="", LLM_MODEL="gpt-4o-mini"
+    )
     @patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False)
     def test_get_langchain_llm_without_api_key(self):
         """Test get_langchain_llm when API key is not configured"""
@@ -63,7 +69,9 @@ class GetLangchainLLMTests(TestCase):
         self.assertEqual(error_response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("OPENAI_API_KEY", str(error_response.data))
 
-    @override_settings(LLM_PROVIDER="openai", OPENAI_API_KEY=None, LLM_MODEL="gpt-4o-mini")
+    @override_settings(
+        LLM_PROVIDER="openai", OPENAI_API_KEY=None, LLM_MODEL="gpt-4o-mini"
+    )
     @patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False)
     def test_get_langchain_llm_with_none_api_key(self):
         """Test get_langchain_llm when API key is None"""

--- a/backend/app/migrations/0013_alter_user_options_alter_chatlog_created_at_and_more.py
+++ b/backend/app/migrations/0013_alter_user_options_alter_chatlog_created_at_and_more.py
@@ -6,143 +6,219 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('app', '0012_remove_user_llm_settings'),
-        ('auth', '0012_alter_user_first_name_max_length'),
+        ("app", "0012_remove_user_llm_settings"),
+        ("auth", "0012_alter_user_first_name_max_length"),
     ]
 
     operations = [
         migrations.AlterModelOptions(
-            name='user',
+            name="user",
             options={},
         ),
         migrations.AlterField(
-            model_name='chatlog',
-            name='created_at',
+            model_name="chatlog",
+            name="created_at",
             field=models.DateTimeField(auto_now_add=True, db_index=True),
         ),
         migrations.AlterField(
-            model_name='chatlog',
-            name='feedback',
-            field=models.CharField(blank=True, choices=[('good', 'Good'), ('bad', 'Bad')], db_index=True, help_text='Feedback on the answer (good/bad)', max_length=4, null=True),
+            model_name="chatlog",
+            name="feedback",
+            field=models.CharField(
+                blank=True,
+                choices=[("good", "Good"), ("bad", "Bad")],
+                db_index=True,
+                help_text="Feedback on the answer (good/bad)",
+                max_length=4,
+                null=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='chatlog',
-            name='is_shared_origin',
+            model_name="chatlog",
+            name="is_shared_origin",
             field=models.BooleanField(db_index=True, default=False),
         ),
         migrations.AlterField(
-            model_name='tag',
-            name='created_at',
+            model_name="tag",
+            name="created_at",
             field=models.DateTimeField(auto_now_add=True, db_index=True),
         ),
         migrations.AlterField(
-            model_name='tag',
-            name='name',
-            field=models.CharField(db_index=True, help_text='Tag name', max_length=50),
+            model_name="tag",
+            name="name",
+            field=models.CharField(db_index=True, help_text="Tag name", max_length=50),
         ),
         migrations.AlterField(
-            model_name='user',
-            name='video_limit',
-            field=models.PositiveIntegerField(blank=True, db_index=True, default=0, help_text='Maximum number of videos user can upload. 0 means no uploads allowed, null means unlimited.', null=True),
+            model_name="user",
+            name="video_limit",
+            field=models.PositiveIntegerField(
+                blank=True,
+                db_index=True,
+                default=0,
+                help_text="Maximum number of videos user can upload. 0 means no uploads allowed, null means unlimited.",
+                null=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='video',
-            name='external_id',
-            field=models.CharField(blank=True, db_index=True, help_text='ID from external LMS (e.g., Moodle cm_id, Canvas content_id)', max_length=255, null=True, unique=True),
+            model_name="video",
+            name="external_id",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                help_text="ID from external LMS (e.g., Moodle cm_id, Canvas content_id)",
+                max_length=255,
+                null=True,
+                unique=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='video',
-            name='status',
-            field=models.CharField(choices=[('pending', 'Pending'), ('processing', 'Processing'), ('completed', 'Completed'), ('error', 'Error')], db_index=True, default='pending', max_length=20),
+            model_name="video",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("pending", "Pending"),
+                    ("processing", "Processing"),
+                    ("completed", "Completed"),
+                    ("error", "Error"),
+                ],
+                db_index=True,
+                default="pending",
+                max_length=20,
+            ),
         ),
         migrations.AlterField(
-            model_name='video',
-            name='uploaded_at',
+            model_name="video",
+            name="uploaded_at",
             field=models.DateTimeField(auto_now_add=True, db_index=True),
         ),
         migrations.AlterField(
-            model_name='videogroup',
-            name='created_at',
+            model_name="videogroup",
+            name="created_at",
             field=models.DateTimeField(auto_now_add=True, db_index=True),
         ),
         migrations.AlterField(
-            model_name='videogroup',
-            name='share_token',
-            field=models.CharField(blank=True, db_index=True, help_text='Share token', max_length=64, null=True, unique=True),
+            model_name="videogroup",
+            name="share_token",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                help_text="Share token",
+                max_length=64,
+                null=True,
+                unique=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='videogroupmember',
-            name='added_at',
+            model_name="videogroupmember",
+            name="added_at",
             field=models.DateTimeField(auto_now_add=True, db_index=True),
         ),
         migrations.AlterField(
-            model_name='videogroupmember',
-            name='order',
-            field=models.IntegerField(db_index=True, default=0, help_text='Order within the group'),
+            model_name="videogroupmember",
+            name="order",
+            field=models.IntegerField(
+                db_index=True, default=0, help_text="Order within the group"
+            ),
         ),
         migrations.AlterField(
-            model_name='videotag',
-            name='added_at',
+            model_name="videotag",
+            name="added_at",
             field=models.DateTimeField(auto_now_add=True, db_index=True),
         ),
         migrations.AddIndex(
-            model_name='chatlog',
-            index=models.Index(fields=['user', '-created_at'], name='app_chatlog_user_id_727742_idx'),
+            model_name="chatlog",
+            index=models.Index(
+                fields=["user", "-created_at"], name="app_chatlog_user_id_727742_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='chatlog',
-            index=models.Index(fields=['group', '-created_at'], name='app_chatlog_group_i_4bc6d0_idx'),
+            model_name="chatlog",
+            index=models.Index(
+                fields=["group", "-created_at"], name="app_chatlog_group_i_4bc6d0_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='chatlog',
-            index=models.Index(condition=models.Q(('feedback__isnull', False)), fields=['feedback'], name='chatlog_feedback_idx'),
+            model_name="chatlog",
+            index=models.Index(
+                condition=models.Q(("feedback__isnull", False)),
+                fields=["feedback"],
+                name="chatlog_feedback_idx",
+            ),
         ),
         migrations.AddIndex(
-            model_name='tag',
-            index=models.Index(fields=['user', 'name'], name='app_tag_user_id_b053bd_idx'),
+            model_name="tag",
+            index=models.Index(
+                fields=["user", "name"], name="app_tag_user_id_b053bd_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='user',
-            index=models.Index(fields=['email', 'is_active'], name='app_user_email_a838b5_idx'),
+            model_name="user",
+            index=models.Index(
+                fields=["email", "is_active"], name="app_user_email_a838b5_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='user',
-            index=models.Index(fields=['date_joined', '-id'], name='app_user_date_jo_c41876_idx'),
+            model_name="user",
+            index=models.Index(
+                fields=["date_joined", "-id"], name="app_user_date_jo_c41876_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='video',
-            index=models.Index(fields=['user', 'status', '-uploaded_at'], name='app_video_user_id_9c7398_idx'),
+            model_name="video",
+            index=models.Index(
+                fields=["user", "status", "-uploaded_at"],
+                name="app_video_user_id_9c7398_idx",
+            ),
         ),
         migrations.AddIndex(
-            model_name='video',
-            index=models.Index(fields=['user', 'title'], name='app_video_user_id_d60748_idx'),
+            model_name="video",
+            index=models.Index(
+                fields=["user", "title"], name="app_video_user_id_d60748_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='video',
-            index=models.Index(condition=models.Q(('external_id__isnull', False)), fields=['external_id'], name='video_external_id_idx'),
+            model_name="video",
+            index=models.Index(
+                condition=models.Q(("external_id__isnull", False)),
+                fields=["external_id"],
+                name="video_external_id_idx",
+            ),
         ),
         migrations.AddIndex(
-            model_name='videogroup',
-            index=models.Index(fields=['user', '-created_at'], name='app_videogr_user_id_28e91c_idx'),
+            model_name="videogroup",
+            index=models.Index(
+                fields=["user", "-created_at"], name="app_videogr_user_id_28e91c_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='videogroup',
-            index=models.Index(condition=models.Q(('share_token__isnull', False)), fields=['share_token'], name='videogroup_share_token_idx'),
+            model_name="videogroup",
+            index=models.Index(
+                condition=models.Q(("share_token__isnull", False)),
+                fields=["share_token"],
+                name="videogroup_share_token_idx",
+            ),
         ),
         migrations.AddIndex(
-            model_name='videogroupmember',
-            index=models.Index(fields=['group', 'order'], name='app_videogr_group_i_d0eb57_idx'),
+            model_name="videogroupmember",
+            index=models.Index(
+                fields=["group", "order"], name="app_videogr_group_i_d0eb57_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='videogroupmember',
-            index=models.Index(fields=['video', 'group'], name='app_videogr_video_i_f96db2_idx'),
+            model_name="videogroupmember",
+            index=models.Index(
+                fields=["video", "group"], name="app_videogr_video_i_f96db2_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='videotag',
-            index=models.Index(fields=['video', 'tag'], name='app_videota_video_i_3d974b_idx'),
+            model_name="videotag",
+            index=models.Index(
+                fields=["video", "tag"], name="app_videota_video_i_3d974b_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='videotag',
-            index=models.Index(fields=['tag', '-added_at'], name='app_videota_tag_id_94f309_idx'),
+            model_name="videotag",
+            index=models.Index(
+                fields=["tag", "-added_at"], name="app_videota_tag_id_94f309_idx"
+            ),
         ),
     ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,18 +1,13 @@
 # Re-export all models for backward compatibility
+# Import signals to ensure they're registered
+from . import signals  # noqa: F401
 from .chat import ChatLog
-from .storage import (
-    SafeFileSystemStorage,
-    SafeFilenameMixin,
-    SafeS3Boto3Storage,
-    get_default_storage,
-)
+from .storage import (SafeFilenameMixin, SafeFileSystemStorage,
+                      SafeS3Boto3Storage, get_default_storage)
 from .tag import Tag, VideoTag
 from .user import User
 from .video import Video, user_directory_path
 from .video_group import VideoGroup, VideoGroupMember
-
-# Import signals to ensure they're registered
-from . import signals  # noqa: F401
 
 __all__ = [
     "User",

--- a/backend/app/models/storage.py
+++ b/backend/app/models/storage.py
@@ -13,11 +13,11 @@ class SafeFilenameMixin:
     def get_available_name(self, name, max_length=None):
         """
         Generate a timestamp-based safe filename, preserve any directory path, and delegate duplicate resolution to the parent storage.
-        
+
         Parameters:
             name (str): Original filename or path. Absolute paths are reduced to the basename.
             max_length (int | None): Optional maximum length for the resulting name; passed through to the parent implementation.
-        
+
         Returns:
             available_name (str): A safe filename in the form `video_<timestamp><extension>` (preserving the original directory if present), potentially modified by the parent storage to avoid naming collisions.
         """
@@ -40,10 +40,10 @@ class SafeFilenameMixin:
     def _get_safe_filename(self, filename):
         """
         Generate a timestamp-based safe filename preserving the original file extension.
-        
+
         Parameters:
             filename (str): Original filename from which the file extension will be preserved.
-        
+
         Returns:
             str: A new filename in the format "video_<timestamp><extension>" where <timestamp> is the current time in milliseconds since the epoch and <extension> is the original file's extension (including the leading dot, if any).
         """
@@ -75,10 +75,10 @@ class SafeS3Boto3Storage(SafeFilenameMixin, S3Boto3Storage):
     def _normalize_name(self, name):
         """
         Normalize a storage name for S3 by converting backslashes to forward slashes and removing a leading slash.
-        
+
         Parameters:
             name (str): The file path or key to normalize; may contain Windows-style backslashes or a leading slash.
-        
+
         Returns:
             str: The normalized storage key with forward slashes and no leading slash, after parent normalization is applied.
         """
@@ -96,9 +96,9 @@ class SafeS3Boto3Storage(SafeFilenameMixin, S3Boto3Storage):
 def get_default_storage():
     """
     Retrieve the project's configured default file storage backend.
-    
+
     This is the storage instance configured via Django's STORAGES setting (django.core.files.storage.default_storage).
-    
+
     Returns:
         The configured storage backend instance.
     """

--- a/backend/app/models/tag.py
+++ b/backend/app/models/tag.py
@@ -27,7 +27,7 @@ class Tag(models.Model):
     def __str__(self):
         """
         Return a human-readable representation of the tag including its creator.
-        
+
         Returns:
             str: Formatted string "<name> (by <username>)" where <username> is the related user's
             username or "user_<user_id>" if the related user object lacks a `username` attribute.
@@ -59,7 +59,7 @@ class VideoTag(models.Model):
     def __str__(self):
         """
         Provide a human-readable representation of this VideoTag combining the tag name and video title.
-        
+
         Returns:
             str: A string in the format "<tag_name> on <video_title>". If the related Tag or Video is missing, `tag_<tag_id>` or `video_<video_id>` is used respectively.
         """

--- a/backend/app/models/video.py
+++ b/backend/app/models/video.py
@@ -7,11 +7,11 @@ from .storage import get_default_storage
 def user_directory_path(instance, filename):
     """
     Builds the upload path for a video's file using the video's user's id.
-    
+
     Parameters:
         instance: Model instance that has a related `user` attribute with an `id`.
         filename: Original filename of the uploaded file.
-    
+
     Returns:
         The file path where the video should be stored, formatted as "videos/{user_id}/{filename}".
     """
@@ -71,9 +71,9 @@ class Video(models.Model):
     def __str__(self):
         """
         Return a human-readable representation of the Video combining its title and uploader.
-        
+
         If the related user has a `username` attribute, that username is used; otherwise the uploader is represented as `user_{user_id}`.
-        
+
         Returns:
             str: A string formatted as "{title} (by {username})".
         """

--- a/backend/app/models/video_group.py
+++ b/backend/app/models/video_group.py
@@ -43,9 +43,9 @@ class VideoGroup(models.Model):
     def __str__(self):
         """
         Return a human-readable representation of the VideoGroup including its name and owner's identifier.
-        
+
         If the related user has a `username` attribute that can be accessed, that username is shown; otherwise the owner's numeric ID is used in the form `user_<id>`.
-        
+
         Returns:
             str: Formatted as "<name> (by <username>)" where `<username>` is the owner's username or "user_<user_id>" if username is not available.
         """
@@ -64,7 +64,9 @@ class VideoGroupMember(models.Model):
         "Video", on_delete=models.CASCADE, related_name="groups", db_index=True
     )
     added_at = models.DateTimeField(auto_now_add=True, db_index=True)
-    order = models.IntegerField(default=0, db_index=True, help_text="Order within the group")
+    order = models.IntegerField(
+        default=0, db_index=True, help_text="Order within the group"
+    )
 
     class Meta:
         ordering = ["order", "added_at"]
@@ -80,9 +82,9 @@ class VideoGroupMember(models.Model):
     def __str__(self):
         """
         Provide a human-readable representation of the membership showing the video title and group name.
-        
+
         The string is formatted as "<video_title> in <group_name>". If the related Video or VideoGroup is unavailable or lacks a title/name, the method falls back to "video_{video_id}" or "group_{group_id}" respectively.
-        
+
         Returns:
             str: The formatted membership representation.
         """

--- a/backend/app/tasks/tests/test_audio_processing.py
+++ b/backend/app/tasks/tests/test_audio_processing.py
@@ -265,9 +265,7 @@ class ExtractAndSplitAudioTests(TestCase):
         mock_extract.return_value = ("/tmp/audio.mp3", 20.0)
 
         with TemporaryFileManager() as temp_manager:
-            extract_and_split_audio(
-                "/path/to/video.mp4", temp_manager=temp_manager
-            )
+            extract_and_split_audio("/path/to/video.mp4", temp_manager=temp_manager)
 
             self.assertEqual(len(temp_manager.temp_files), 1)
             self.assertEqual(temp_manager.temp_files[0], "/tmp/audio.mp3")

--- a/backend/app/tasks/tests/test_transcription.py
+++ b/backend/app/tasks/tests/test_transcription.py
@@ -78,7 +78,7 @@ class DownloadVideoFromStorageTests(TestCase):
     def test_attribute_error_triggers_download(self):
         """Test that AttributeError on path also triggers download"""
         with TemporaryFileManager() as temp_manager:
-            mock_file = MagicMock(spec=['name', 'open'])
+            mock_file = MagicMock(spec=["name", "open"])
             mock_file.name = "test_video.mp4"
 
             mock_remote_content = b"fake video content"
@@ -87,7 +87,12 @@ class DownloadVideoFromStorageTests(TestCase):
             )
             mock_file.open.return_value.__exit__ = MagicMock(return_value=False)
 
-            with patch.object(type(self.video), 'file', new_callable=PropertyMock, return_value=mock_file):
+            with patch.object(
+                type(self.video),
+                "file",
+                new_callable=PropertyMock,
+                return_value=mock_file,
+            ):
                 with patch("builtins.open", MagicMock()):
                     path, file_obj = download_video_from_storage(
                         self.video, self.video.id, temp_manager
@@ -205,7 +210,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
-    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
+    @patch(
+        "app.tasks.transcription.VideoTaskManager.validate_video_for_processing",
+        return_value=(True, None),
+    )
     def test_successful_transcription_pipeline(
         self,
         mock_validate,
@@ -245,7 +253,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
-    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
+    @patch(
+        "app.tasks.transcription.VideoTaskManager.validate_video_for_processing",
+        return_value=(True, None),
+    )
     def test_handles_empty_audio_segments(
         self,
         mock_validate,
@@ -278,7 +289,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
-    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
+    @patch(
+        "app.tasks.transcription.VideoTaskManager.validate_video_for_processing",
+        return_value=(True, None),
+    )
     def test_handles_transcription_failure(
         self,
         mock_validate,
@@ -322,7 +336,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
-    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
+    @patch(
+        "app.tasks.transcription.VideoTaskManager.validate_video_for_processing",
+        return_value=(True, None),
+    )
     def test_external_id_triggers_file_cleanup(
         self,
         mock_validate,
@@ -364,7 +381,10 @@ class TranscribeVideoTaskTests(TestCase):
     @patch("app.tasks.transcription.create_whisper_client")
     @patch("app.tasks.transcription.get_whisper_model_name")
     @patch("app.tasks.transcription.WhisperConfig")
-    @patch("app.tasks.transcription.VideoTaskManager.validate_video_for_processing", return_value=(True, None))
+    @patch(
+        "app.tasks.transcription.VideoTaskManager.validate_video_for_processing",
+        return_value=(True, None),
+    )
     def test_no_external_id_keeps_file(
         self,
         mock_validate,

--- a/backend/app/tasks/tests/test_vector_indexing.py
+++ b/backend/app/tasks/tests/test_vector_indexing.py
@@ -8,11 +8,9 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from app.models import Video
-from app.tasks.vector_indexing import (
-    create_scene_metadata,
-    index_scenes_batch,
-    index_scenes_to_vectorstore,
-)
+from app.tasks.vector_indexing import (create_scene_metadata,
+                                       index_scenes_batch,
+                                       index_scenes_to_vectorstore)
 
 User = get_user_model()
 

--- a/backend/app/utils/tests/test_vector_manager.py
+++ b/backend/app/utils/tests/test_vector_manager.py
@@ -7,12 +7,9 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
-from app.utils.vector_manager import (
-    PGVectorManager,
-    delete_all_vectors,
-    delete_video_vectors,
-    update_video_title_in_vectors,
-)
+from app.utils.vector_manager import (PGVectorManager, delete_all_vectors,
+                                      delete_video_vectors,
+                                      update_video_title_in_vectors)
 
 
 class PGVectorManagerTests(TestCase):

--- a/backend/app/utils/vector_manager.py
+++ b/backend/app/utils/vector_manager.py
@@ -153,7 +153,9 @@ def update_video_title_in_vectors(video_id, new_title):
                     to_jsonb(%s::text)
                 )
                 WHERE video_id = %s
-                """.format(table),
+                """.format(
+                    table
+                ),
                 [new_title, int(video_id)],
             )
             updated_count = cursor.rowcount

--- a/backend/app/video/tests/test_nplusone.py
+++ b/backend/app/video/tests/test_nplusone.py
@@ -1,18 +1,20 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
-from rest_framework.test import APIClient
 from rest_framework import status
-from app.models import Video, Tag, VideoTag, VideoGroup, VideoGroupMember
+from rest_framework.test import APIClient
+
+from app.models import Tag, Video, VideoGroup, VideoGroupMember, VideoTag
 
 User = get_user_model()
+
 
 class NPlusOneTestCase(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="test", password="password")
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
-        
+
         # Create tags
         self.tag1 = Tag.objects.create(user=self.user, name="Tag1", color="#000000")
         self.tag2 = Tag.objects.create(user=self.user, name="Tag2", color="#ffffff")
@@ -20,19 +22,17 @@ class NPlusOneTestCase(TestCase):
         # Create 5 videos with tags
         for i in range(5):
             video = Video.objects.create(
-                user=self.user,
-                title=f"Video {i}",
-                status="completed"
+                user=self.user, title=f"Video {i}", status="completed"
             )
             VideoTag.objects.create(video=video, tag=self.tag1)
             VideoTag.objects.create(video=video, tag=self.tag2)
 
     def test_video_list_n_plus_one(self):
         url = reverse("video-list")
-        
+
         # 1. Main Video Query (includes User join)
         # 2. VideoTag Query (includes Tag join) - Prefetch
-        with self.assertNumQueries(2): 
+        with self.assertNumQueries(2):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -42,9 +42,9 @@ class NPlusOneTestCase(TestCase):
         videos = Video.objects.all()
         for i, video in enumerate(videos):
             VideoGroupMember.objects.create(group=group, video=video, order=i)
-            
+
         url = reverse("video-group-detail", kwargs={"pk": group.pk})
-        
+
         # Expected queries:
         # 1. VideoGroup Query (includes User join)
         # 2. VideoGroupMember Query (prefetch 'members', joins 'video')
@@ -58,7 +58,7 @@ class NPlusOneTestCase(TestCase):
     def test_tag_detail_n_plus_one(self):
         # Use existing tag
         url = reverse("tag-detail", kwargs={"pk": self.tag1.pk})
-        
+
         # Expected queries:
         # 1. Tag Query (includes video_count, no join needed for user as it is filtered by user?)
         # NOTE: TagDetailView.get_queryset uses:
@@ -72,4 +72,3 @@ class NPlusOneTestCase(TestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(len(response.data["videos"]), 5)
-

--- a/backend/app/video/tests/test_serializers.py
+++ b/backend/app/video/tests/test_serializers.py
@@ -13,10 +13,8 @@ from rest_framework.test import APIRequestFactory, force_authenticate
 
 from app.models import Tag, Video, VideoGroup, VideoGroupMember, VideoTag
 from app.video.serializers import (TagCreateSerializer, TagDetailSerializer,
-                                   TagUpdateSerializer,
-                                   VideoCreateSerializer,
-                                   VideoGroupDetailSerializer,
-                                   VideoSerializer)
+                                   TagUpdateSerializer, VideoCreateSerializer,
+                                   VideoGroupDetailSerializer, VideoSerializer)
 
 User = get_user_model()
 

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -379,9 +379,7 @@ OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", DefaultSettings.OLLAMA_BASE_
 # Vector store configuration
 PGVECTOR_COLLECTION_NAME = os.environ.get("PGVECTOR_COLLECTION_NAME", "videoq_scenes")
 
-EMBEDDING_VECTOR_SIZE = int(
-    os.environ.get("EMBEDDING_VECTOR_SIZE", 1536)
-)
+EMBEDDING_VECTOR_SIZE = int(os.environ.get("EMBEDDING_VECTOR_SIZE", 1536))
 
 # LLM configuration
 LLM_PROVIDER = os.environ.get("LLM_PROVIDER", DefaultSettings.LLM_PROVIDER).lower()

--- a/frontend/src/components/shorts/ShortsPlayer.tsx
+++ b/frontend/src/components/shorts/ShortsPlayer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, Volume2, VolumeX, Play } from 'lucide-react';
+import { X, Volume2, VolumeX, Play, MessageCircleQuestion } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { apiClient, type PopularScene } from '@/lib/api';
 import { timeStringToSeconds } from '@/lib/utils/video';
@@ -10,6 +10,8 @@ interface ShortsPlayerProps {
   shareToken?: string;
   onClose: () => void;
 }
+
+type QuestionPhase = 'center' | 'shrinking' | 'top' | 'hidden';
 
 export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps) {
   const { t } = useTranslation();
@@ -22,6 +24,8 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
   const [videoOffset, setVideoOffset] = useState(0);  // For smooth scroll following
   const currentIndexRef = useRef(currentIndex);
   const [isScrolling, setIsScrolling] = useState(false);
+  const [questionPhase, setQuestionPhase] = useState<QuestionPhase>('hidden');
+  const questionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Keep ref in sync
   useEffect(() => {
@@ -51,6 +55,46 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
 
   // Current scene metadata
   const currentMeta = sceneMeta[currentIndex];
+  const currentScene = scenes[currentIndex];
+  const currentQuestion = currentScene?.questions?.[0] || '';
+
+  // Start question flashcard animation sequence
+  const startQuestionAnimation = useCallback(() => {
+    // Clear any existing timer
+    if (questionTimerRef.current) {
+      clearTimeout(questionTimerRef.current);
+    }
+
+    if (!currentQuestion) {
+      setQuestionPhase('hidden');
+      return;
+    }
+
+    // Phase 1: Show question centered
+    setQuestionPhase('center');
+
+    // Phase 2: After 2.5s, shrink to top
+    questionTimerRef.current = setTimeout(() => {
+      setQuestionPhase('shrinking');
+
+      // Phase 3: After shrink animation completes (500ms), set to top
+      questionTimerRef.current = setTimeout(() => {
+        setQuestionPhase('top');
+      }, 500);
+    }, 2500);
+  }, [currentQuestion]);
+
+  // Trigger question animation when slide changes (and not on initial load)
+  useEffect(() => {
+    if (!showPlayOverlay) {
+      startQuestionAnimation();
+    }
+    return () => {
+      if (questionTimerRef.current) {
+        clearTimeout(questionTimerRef.current);
+      }
+    };
+  }, [currentIndex, showPlayOverlay, startQuestionAnimation]);
 
   // Play the current video
   const playCurrentVideo = useCallback(() => {
@@ -263,6 +307,100 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
 
   return (
     <div className="fixed inset-0 z-50 bg-black overflow-hidden">
+      {/* Question Flashcard Overlay */}
+      {currentQuestion && questionPhase !== 'hidden' && (
+        <>
+          {/* Center question (full-screen overlay) */}
+          {questionPhase === 'center' && (
+            <div
+              className="absolute inset-0 z-40 flex items-center justify-center px-8"
+              style={{
+                animation: 'questionFadeIn 0.4s ease-out',
+              }}
+            >
+              <div
+                className="max-w-md w-full p-6 rounded-2xl text-center"
+                style={{
+                  background: 'rgba(0, 0, 0, 0.7)',
+                  backdropFilter: 'blur(20px)',
+                  WebkitBackdropFilter: 'blur(20px)',
+                  border: '1px solid rgba(255, 255, 255, 0.15)',
+                  boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
+                }}
+              >
+                <div className="flex items-center justify-center gap-2 mb-3">
+                  <MessageCircleQuestion className="h-5 w-5 text-blue-400" />
+                  <span className="text-blue-400 text-sm font-medium tracking-wide uppercase">
+                    {t('shorts.question')}
+                  </span>
+                </div>
+                <p className="text-white text-xl font-semibold leading-relaxed">
+                  {currentQuestion}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Shrinking/Top question (persistent badge) */}
+          {(questionPhase === 'shrinking' || questionPhase === 'top') && (
+            <div
+              className="absolute left-4 right-16 z-40"
+              style={{
+                top: questionPhase === 'shrinking' ? undefined : '3.5rem',
+                animation: questionPhase === 'shrinking'
+                  ? 'questionShrinkToTop 0.5s ease-in-out forwards'
+                  : undefined,
+              }}
+            >
+              <div
+                className="inline-flex items-center gap-2 px-3 py-2 rounded-xl max-w-full"
+                style={{
+                  background: 'rgba(0, 0, 0, 0.6)',
+                  backdropFilter: 'blur(12px)',
+                  WebkitBackdropFilter: 'blur(12px)',
+                  border: '1px solid rgba(255, 255, 255, 0.1)',
+                }}
+              >
+                <MessageCircleQuestion className="h-4 w-4 text-blue-400 shrink-0" />
+                <p className="text-white text-sm font-medium truncate">
+                  {currentQuestion}
+                </p>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* CSS Animations */}
+      <style>{`
+        @keyframes questionFadeIn {
+          from {
+            opacity: 0;
+            transform: scale(0.9);
+          }
+          to {
+            opacity: 1;
+            transform: scale(1);
+          }
+        }
+        @keyframes questionShrinkToTop {
+          from {
+            top: 50%;
+            left: 50%;
+            right: auto;
+            transform: translate(-50%, -50%) scale(1);
+            opacity: 0.8;
+          }
+          to {
+            top: 3.5rem;
+            left: 1rem;
+            right: auto;
+            transform: translate(0, 0) scale(1);
+            opacity: 1;
+          }
+        }
+      `}</style>
+
       {/* Single video element that follows scroll */}
       <div
         className="absolute inset-0 flex items-center justify-center pointer-events-none"
@@ -304,7 +442,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
       )}
 
       {/* Controls */}
-      <div className="absolute top-4 right-4 z-30 flex gap-2">
+      <div className="absolute top-4 right-4 z-50 flex gap-2">
         <Button variant="ghost" size="icon" className="text-white hover:bg-white/20" onClick={handleMuteToggle}>
           {isMuted ? <VolumeX className="h-6 w-6" /> : <Volume2 className="h-6 w-6" />}
         </Button>
@@ -332,7 +470,7 @@ export function ShortsPlayer({ scenes, shareToken, onClose }: ShortsPlayerProps)
             className="h-full w-full snap-start snap-always relative flex items-center justify-center"
           >
             {/* Scene info overlay */}
-            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-6 pb-8 pointer-events-none z-20">
+            <div className="absolute bottom-0 left-0 right-0 bg-linear-to-t from-black/80 to-transparent p-6 pb-8 pointer-events-none z-20">
               <h3 className="text-white text-lg font-semibold mb-1 line-clamp-2">{scene.title}</h3>
               <div className="flex items-center gap-4 text-white/70 text-sm">
                 <span>{scene.start_time} - {scene.end_time}</span>

--- a/frontend/src/components/shorts/__tests__/ShortsButton.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsButton.test.tsx
@@ -53,13 +53,14 @@ const mockPopularScenes: PopularScene[] = [
     end_time: '00:02:00',
     reference_count: 5,
     file: 'videos/1/test1.mp4',
+    questions: ['What is the main topic?'],
   },
 ]
 
 describe('ShortsButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(apiClient.getPopularScenes as any).mockResolvedValue(mockPopularScenes)
+      ; (apiClient.getPopularScenes as any).mockResolvedValue(mockPopularScenes)
   })
 
   it('should render button with correct text', () => {
@@ -114,8 +115,8 @@ describe('ShortsButton', () => {
   })
 
   it('should handle API error gracefully on click when prefetch failed', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    ;(apiClient.getPopularScenes as any).mockRejectedValue(new Error('API Error'))
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { })
+      ; (apiClient.getPopularScenes as any).mockRejectedValue(new Error('API Error'))
 
     render(<ShortsButton groupId={1} videos={mockVideos} />)
 
@@ -142,9 +143,9 @@ describe('ShortsButton', () => {
     let resolveSecond: (value: PopularScene[]) => void
     const firstPromise = new Promise<PopularScene[]>((resolve) => { resolveFirst = resolve })
     const secondPromise = new Promise<PopularScene[]>((resolve) => { resolveSecond = resolve })
-    ;(apiClient.getPopularScenes as any)
-      .mockReturnValueOnce(firstPromise)   // prefetch
-      .mockReturnValueOnce(secondPromise)  // click
+      ; (apiClient.getPopularScenes as any)
+        .mockReturnValueOnce(firstPromise)   // prefetch
+        .mockReturnValueOnce(secondPromise)  // click
 
     render(<ShortsButton groupId={1} videos={mockVideos} />)
 

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -514,6 +514,7 @@
     "button": "Short Videos",
     "noScenes": "No scenes to display",
     "referenceCount": "{{count}} references",
-    "tapToPlay": "Tap to play"
+    "tapToPlay": "Tap to play",
+    "question": "Question"
   }
 }

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -520,6 +520,7 @@
     "button": "ショート動画",
     "noScenes": "表示するシーンがありません",
     "referenceCount": "{{count}}回参照",
-    "tapToPlay": "タップして再生"
+    "tapToPlay": "タップして再生",
+    "question": "質問"
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -63,6 +63,7 @@ export interface PopularScene {
   end_time: string;
   reference_count: number;
   file: string | null;
+  questions: string[];
 }
 
 export interface ChatHistoryItem {


### PR DESCRIPTION
## 概要

ショート動画にチャットの質問を表示する機能を追加しました。

## 変更内容

### バックエンド
- `PopularScenesView` が各シーンに紐づく質問を収集・返却するように修正
- `ChatLog` の `question` フィールドから、各シーンに関連する質問を最大3件まで取得
- OpenAPIスキーマに `questions` フィールドを追加

### フロントエンド
- `PopularScene` インターフェースに `questions: string[]` フィールド追加
- `ShortsPlayer` にフラッシュカード式の質問表示を実装:
  1. **中央表示** (2.5秒): 画面中央にガラスモーフィズムカードで質問を大きく表示
  2. **縮小アニメーション** (0.5秒): 中央から画面上部へスムーズに移動
  3. **トップバッジ**: 動画再生中も画面上部に小さく質問を常時表示
- 翻訳キー `shorts.question` を日英両方に追加

### テスト
- バックエンド: 質問収集テスト、最大3件制限テストを追加 (全12件パス ✅)
- フロントエンド: フラッシュカード表示、アニメーション遷移、質問なしケースのテスト追加 (全37件パス ✅)

## 対象ファイル
| ファイル | 変更内容 |
|---|---|
| `backend/app/chat/views.py` | questions フィールド追加 |
| `backend/app/chat/tests/test_views.py` | テスト追加 |
| `frontend/src/lib/api.ts` | PopularScene 型更新 |
| `frontend/src/components/shorts/ShortsPlayer.tsx` | フラッシュカードUI実装 |
| `frontend/src/components/shorts/__tests__/ShortsPlayer.test.tsx` | テスト更新 |
| `frontend/src/components/shorts/__tests__/ShortsButton.test.tsx` | モックデータ更新 |
| `frontend/src/i18n/locales/en/translation.json` | 翻訳追加 |
| `frontend/src/i18n/locales/ja/translation.json` | 翻訳追加 |