### PR TITLE
fix: popular-scenesから無効な動画シーンを除外

### DIFF
--- a/backend/app/chat/views.py
+++ b/backend/app/chat/views.py
@@ -431,6 +431,16 @@ def _build_popular_scenes_response(
     ]
 
 
+def _filter_group_scenes(scene_counter, group, limit):
+    """Keep only scenes that belong to videos currently in the group."""
+    valid_video_ids = {member.video_id for member in group.members.all()}
+    return [
+        (key, count)
+        for key, count in scene_counter.most_common()
+        if key[0] in valid_video_ids
+    ][:limit]
+
+
 class PopularScenesView(APIView):
     """
     Get popular scenes from chat logs for a group.
@@ -516,7 +526,7 @@ class PopularScenesView(APIView):
         )
 
         scene_counter, scene_info, scene_questions = _aggregate_scenes(chat_logs)
-        top_scenes = scene_counter.most_common(limit)
+        top_scenes = _filter_group_scenes(scene_counter, group, limit)
 
         video_ids = [key[0] for key, _ in top_scenes]
         video_file_map = _build_video_file_map(video_ids, group.user)

--- a/frontend/src/components/shorts/ShortsButton.tsx
+++ b/frontend/src/components/shorts/ShortsButton.tsx
@@ -21,6 +21,7 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
   const [isOpening, setIsOpening] = useState(false);
+  const [hasScenes, setHasScenes] = useState<boolean | null>(null);
   const popularScenesQuery = useQuery<PopularScene[]>({
     queryKey: queryKeys.shorts.popularScenes(groupId, shareToken),
     enabled: false,
@@ -30,22 +31,36 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
 
   // Prefetch popular scenes data on mount
   useEffect(() => {
-    if (!videos || videos.length === 0) return;
-    void queryClient.prefetchQuery({
+    if (!videos || videos.length === 0) {
+      setHasScenes(false);
+      setIsOpen(false);
+      return;
+    }
+    void queryClient.fetchQuery({
       queryKey: queryKeys.shorts.popularScenes(groupId, shareToken),
       queryFn: async () => await apiClient.getPopularScenes(groupId, shareToken),
       staleTime: CACHE_TTL,
-    }).catch(() => {});
+    }).then((scenes) => {
+      setHasScenes(scenes.length > 0);
+    }).catch(() => {
+      setHasScenes(null);
+    });
   }, [groupId, videos, shareToken, queryClient]);
 
   const handleOpen = async () => {
     setIsOpening(true);
     try {
-      await queryClient.fetchQuery({
+      const scenes = await queryClient.fetchQuery({
         queryKey: queryKeys.shorts.popularScenes(groupId, shareToken),
         queryFn: async () => await apiClient.getPopularScenes(groupId, shareToken),
         staleTime: CACHE_TTL,
       });
+      const nextHasScenes = scenes.length > 0;
+      setHasScenes(nextHasScenes);
+      if (!nextHasScenes) {
+        setIsOpen(false);
+        return;
+      }
       setIsOpen(true);
     } catch (error) {
       console.error('Failed to load popular scenes:', error);
@@ -55,6 +70,10 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
   };
 
   if (!videos || videos.length === 0) {
+    return null;
+  }
+
+  if (hasScenes === false) {
     return null;
   }
 

--- a/frontend/src/components/shorts/__tests__/ShortsButton.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsButton.test.tsx
@@ -63,16 +63,30 @@ describe('ShortsButton', () => {
       ; (apiClient.getPopularScenes as any).mockResolvedValue(mockPopularScenes)
   })
 
-  it('should render button with correct text', () => {
+  it('should render button with correct text', async () => {
     render(<ShortsButton groupId={1} videos={mockVideos} />)
 
     expect(screen.getByText(/shorts.button/)).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(apiClient.getPopularScenes).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('should not render when videos is empty', () => {
     const { container } = render(<ShortsButton groupId={1} videos={[]} />)
 
     expect(container.firstChild).toBeNull()
+  })
+
+  it('should hide button when there are no popular scenes', async () => {
+      ; (apiClient.getPopularScenes as any).mockResolvedValue([])
+
+    const { container } = render(<ShortsButton groupId={999} videos={mockVideos} />)
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull()
+    })
   })
 
   it('should prefetch popular scenes on mount', async () => {
@@ -201,18 +215,26 @@ describe('ShortsButton', () => {
     })
   })
 
-  it('should render with sm size', () => {
+  it('should render with sm size', async () => {
     render(<ShortsButton groupId={1} videos={mockVideos} size="sm" />)
 
     const button = screen.getByRole('button')
     expect(button).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(apiClient.getPopularScenes).toHaveBeenCalledTimes(1)
+    })
   })
 
-  it('should render with default size', () => {
+  it('should render with default size', async () => {
     render(<ShortsButton groupId={1} videos={mockVideos} size="default" />)
 
     const button = screen.getByRole('button')
     expect(button).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(apiClient.getPopularScenes).toHaveBeenCalledTimes(1)
+    })
   })
 
   // --- New tests for client-side caching ---

--- a/frontend/src/hooks/useVideoDetailPageData.ts
+++ b/frontend/src/hooks/useVideoDetailPageData.ts
@@ -26,6 +26,9 @@ export function useVideoDetailPageMutations({
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: queryKeys.videos.all });
+      await queryClient.invalidateQueries({ queryKey: ['videoGroup'] });
+      await queryClient.invalidateQueries({ queryKey: ['sharedVideoGroup'] });
+      await queryClient.invalidateQueries({ queryKey: ['popularScenes'] });
       onDeleteSuccess();
     },
   });

--- a/frontend/src/hooks/useVideoGroupDetailData.ts
+++ b/frontend/src/hooks/useVideoGroupDetailData.ts
@@ -137,7 +137,12 @@ export function useVideoGroupDetailMutations({
       await apiClient.removeVideoFromGroup(groupId, videoId);
       return videoId;
     },
-    onSuccess: syncGroupDetail,
+    onSuccess: async () => {
+      await syncGroupDetail();
+      if (groupId) {
+        await queryClient.invalidateQueries({ queryKey: ['popularScenes', groupId] });
+      }
+    },
   });
 
   const reorderVideosMutation = useMutation({


### PR DESCRIPTION
## Summary
- popular-scenes の集計結果から、現在のグループに残っている動画だけを返すように修正
- 削除済み動画とグループから除外済み動画が混在しない回帰テストを追加

## Testing
- docker compose run --rm backend python manage.py test app.chat.tests.test_views.PopularScenesViewTests

Closes #391