### PR TITLE
docs: SECRET_KEY設定手順の追加とドキュメント正確性の改善

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/0
 
 # Django settings
+# SECRET_KEY: Must be set. Generate with:
+#   docker compose run --rm backend python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+SECRET_KEY=
 ALLOWED_HOSTS=localhost,127.0.0.1
 CORS_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1
 SECURE_COOKIES=False

--- a/README.md
+++ b/README.md
@@ -45,9 +45,16 @@ cd videoq
 cp .env.example .env
 ```
 
-`.env` ファイルを編集してOpenAI APIキーを追加：
+`.env` ファイルを編集して必要なキーを設定：
 
 ```bash
+# SECRET_KEYを生成して設定（必須）
+docker compose run --rm backend python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+
+# 生成された値を .env に設定
+SECRET_KEY=生成された値をここに貼り付け
+
+# OpenAI APIキーを設定
 OPENAI_API_KEY=sk-your-key-here
 ```
 

--- a/docs/architecture/system-configuration-diagram.md
+++ b/docs/architecture/system-configuration-diagram.md
@@ -242,7 +242,8 @@ graph TB
             CORS["CORS Settings
             Allowed Origin Restrictions"]
             RateLimit["Rate Limiting
-            API Call Restrictions"]
+            API Call Restrictions
+            (Not yet implemented)"]
         end
     end
 

--- a/docs/design/deployment-diagram.md
+++ b/docs/design/deployment-diagram.md
@@ -214,7 +214,7 @@ graph TB
         E1[POSTGRES_DB]
         E2[POSTGRES_USER]
         E3[POSTGRES_PASSWORD]
-        E4["SECRET_KEY<br/>(recommended; required for production)"]
+        E4["SECRET_KEY<br/>(required)"]
         E5[DATABASE_URL]
         E6[CELERY_BROKER_URL]
         E6b[CELERY_RESULT_BACKEND]


### PR DESCRIPTION
## 概要

SECRET_KEYの設定手順をドキュメントに追加し、既存ドキュメントの記述を現状に合わせて修正します。

## 変更内容

### .env.example
- `SECRET_KEY=` 項目を追加（生成コマンド付き）

### README.md
- クイックスタートのステップ2に SECRET_KEY の生成・設定手順を追加
- これがないとDjangoが起動しないため、セットアップで躓く原因になっていた

### docs/architecture/system-configuration-diagram.md
- Security セクションの Rate Limiting に `(Not yet implemented)` を追記
- 現状未実装の機能が実装済みかのように見えていたのを修正

### docs/design/deployment-diagram.md
- SECRET_KEY の説明を `(recommended; required for production)` → `(required)` に変更