### PR TITLE
fix: add rate limiting to chat API to prevent API cost abuse

### DIFF
--- a/backend/app/chat/views.py
+++ b/backend/app/chat/views.py
@@ -14,6 +14,9 @@ from app.common.authentication import CookieJWTAuthentication
 from app.common.permissions import (IsAuthenticatedOrSharedAccess,
                                     ShareTokenAuthentication)
 from app.common.responses import create_error_response
+from app.common.throttles import (ChatShareTokenBurstThrottle,
+                                  ChatShareTokenRateThrottle,
+                                  ChatUserRateThrottle)
 from app.models import ChatLog, Video, VideoGroup, VideoGroupMember
 
 from .serializers import (ChatFeedbackRequestSerializer,
@@ -71,6 +74,11 @@ class ChatView(generics.CreateAPIView):
     serializer_class = ChatRequestSerializer
     authentication_classes = [CookieJWTAuthentication, ShareTokenAuthentication]
     permission_classes = [IsAuthenticatedOrSharedAccess]
+    throttle_classes = [
+        ChatUserRateThrottle,
+        ChatShareTokenRateThrottle,
+        ChatShareTokenBurstThrottle,
+    ]
 
     @extend_schema(
         request=ChatRequestSerializer,

--- a/backend/app/common/throttles.py
+++ b/backend/app/common/throttles.py
@@ -1,0 +1,67 @@
+"""
+Rate limiting throttles for API abuse prevention.
+
+Provides differentiated rate limits:
+- Authenticated users get standard limits
+- Share token (anonymous) access gets stricter limits to prevent API cost attacks
+"""
+
+from rest_framework.throttling import SimpleRateThrottle
+
+
+class ChatUserRateThrottle(SimpleRateThrottle):
+    """Rate limit for authenticated chat users."""
+
+    scope = "chat_user"
+    rate = "30/minute"
+
+    def get_cache_key(self, request, view):
+        if request.user and request.user.is_authenticated:
+            return self.cache_format % {
+                "scope": self.scope,
+                "ident": request.user.pk,
+            }
+        return None
+
+
+class ChatShareTokenRateThrottle(SimpleRateThrottle):
+    """
+    Rate limit for share token (anonymous) chat access.
+
+    Prevents API cost attacks where an attacker uses a shared URL
+    to make excessive LLM API calls billed to the group owner.
+    Rate is per share_token + IP combination.
+    """
+
+    scope = "chat_shared"
+    rate = "120/hour"
+
+    def get_cache_key(self, request, view):
+        share_token = request.query_params.get("share_token")
+        if not share_token:
+            return None
+        ident = f"{share_token}_{self.get_ident(request)}"
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": ident,
+        }
+
+
+class ChatShareTokenBurstThrottle(SimpleRateThrottle):
+    """
+    Short-term burst limit for share token access.
+    Prevents rapid-fire requests even within the hourly limit.
+    """
+
+    scope = "chat_shared_burst"
+    rate = "20/minute"
+
+    def get_cache_key(self, request, view):
+        share_token = request.query_params.get("share_token")
+        if not share_token:
+            return None
+        ident = f"{share_token}_{self.get_ident(request)}"
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": ident,
+        }

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -195,6 +195,11 @@ REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",
     ],
+    "DEFAULT_THROTTLE_RATES": {
+        "chat_user": "30/minute",
+        "chat_shared": "120/hour",
+        "chat_shared_burst": "20/minute",
+    },
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "EXCEPTION_HANDLER": "app.common.exceptions.custom_exception_handler",
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,6 +8,10 @@ http {
 
     client_max_body_size 1000M;
 
+    # Rate limit zones
+    limit_req_zone $binary_remote_addr zone=chat_zone:10m rate=20r/m;
+    limit_req_zone $binary_remote_addr zone=auth_zone:10m rate=5r/m;
+
     upstream backend {
         server videoq-backend:8000;
     }
@@ -29,6 +33,30 @@ http {
         location /api/protected_media/ {
             internal;
             alias /media/;
+        }
+
+        # Chat endpoint - strict rate limit (LLM API cost protection)
+        location /api/chat/ {
+            limit_req zone=chat_zone burst=5 nodelay;
+            limit_req_status 429;
+
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Auth endpoints - rate limit to prevent brute force
+        location /api/auth/ {
+            limit_req zone=auth_zone burst=3 nodelay;
+            limit_req_status 429;
+
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         # All API routes to backend (admin, media, auth, etc.)

--- a/nginx.conf
+++ b/nginx.conf
@@ -47,8 +47,20 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # Auth endpoints - rate limit to prevent brute force
-        location /api/auth/ {
+        # Auth login/password-reset - rate limit to prevent brute force
+        # Only targets POST-heavy attack surfaces, not /me or /refresh
+        location /api/auth/login/ {
+            limit_req zone=auth_zone burst=3 nodelay;
+            limit_req_status 429;
+
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /api/auth/password-reset/ {
             limit_req zone=auth_zone burst=3 nodelay;
             limit_req_status 429;
 


### PR DESCRIPTION
## Summary
- Share token（未認証）経由のチャットAPIにレート制限がなく、攻撃者が共有URLを使ってグループオーナーのLLM APIコストを無制限に消費できる脆弱性を修正
- Django DRFスロットル（認証ユーザー: 30回/分、share token: 120回/時 + 20回/分バースト）とNginxレート制限（chat: 20r/m、auth: 5r/m）の2層防御を追加

## Changes
- `backend/app/common/throttles.py` — 3つのカスタムスロットルクラスを新規作成
- `backend/app/chat/views.py` — ChatViewにスロットルを適用
- `backend/videoq/settings.py` — `DEFAULT_THROTTLE_RATES` を追加
- `nginx.conf` — `/api/chat/` と `/api/auth/` にNginxレベルのレート制限を追加

## Test plan
- [x] 既存の全38テスト（chat views）が通ることを確認済み
- [ ] 共有リンクでチャットを連続使用し、制限超過時に429が返ることを確認
- [ ] 認証済みユーザーが通常利用で制限に引っかからないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)