### PR TITLE
feat: add transaction.atomic to ensure data consistency

### DIFF
--- a/backend/app/tasks/transcription.py
+++ b/backend/app/tasks/transcription.py
@@ -8,6 +8,7 @@ import tempfile
 
 from celery import shared_task
 from django.conf import settings
+from django.db import transaction
 
 from app.tasks.audio_processing import extract_and_split_audio
 from app.tasks.srt_processing import (apply_scene_splitting,
@@ -66,6 +67,7 @@ def cleanup_external_upload(video_file, video_id):
         )
 
 
+@transaction.atomic
 def save_transcription_result(video, scene_split_srt):
     """
     Save transcription result

--- a/backend/app/video/tests/test_serializers.py
+++ b/backend/app/video/tests/test_serializers.py
@@ -75,7 +75,8 @@ class VideoCreateSerializerTests(TestCase):
             data=data, context=self._get_request_context()
         )
         self.assertTrue(serializer.is_valid())
-        video = serializer.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            video = serializer.save()
 
         mock_task.assert_called_once_with(video.id)
 


### PR DESCRIPTION
## Summary

- 複数のDB書き込みを伴う操作に `@transaction.atomic` を追加し、部分的な更新によるデータ不整合を防止
- ファイル削除やCeleryタスク発行など、トランザクション外で実行すべき副作用を `transaction.on_commit` に移行

## Changes

### `backend/app/video/views.py`
- `add_video_to_group`: 存在チェック + order取得 + create のレースコンディション防止
- `add_videos_to_group`: 既存メンバー確認 + bulk_create の整合性保証
- `reorder_videos_in_group`: メンバー取得 + bulk_update の整合性保証
- `add_tags_to_video`: 既存タグ確認 + bulk_create の整合性保証
- `VideoDetailView.update`: Video更新 + PGVectorメタデータ更新の整合性保証
- `VideoDetailView.destroy`: DB削除成功後に `on_commit` でファイル削除

### `backend/app/auth/serializers.py`
- `UserSignupSerializer.create`: メール送信失敗時に手動 `user.delete()` ではなくトランザクションの自動ロールバックを利用

### `backend/app/tasks/transcription.py`
- `save_transcription_result`: ステータス更新 + トランスクリプト保存をアトミックに実行

### `backend/app/video/serializers.py`
- `VideoCreateSerializer.create`: Celeryタスクを `on_commit` 経由で発行し、未コミットのレコードをタスクが読めない問題を防止

## Test plan
- [x] 動画アップロード → 文字起こしタスクが正常に発行されることを確認
- [x] 動画のタイトル更新 → PGVectorメタデータも更新されることを確認
- [x] 動画削除 → DBレコード削除後にファイルが削除されることを確認
- [x] グループへの動画追加（単体・複数）が正常に動作することを確認
- [x] グループ内の動画並び替えが正常に動作することを確認
- [x] タグの一括追加が正常に動作することを確認
- [ ] ユーザーサインアップ → メール送信失敗時にユーザーが作成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)