### PR TITLE
fix: use shrink-0 utility in chat panel

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -33,7 +33,7 @@ function ChatMessageBubble({ message, feedbackUpdatingId, onVideoNavigate, onFee
               {message.related_videos.map((video, videoIndex) => (
                 <div
                   key={videoIndex}
-                  className="flex-shrink-0 bg-white border border-gray-200 rounded p-2 hover:bg-gray-50 cursor-pointer"
+                  className="shrink-0 bg-white border border-gray-200 rounded p-2 hover:bg-gray-50 cursor-pointer"
                   onClick={() => onVideoNavigate(video.video_id, video.start_time)}
                 >
                   <p className="text-xs font-medium text-gray-800 truncate mb-1">{video.title}</p>


### PR DESCRIPTION
## 概要
- チャットパネル内の関連動画カードで使用している Tailwind クラス名を flex-shrink-0 から shrink-0 に変更
- 現行のユーティリティ名に合わせる修正（レイアウト挙動は維持）