### PR TITLE
Release: account deletion, rate limiting, and data fetching improvements

### DIFF
--- a/backend/app/chat/views.py
+++ b/backend/app/chat/views.py
@@ -431,6 +431,16 @@ def _build_popular_scenes_response(
     ]
 
 
+def _filter_group_scenes(scene_counter, group, limit):
+    """Keep only scenes that belong to videos currently in the group."""
+    valid_video_ids = {member.video_id for member in group.members.all()}
+    return [
+        (key, count)
+        for key, count in scene_counter.most_common()
+        if key[0] in valid_video_ids
+    ][:limit]
+
+
 class PopularScenesView(APIView):
     """
     Get popular scenes from chat logs for a group.
@@ -516,7 +526,7 @@ class PopularScenesView(APIView):
         )
 
         scene_counter, scene_info, scene_questions = _aggregate_scenes(chat_logs)
-        top_scenes = scene_counter.most_common(limit)
+        top_scenes = _filter_group_scenes(scene_counter, group, limit)
 
         video_ids = [key[0] for key, _ in top_scenes]
         video_file_map = _build_video_file_map(video_ids, group.user)

--- a/docs/architecture/bpmn.md
+++ b/docs/architecture/bpmn.md
@@ -261,3 +261,19 @@ flowchart TD
 ### Data Integrity
 - Transaction management using `transaction.atomic` to ensure data consistency
 - Referential integrity guarantee through CASCADE deletion
+
+## 8. Account Deactivation Process
+
+```mermaid
+flowchart TD
+    Start([Start]) --> RequestDelete[Request Account Deactivation]
+    RequestDelete --> InputPassword[Input Current Password]
+    InputPassword --> InputReason[Input Reason for Leaving]
+    InputReason --> Validate{Password Verification}
+    Validate -->|Invalid| ShowError[Error Display]
+    ShowError --> InputPassword
+    Validate -->|Valid| CreateRequest[Create AccountDeletionRequest]
+    CreateRequest --> DeactivateUser[Deactivate User<br/>is_active: False<br/>deactivated_at: now]
+    DeactivateUser --> ClearCookies[Clear Auth Cookies<br/>HttpOnly Cookie Deletion]
+    ClearCookies --> Complete([Account Deactivated])
+```

--- a/docs/architecture/flowchart.md
+++ b/docs/architecture/flowchart.md
@@ -281,3 +281,26 @@ flowchart TD
     ServerError --> NotifyAdmin[Notify Administrator]
     NotifyAdmin --> LogError
 ```
+
+## 7. Account Deactivation Processing Flow
+
+```mermaid
+flowchart TD
+    Start([Account Deactivation]) --> Navigate[Navigate to Settings Page]
+    Navigate --> ClickDelete[Click Account Deactivation]
+    ClickDelete --> ShowDialog[Show Confirmation Dialog]
+    ShowDialog --> InputPassword[Input Current Password]
+    InputPassword --> InputReason[Input Reason for Leaving]
+    InputReason --> Submit[Submit Deactivation Request]
+    Submit --> API[DELETE /api/auth/account/]
+    API --> ValidatePassword{Password Verification}
+    ValidatePassword -->|Invalid| Error1[400 Bad Request]
+    ValidatePassword -->|Valid| CreateRequest[(Database<br/>Create AccountDeletionRequest)]
+    CreateRequest --> DeactivateUser[(Database<br/>Update User<br/>is_active: False<br/>deactivated_at: now)]
+    DeactivateUser --> ClearCookies[Clear HttpOnly Cookies]
+    ClearCookies --> Redirect[Redirect to Home Page]
+    Redirect --> End([Complete])
+    
+    Error1 --> ShowError[Display Error Message]
+    ShowError --> InputPassword
+```

--- a/docs/architecture/system-configuration-diagram.md
+++ b/docs/architecture/system-configuration-diagram.md
@@ -223,6 +223,9 @@ graph TB
             ShareToken["Share Token Authentication
             Temporary Access
             Guest Access"]
+            AccountDeactivation["Account Deactivation
+            Password Verification
+            Soft Delete (deactivated_at)"]
         end
 
         subgraph Authorization["Authorization"]

--- a/docs/database/data-dictionary.md
+++ b/docs/database/data-dictionary.md
@@ -33,11 +33,16 @@ Table that stores user information for the system.
 | first_name | VARCHAR(150) | NOT NULL | '' | First name |
 | last_name | VARCHAR(150) | NOT NULL | '' | Last name |
 | video_limit | INTEGER | NULL, CHECK (video_limit >= 0) | 0 | Max number of videos the user can upload (`NULL` = unlimited, `0` = uploads disabled) |
+| deactivated_at | TIMESTAMPTZ | NULL | NULL | Date and time when the account was deactivated (soft delete). `NULL` means the account is active. |
 
 ### Indexes
 - PRIMARY KEY: `id`
 - UNIQUE: `username`
 - UNIQUE: `email`
+- INDEX: `(email, is_active)` (for login lookup)
+- INDEX: `(date_joined, -id)` (for user listing)
+- INDEX: `deactivated_at` (for deactivated account queries)
+- INDEX: `video_limit` (for limit queries)
 
 ### Relations
 - `videos`: One-to-many relationship with Video table
@@ -285,7 +290,7 @@ Table that stores chat history.
 ## PGVector Collection
 
 ### Collection Name
-`video_scenes` (configurable)
+`videoq_scenes` (configurable via `PGVECTOR_COLLECTION_NAME` environment variable)
 
 ### Description
 Collection that stores vectorized video scenes.
@@ -295,7 +300,7 @@ Collection that stores vectorized video scenes.
 | Column Name | Data Type | Description |
 |------------|-----------|-------------|
 | id | UUID | Vector ID |
-| embedding | vector(1536) | Text embedding vector (configurable via `EMBEDDING_MODEL` env var, default: text-embedding-3-small) |
+| embedding | vector(1536) | Text embedding vector (dimension configurable via `EMBEDDING_VECTOR_SIZE` env var; model configurable via `EMBEDDING_MODEL` env var, default: text-embedding-3-small/1536) |
 | document | TEXT | Scene text content |
 | metadata | JSONB | Metadata |
 

--- a/docs/database/data-flow-diagram.md
+++ b/docs/database/data-flow-diagram.md
@@ -247,3 +247,28 @@ graph TB
 ### Scalability
 - File storage supports S3
 - Vector search is accelerated with pgvector
+
+## 7. Account Deactivation Data Flow
+
+```mermaid
+flowchart TD
+    Start([User]) --> Navigate[Navigate to Settings Page]
+    Navigate --> Frontend[Frontend]
+    Frontend --> API[DELETE /api/auth/account/]
+    
+    API --> Auth{Authentication Check}
+    Auth -->|Failed| Error1[Authentication Error]
+    Auth -->|Success| ValidatePassword{Password Verification}
+    
+    ValidatePassword -->|Invalid| Error2[Password Error]
+    ValidatePassword -->|Valid| CreateRequest[(Database<br/>Create AccountDeletionRequest)]
+    
+    CreateRequest --> DeactivateUser[(Database<br/>Update User<br/>is_active: False<br/>deactivated_at: now)]
+    DeactivateUser --> ClearCookies[Clear HttpOnly Cookies]
+    ClearCookies --> Response[204 No Content]
+    Response --> Frontend
+    Frontend --> End([User - Redirected to Home])
+    
+    Error1 --> Frontend
+    Error2 --> Frontend
+```

--- a/docs/database/er-diagram.md
+++ b/docs/database/er-diagram.md
@@ -32,6 +32,7 @@ erDiagram
         string first_name
         string last_name
         int video_limit
+        datetime deactivated_at
     }
     
     Video {
@@ -191,7 +192,13 @@ erDiagram
 - Unique Constraints: `username`, `email`, `share_token`
 
 ### Custom Indexes
+- `User(email, is_active)`: For login lookup
+- `User(date_joined, -id)`: For user listing
+- `User.deactivated_at`: For deactivated account queries
+- `User.video_limit`: For limit queries
 - `Video.uploaded_at`: For descending sort (Meta.ordering)
+- `Video(user, status, -uploaded_at)`: For filtered user video listing
+- `Video(user, title)`: For title search
 - `VideoGroup.created_at`: For descending sort (Meta.ordering)
 - `ChatLog.created_at`: For descending sort (Meta.ordering)
 - `VideoGroupMember(order, added_at)`: For order sorting (Meta.ordering)

--- a/docs/design/class-diagram.md
+++ b/docs/design/class-diagram.md
@@ -17,6 +17,7 @@ classDiagram
         +bool is_staff
         +bool is_superuser
         +int video_limit (nullable)
+        +datetime deactivated_at (nullable)
     }
     
     class Video {
@@ -237,6 +238,18 @@ classDiagram
         +function onFilterChange
         +render()
     }
+
+    class ShortsButton {
+        +int groupId
+        +string shareToken
+        +render()
+    }
+
+    class ShortsPlayer {
+        +Scene[] scenes
+        +function onClose
+        +render()
+    }
     
     class LoadingState {
         +bool isLoading
@@ -308,6 +321,10 @@ classDiagram
     
     class ChatView {
         +post()
+    }
+    
+    class AccountDeleteView {
+        +delete()
     }
     
     class ChatHistoryView {

--- a/docs/design/component-diagram.md
+++ b/docs/design/component-diagram.md
@@ -47,6 +47,11 @@ graph TB
             subgraph Chat["Chat Components"]
                 ChatPanel[ChatPanel]
             end
+
+            subgraph Shorts["Shorts Components"]
+                ShortsButton[ShortsButton]
+                ShortsPlayer[ShortsPlayer]
+            end
             
             subgraph Layout["Layout Components"]
                 PageLayout[PageLayout]

--- a/docs/design/deployment-diagram.md
+++ b/docs/design/deployment-diagram.md
@@ -235,6 +235,8 @@ graph TB
         E20["LLM_PROVIDER<br/>(openai or ollama)"]
         E21["LLM_MODEL<br/>(LLM model for selected provider)"]
         E22["OLLAMA_BASE_URL<br/>(Ollama server URL)"]
+        E23["EMBEDDING_VECTOR_SIZE<br/>(must match EMBEDDING_MODEL)"]
+        E24["PGVECTOR_COLLECTION_NAME<br/>(vector storage table name)"]
     end
     
     subgraph Containers["Containers"]
@@ -274,6 +276,10 @@ graph TB
     E21 --> C2
     E22 --> C2
     E22 --> C3
+    E23 --> C2
+    E23 --> C3
+    E24 --> C2
+    E24 --> C3
 ```
 
 ## Optional: Scaling Configuration (production example)

--- a/docs/design/sequence-diagram.md
+++ b/docs/design/sequence-diagram.md
@@ -289,3 +289,31 @@ sequenceDiagram
     Note over Admin,DjangoAdmin: docker compose logs -f celery-worker
     DjangoAdmin-->>Admin: Display Progress Logs
 ```
+
+## 8. Account Deactivation Flow
+
+```mermaid
+sequenceDiagram
+    participant User as User
+    participant Frontend as Frontend
+    participant Backend as Backend API
+    participant DB as Database
+
+    User->>Frontend: Navigate to Settings Page
+    User->>Frontend: Request Account Deactivation
+    Frontend->>Frontend: Display Confirmation Dialog
+    User->>Frontend: Input Password + Reason
+    Frontend->>Backend: DELETE /api/auth/account/
+    Backend->>Backend: Verify Password
+    alt Password Invalid
+        Backend-->>Frontend: 400 Bad Request
+        Frontend-->>User: Error Display
+    else Password Valid
+        Backend->>DB: Create AccountDeletionRequest
+        DB-->>Backend: Request Created
+        Backend->>DB: Update User(is_active: False, deactivated_at: now)
+        DB-->>Backend: User Updated
+        Backend-->>Frontend: Clear HttpOnly Cookies<br/>(Access & Refresh Tokens)
+        Frontend-->>User: Redirect to Home Page
+    end
+```

--- a/docs/design/state-diagram.md
+++ b/docs/design/state-diagram.md
@@ -59,6 +59,7 @@ stateDiagram-v2
     Active --> LoggedOut: Logout
     LoggedOut --> Active: Login
     
+    Active --> Deactivated: Account Deactivation
     Active --> [*]: Account Deleted
     Inactive --> [*]: Account Deleted
     
@@ -85,6 +86,14 @@ stateDiagram-v2
         Logged Out
         - Session Terminated
         - Can Login Again
+    end note
+
+    note right of Deactivated
+        Deactivated
+        - is_active: False
+        - deactivated_at recorded
+        - Cannot Login
+        - Data retained for admin review
     end note
 ```
 

--- a/docs/requirements/activity-diagram.md
+++ b/docs/requirements/activity-diagram.md
@@ -156,3 +156,20 @@ flowchart TD
         Error2 --> ReorderEnd
     end
 ```
+
+## 6. Account Deactivation Flow
+
+```mermaid
+flowchart TD
+    Start([User Requests Account Deactivation]) --> InputPassword[Input Current Password]
+    InputPassword --> InputReason[Input Reason]
+    InputReason --> Submit[Submit Request]
+    Submit --> Validate{Password Verification}
+    Validate -->|Invalid| ShowError[Error Display]
+    ShowError --> InputPassword
+    Validate -->|Valid| CreateRequest[Create AccountDeletionRequest]
+    CreateRequest --> Deactivate[Deactivate Account<br/>is_active: False<br/>deactivated_at: now]
+    Deactivate --> ClearSession[Clear Auth Cookies]
+    ClearSession --> Redirect[Redirect to Home Page]
+    Redirect --> End([Complete])
+```

--- a/docs/requirements/screen-transition-diagram.md
+++ b/docs/requirements/screen-transition-diagram.md
@@ -42,6 +42,9 @@ stateDiagram-v2
 
     Home --> SharePage: Share Token URL
     SharePage --> SharePage: Chat with Shared Group
+
+    VideoList --> Settings: Settings Menu
+    Settings --> VideoList: Back
     
     note right of Home
         Home Page
@@ -69,6 +72,12 @@ stateDiagram-v2
         - Chat functionality
         - Share link management
     end note
+
+    note right of Settings
+        Settings Page
+        - User info display
+        - Account deactivation
+    end note
 ```
 
 ## Screen List
@@ -92,6 +101,9 @@ stateDiagram-v2
 
 ### Sharing
 - **SharePage** (`/share/:token` or `/:locale/share/:token`): Share page (no authentication required)
+
+### Settings
+- **Settings** (`/settings` or `/:locale/settings`): Settings page (account info, deactivation)
 
 **Note**: This project implements locale-aware routing with React Router + react-i18next (not Next.js / next-intl) (`frontend/src/App.tsx`).
 - The default locale (`en`) has no prefix: `/videos`

--- a/docs/requirements/use-case-diagram.md
+++ b/docs/requirements/use-case-diagram.md
@@ -63,6 +63,8 @@ graph TB
 
     subgraph Settings["Settings"]
         UC31[View User Info]
+        UC33[Deactivate Account]
+        UC34[Request Account Deletion]
     end
 
     subgraph Administration["Administration"]
@@ -102,6 +104,8 @@ graph TB
     User --> UC30
     User --> UC31
     User --> UC32
+    User --> UC33
+    User --> UC34
     
     Guest --> UC29
     Guest --> UC30
@@ -164,6 +168,8 @@ graph TB
 
 ### Settings
 - **UC31 View User Info**: Display current user information
+- **UC33 Deactivate Account**: Deactivate user account (soft delete, sets `is_active=False` and records `deactivated_at`)
+- **UC34 Request Account Deletion**: Submit an account deletion request with a reason
 
 ### Administration
 - **UC35 Re-index Video Embeddings**: Re-generate all video embeddings with new model (superuser only)

--- a/frontend/src/components/shorts/ShortsButton.tsx
+++ b/frontend/src/components/shorts/ShortsButton.tsx
@@ -21,6 +21,7 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
   const [isOpening, setIsOpening] = useState(false);
+  const [hasScenes, setHasScenes] = useState<boolean | null>(null);
   const popularScenesQuery = useQuery<PopularScene[]>({
     queryKey: queryKeys.shorts.popularScenes(groupId, shareToken),
     enabled: false,
@@ -30,22 +31,36 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
 
   // Prefetch popular scenes data on mount
   useEffect(() => {
-    if (!videos || videos.length === 0) return;
-    void queryClient.prefetchQuery({
+    if (!videos || videos.length === 0) {
+      setHasScenes(false);
+      setIsOpen(false);
+      return;
+    }
+    void queryClient.fetchQuery({
       queryKey: queryKeys.shorts.popularScenes(groupId, shareToken),
       queryFn: async () => await apiClient.getPopularScenes(groupId, shareToken),
       staleTime: CACHE_TTL,
-    }).catch(() => {});
+    }).then((scenes) => {
+      setHasScenes(scenes.length > 0);
+    }).catch(() => {
+      setHasScenes(null);
+    });
   }, [groupId, videos, shareToken, queryClient]);
 
   const handleOpen = async () => {
     setIsOpening(true);
     try {
-      await queryClient.fetchQuery({
+      const scenes = await queryClient.fetchQuery({
         queryKey: queryKeys.shorts.popularScenes(groupId, shareToken),
         queryFn: async () => await apiClient.getPopularScenes(groupId, shareToken),
         staleTime: CACHE_TTL,
       });
+      const nextHasScenes = scenes.length > 0;
+      setHasScenes(nextHasScenes);
+      if (!nextHasScenes) {
+        setIsOpen(false);
+        return;
+      }
       setIsOpen(true);
     } catch (error) {
       console.error('Failed to load popular scenes:', error);
@@ -55,6 +70,10 @@ export function ShortsButton({ groupId, videos, shareToken, size = 'default' }: 
   };
 
   if (!videos || videos.length === 0) {
+    return null;
+  }
+
+  if (hasScenes === false) {
     return null;
   }
 

--- a/frontend/src/components/shorts/__tests__/ShortsButton.test.tsx
+++ b/frontend/src/components/shorts/__tests__/ShortsButton.test.tsx
@@ -63,16 +63,30 @@ describe('ShortsButton', () => {
       ; (apiClient.getPopularScenes as any).mockResolvedValue(mockPopularScenes)
   })
 
-  it('should render button with correct text', () => {
+  it('should render button with correct text', async () => {
     render(<ShortsButton groupId={1} videos={mockVideos} />)
 
     expect(screen.getByText(/shorts.button/)).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(apiClient.getPopularScenes).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('should not render when videos is empty', () => {
     const { container } = render(<ShortsButton groupId={1} videos={[]} />)
 
     expect(container.firstChild).toBeNull()
+  })
+
+  it('should hide button when there are no popular scenes', async () => {
+      ; (apiClient.getPopularScenes as any).mockResolvedValue([])
+
+    const { container } = render(<ShortsButton groupId={999} videos={mockVideos} />)
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull()
+    })
   })
 
   it('should prefetch popular scenes on mount', async () => {
@@ -201,18 +215,26 @@ describe('ShortsButton', () => {
     })
   })
 
-  it('should render with sm size', () => {
+  it('should render with sm size', async () => {
     render(<ShortsButton groupId={1} videos={mockVideos} size="sm" />)
 
     const button = screen.getByRole('button')
     expect(button).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(apiClient.getPopularScenes).toHaveBeenCalledTimes(1)
+    })
   })
 
-  it('should render with default size', () => {
+  it('should render with default size', async () => {
     render(<ShortsButton groupId={1} videos={mockVideos} size="default" />)
 
     const button = screen.getByRole('button')
     expect(button).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(apiClient.getPopularScenes).toHaveBeenCalledTimes(1)
+    })
   })
 
   // --- New tests for client-side caching ---

--- a/frontend/src/hooks/useVideoDetailPageData.ts
+++ b/frontend/src/hooks/useVideoDetailPageData.ts
@@ -26,6 +26,9 @@ export function useVideoDetailPageMutations({
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: queryKeys.videos.all });
+      await queryClient.invalidateQueries({ queryKey: ['videoGroup'] });
+      await queryClient.invalidateQueries({ queryKey: ['sharedVideoGroup'] });
+      await queryClient.invalidateQueries({ queryKey: ['popularScenes'] });
       onDeleteSuccess();
     },
   });

--- a/frontend/src/hooks/useVideoGroupDetailData.ts
+++ b/frontend/src/hooks/useVideoGroupDetailData.ts
@@ -137,7 +137,12 @@ export function useVideoGroupDetailMutations({
       await apiClient.removeVideoFromGroup(groupId, videoId);
       return videoId;
     },
-    onSuccess: syncGroupDetail,
+    onSuccess: async () => {
+      await syncGroupDetail();
+      if (groupId) {
+        await queryClient.invalidateQueries({ queryKey: ['popularScenes', groupId] });
+      }
+    },
   });
 
   const reorderVideosMutation = useMutation({


### PR DESCRIPTION
## 概要
`develop` ブランチの変更を `main` に取り込むための PR です。

## 主な変更点
- Popular Scenes で、削除済み動画およびグループから除外済みの動画に紐づくシーンを除外
- Popular Scenes が空の場合は Shorts ボタンを非表示にするよう修正
- 動画削除時およびグループ更新時に Popular Scenes 関連キャッシュを無効化し、表示の整合性を改善
- 上記に対応するバックエンド / フロントエンドのテストを追加・更新

## レビュー観点
- Popular Scenes に削除済み動画・グループ除外済み動画のシーンが表示されないこと
- Popular Scenes が存在しない場合に Shorts ボタンが表示されないこと
- 動画削除やグループ変更後に Shorts 表示が最新状態へ反映されること