### PR TITLE
ヘッダーの設定リンクをアカウント操作の横に移動

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -67,13 +67,6 @@ export function Header({ children }: HeaderProps) {
                 >
                   {t('navigation.videoGroups')}
                 </button>
-                <span className="text-gray-300">|</span>
-                <button
-                  onClick={() => navigate('/settings')}
-                  className="text-gray-600 hover:text-gray-900 transition-colors"
-                >
-                  {t('navigation.settings')}
-                </button>
               </>
             )}
             {children}
@@ -84,6 +77,13 @@ export function Header({ children }: HeaderProps) {
               <span className="text-gray-600">
                 {t('navigation.welcome', { username: user.username })}
               </span>
+              <span className="text-gray-300">|</span>
+              <button
+                onClick={() => navigate('/settings')}
+                className="text-gray-600 hover:text-gray-900 transition-colors"
+              >
+                {t('navigation.settings')}
+              </button>
               <span className="text-gray-300">|</span>
               <button
                 onClick={handleLogout}


### PR DESCRIPTION
## 概要

ヘッダーナビゲーションの「設定」リンクの配置を改善しました。

## 変更内容

- **設定リンクの位置変更**: ナビゲーションエリア（ホーム・動画グループの横）から、アカウント操作エリア（ユーザー名・ログアウトの横）に移動
- ユーザー名 | **設定** | ログアウト の順に表示されるようになりました

## 変更の動機

設定はアカウントに関連する操作であるため、ログアウトボタンなどのアカウント操作と同じエリアに配置する方がUX的に自然です。

## 変更ファイル

- `frontend/src/components/layout/Header.tsx`

## テスト

- [x] ヘッダーの設定リンクが正しい位置に表示される
- [x] 設定リンクのクリックで設定ページに遷移する
- [x] レスポンシブ表示で問題がない