### PR TITLE
Fix Radix dialog accessibility warnings

### DIFF
--- a/frontend/src/components/dashboard/DashboardButton.tsx
+++ b/frontend/src/components/dashboard/DashboardButton.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BarChart3 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useChatAnalytics } from '@/hooks/useChatAnalytics';
 import { AnalyticsDashboard } from './AnalyticsDashboard';
 
@@ -32,6 +32,9 @@ export function DashboardButton({ groupId, size = 'default' }: DashboardButtonPr
         <DialogContent className="max-w-[95vw] lg:max-w-5xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>{t('dashboard.title')}</DialogTitle>
+            <DialogDescription className="sr-only">
+              {t('dashboard.dialogDescription', 'Displays analytics and trends for this chat group.')}
+            </DialogDescription>
           </DialogHeader>
           <AnalyticsDashboard data={data} isLoading={isLoading} />
         </DialogContent>

--- a/frontend/src/components/video/TagManagementModal.tsx
+++ b/frontend/src/components/video/TagManagementModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import {
     Dialog,
     DialogContent,
+    DialogDescription,
     DialogHeader,
     DialogTitle,
     DialogFooter,
@@ -37,6 +38,9 @@ export function TagManagementModal({ isOpen, onClose }: TagManagementModalProps)
             <DialogContent className="sm:max-w-md">
                 <DialogHeader>
                     <DialogTitle>{t('tags.management.title', 'Tag Management')}</DialogTitle>
+                    <DialogDescription className="sr-only">
+                        {t('tags.management.description', 'Review existing tags and remove ones you no longer need.')}
+                    </DialogDescription>
                 </DialogHeader>
 
                 <div className="space-y-4 max-h-[60vh] overflow-y-auto py-4">


### PR DESCRIPTION
## Summary
This PR fixes Radix Dialog accessibility warnings caused by DialogContent being rendered without an associated description.

## Changes
- Added DialogDescription to the analytics dashboard dialog in frontend/src/components/dashboard/DashboardButton.tsx
- Added DialogDescription to the tag management dialog in frontend/src/components/video/TagManagementModal.tsx
- Kept both descriptions visually hidden with sr-only, so there is no UI change

## Why
In development, Radix emits this warning when a dialog is missing accessible descriptive text:

Warning: Missing Description or aria-describedby={undefined} for {DialogContent}

These changes satisfy that accessibility requirement and remove the warning without changing behavior.

## Impact
- No functional behavior changes
- No visual layout changes
- Improves screen reader support for the affected dialogs

## Testing
- Not run locally yet
- Expected manual check:
  - Open analytics dashboard dialog
  - Open tag management dialog
  - Confirm the Radix warning no longer appears in the console