### PR TITLE
frontend: indexing ステータス対応をUI全体へ反映

### DIFF
--- a/frontend/src/hooks/__tests__/useVideoStats.test.ts
+++ b/frontend/src/hooks/__tests__/useVideoStats.test.ts
@@ -10,6 +10,7 @@ describe('useVideoStats', () => {
       completed: 0,
       pending: 0,
       processing: 0,
+      indexing: 0,
       error: 0,
     })
   })
@@ -20,16 +21,18 @@ describe('useVideoStats', () => {
       { status: 'completed' as const },
       { status: 'pending' as const },
       { status: 'processing' as const },
+      { status: 'indexing' as const },
       { status: 'error' as const },
     ]
     
     const { result } = renderHook(() => useVideoStats(videos))
     
     expect(result.current).toEqual({
-      total: 5,
+      total: 6,
       completed: 2,
       pending: 1,
       processing: 1,
+      indexing: 1,
       error: 1,
     })
   })
@@ -37,7 +40,7 @@ describe('useVideoStats', () => {
   it('should recalculate when videos change', () => {
     const { result, rerender } = renderHook<
       ReturnType<typeof useVideoStats>,
-      { videos: Array<{ status: 'completed' | 'pending' | 'processing' | 'error' }> }
+      { videos: Array<{ status: 'completed' | 'pending' | 'processing' | 'indexing' | 'error' }> }
     >(
       ({ videos }) => useVideoStats(videos),
       {
@@ -62,4 +65,3 @@ describe('useVideoStats', () => {
     expect(result.current.pending).toBe(1)
   })
 })
-

--- a/frontend/src/hooks/useVideoStats.ts
+++ b/frontend/src/hooks/useVideoStats.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-export type VideoStatus = 'pending' | 'processing' | 'completed' | 'error';
+export type VideoStatus = 'pending' | 'processing' | 'indexing' | 'completed' | 'error';
 
 export interface VideoLike {
   status: VideoStatus;
@@ -11,6 +11,7 @@ export interface VideoStats {
   completed: number;
   pending: number;
   processing: number;
+  indexing: number;
   error: number;
 }
 
@@ -26,6 +27,7 @@ export function useVideoStats<T extends VideoLike>(videos: T[]): VideoStats {
       completed: 0,
       pending: 0,
       processing: 0,
+      indexing: 0,
       error: 0,
     };
 
@@ -40,6 +42,9 @@ export function useVideoStats<T extends VideoLike>(videos: T[]): VideoStats {
         case 'processing':
           stats.processing++;
           break;
+        case 'indexing':
+          stats.indexing++;
+          break;
         case 'error':
           stats.error++;
           break;
@@ -49,4 +54,3 @@ export function useVideoStats<T extends VideoLike>(videos: T[]): VideoStats {
     return stats;
   }, [videos]);
 }
-

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -59,6 +59,7 @@
       "groupNotFound": "Chat group not found",
       "transcriptionPending": "Transcription has not started yet.",
       "transcriptionProcessing": "Transcription is currently processing...",
+      "transcriptionIndexing": "Transcription results are being indexed...",
       "transcriptionUnavailable": "Transcription is not available yet.",
       "transcriptionError": "An error occurred while processing the transcription.",
       "browserNoVideoSupport": "Your browser does not support the video tag.",
@@ -147,6 +148,7 @@
       "completed": "Completed",
       "pending": "Pending",
       "processing": "Processing",
+      "indexing": "Indexing",
       "error": "Error"
     },
     "account": {
@@ -186,7 +188,8 @@
         "total": "Total videos",
         "completed": "Completed",
         "pending": "Pending",
-        "processing": "Processing"
+        "processing": "Processing",
+        "indexing": "Indexing"
       },
       "noVideos": "No videos yet",
       "noVideosHint": "Use the \"Upload video\" button above to add videos.",
@@ -291,6 +294,7 @@
         "all": "All statuses",
         "completed": "Completed",
         "processing": "Processing",
+        "indexing": "Indexing",
         "pending": "Pending",
         "error": "Error"
       },

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -60,6 +60,7 @@
       "groupNotFound": "チャットグループが見つかりません",
       "transcriptionPending": "文字起こし処理はまだ開始されていません。",
       "transcriptionProcessing": "文字起こしを処理しています...",
+      "transcriptionIndexing": "文字起こし結果をインデックス化しています...",
       "transcriptionUnavailable": "文字起こしはまだ利用できません。",
       "transcriptionError": "文字起こしの処理中にエラーが発生しました。",
       "browserNoVideoSupport": "お使いのブラウザは動画タグをサポートしていません。",
@@ -153,6 +154,7 @@
       "completed": "処理完了",
       "pending": "待機中",
       "processing": "処理中",
+      "indexing": "インデックス中",
       "error": "エラー"
     },
     "account": {
@@ -192,7 +194,8 @@
         "total": "総動画数",
         "completed": "完了",
         "pending": "待機中",
-        "processing": "処理中"
+        "processing": "処理中",
+        "indexing": "インデックス中"
       },
       "noVideos": "動画がありません",
       "noVideosHint": "上部の「動画をアップロード」ボタンから動画を追加できます。",
@@ -297,6 +300,7 @@
         "all": "すべてのステータス",
         "completed": "完了",
         "processing": "処理中",
+        "indexing": "インデックス中",
         "pending": "待機中",
         "error": "エラー"
       },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -138,7 +138,7 @@ export interface Video {
   description: string;
   uploaded_at: string;
   transcript?: string;
-  status: 'pending' | 'processing' | 'completed' | 'error';
+  status: 'pending' | 'processing' | 'indexing' | 'completed' | 'error';
   error_message?: string;
   tags?: { id: number; name: string; color: string }[];
 }
@@ -149,7 +149,7 @@ export interface VideoList {
   title: string;
   description: string;
   uploaded_at: string;
-  status: 'pending' | 'processing' | 'completed' | 'error';
+  status: 'pending' | 'processing' | 'indexing' | 'completed' | 'error';
   tags?: { id: number; name: string; color: string }[];
 }
 
@@ -181,7 +181,7 @@ export interface VideoInGroup {
   description: string;
   file: string | null;
   uploaded_at: string;
-  status: 'pending' | 'processing' | 'completed' | 'error';
+  status: 'pending' | 'processing' | 'indexing' | 'completed' | 'error';
   order: number;
 }
 

--- a/frontend/src/lib/utils/__tests__/video.test.ts
+++ b/frontend/src/lib/utils/__tests__/video.test.ts
@@ -30,6 +30,12 @@ describe('video utils', () => {
       expect(result).toContain('text-red-800');
     });
 
+    it('should return correct class for indexing status', () => {
+      const result = getStatusBadgeClassName('indexing');
+      expect(result).toContain('bg-purple-100');
+      expect(result).toContain('text-purple-800');
+    });
+
     it('should return default class for unknown status', () => {
       const result = getStatusBadgeClassName('unknown');
       expect(result).toContain('bg-gray-100');
@@ -42,6 +48,7 @@ describe('video utils', () => {
       expect(getStatusLabel('completed')).toBe('common.status.completed');
       expect(getStatusLabel('pending')).toBe('common.status.pending');
       expect(getStatusLabel('processing')).toBe('common.status.processing');
+      expect(getStatusLabel('indexing')).toBe('common.status.indexing');
       expect(getStatusLabel('error')).toBe('common.status.error');
     });
   });

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -78,7 +78,7 @@ export default function HomePage() {
           </Card>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
           <Card>
             <CardContent className="pt-6 text-center">
               <div className="text-4xl font-bold text-green-600">{videoStats.completed}</div>
@@ -97,6 +97,13 @@ export default function HomePage() {
             <CardContent className="pt-6 text-center">
               <div className="text-4xl font-bold text-yellow-600">{videoStats.processing}</div>
               <p className="text-sm text-gray-600 mt-2">{t('home.stats.processing')}</p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="pt-6 text-center">
+              <div className="text-4xl font-bold text-purple-600">{videoStats.indexing}</div>
+              <p className="text-sm text-gray-600 mt-2">{t('home.stats.indexing')}</p>
             </CardContent>
           </Card>
 

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -106,6 +106,7 @@ function TranscriptSection({ transcript, status }: TranscriptSectionProps) {
   const statusMessages: Record<string, { key: string; className: string }> = {
     pending: { key: 'common.messages.transcriptionPending', className: 'text-gray-500 italic' },
     processing: { key: 'common.messages.transcriptionProcessing', className: 'text-gray-500 italic' },
+    indexing: { key: 'common.messages.transcriptionIndexing', className: 'text-gray-500 italic' },
     completed: { key: 'common.messages.transcriptionUnavailable', className: 'text-gray-500 italic' },
     error: { key: 'common.messages.transcriptionError', className: 'text-red-600 italic' },
   };

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -410,6 +410,7 @@ function AddVideosDialog({ isOpen, onOpenChange, groupId, group, onVideosAdded }
                 <option value="">{t('videos.groupDetail.statusFilter.all')}</option>
                 <option value="completed">{t('videos.groupDetail.statusFilter.completed')}</option>
                 <option value="processing">{t('videos.groupDetail.statusFilter.processing')}</option>
+                <option value="indexing">{t('videos.groupDetail.statusFilter.indexing')}</option>
                 <option value="pending">{t('videos.groupDetail.statusFilter.pending')}</option>
                 <option value="error">{t('videos.groupDetail.statusFilter.error')}</option>
               </select>

--- a/frontend/src/pages/VideosPage.tsx
+++ b/frontend/src/pages/VideosPage.tsx
@@ -20,7 +20,7 @@ import { TagManagementModal } from '@/components/video/TagManagementModal';
  * Render the Videos management page with listing, filtering, statistics, and upload/tag modals.
  *
  * Displays a scrollable video list with loading and error states, a tag filter panel with management,
- * statistic cards for total/completed/pending/processing counts, an upload button (disabled when the
+ * statistic cards for total/completed/pending/processing/indexing counts, an upload button (disabled when the
  * current user cannot upload), and a warning when the user's upload limit is reached. The upload modal
  * can be opened via UI or the `upload=true` query parameter; successful uploads reload videos and refresh
  * user data.
@@ -127,7 +127,7 @@ export default function VideosPage() {
 
 
           {stats.total > 0 && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
               <div className="bg-blue-50 rounded-lg p-4 border border-blue-100">
                 <div className="text-2xl font-bold text-blue-600">{stats.total}</div>
                 <div className="text-sm text-blue-600">{t('videos.list.stats.total')}</div>
@@ -143,6 +143,10 @@ export default function VideosPage() {
               <div className="bg-purple-50 rounded-lg p-4 border border-purple-100">
                 <div className="text-2xl font-bold text-purple-600">{stats.processing}</div>
                 <div className="text-sm text-purple-600">{t('videos.list.stats.processing')}</div>
+              </div>
+              <div className="bg-indigo-50 rounded-lg p-4 border border-indigo-100">
+                <div className="text-2xl font-bold text-indigo-600">{stats.indexing}</div>
+                <div className="text-sm text-indigo-600">{t('videos.list.stats.indexing')}</div>
               </div>
             </div>
           )}

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -9,7 +9,8 @@ const mockVideos = [
   { id: 1, title: 'Video 1', status: 'completed' },
   { id: 2, title: 'Video 2', status: 'pending' },
   { id: 3, title: 'Video 3', status: 'processing' },
-  { id: 4, title: 'Video 4', status: 'error' },
+  { id: 4, title: 'Video 4', status: 'indexing' },
+  { id: 5, title: 'Video 5', status: 'error' },
 ]
 
 const mockGroups = [
@@ -88,6 +89,7 @@ describe('HomePage', () => {
       expect(screen.getByText('home.stats.completed')).toBeInTheDocument()
       expect(screen.getByText('home.stats.pending')).toBeInTheDocument()
       expect(screen.getByText('home.stats.processing')).toBeInTheDocument()
+      expect(screen.getByText('home.stats.indexing')).toBeInTheDocument()
       expect(screen.getByText('home.stats.error')).toBeInTheDocument()
     })
   })

--- a/frontend/src/pages/__tests__/VideosPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideosPage.test.tsx
@@ -5,6 +5,7 @@ const mockVideos = [
   { id: 1, title: 'Video 1', status: 'completed', file: 'test1.mp4', uploaded_at: '2024-01-01' },
   { id: 2, title: 'Video 2', status: 'pending', file: 'test2.mp4', uploaded_at: '2024-01-02' },
   { id: 3, title: 'Video 3', status: 'processing', file: 'test3.mp4', uploaded_at: '2024-01-03' },
+  { id: 4, title: 'Video 4', status: 'indexing', file: 'test4.mp4', uploaded_at: '2024-01-04' },
 ]
 
 const mockLoadVideos = vi.fn()
@@ -21,10 +22,11 @@ vi.mock('@/hooks/useVideos', () => ({
 
 vi.mock('@/hooks/useVideoStats', () => ({
   useVideoStats: () => ({
-    total: 3,
+    total: 4,
     completed: 1,
     pending: 1,
     processing: 1,
+    indexing: 1,
     error: 0,
   }),
 }))
@@ -96,6 +98,7 @@ describe('VideosPage', () => {
     expect(screen.getByText('videos.list.stats.completed')).toBeInTheDocument()
     expect(screen.getByText('videos.list.stats.pending')).toBeInTheDocument()
     expect(screen.getByText('videos.list.stats.processing')).toBeInTheDocument()
+    expect(screen.getByText('videos.list.stats.indexing')).toBeInTheDocument()
   })
 
   it('should render video list', () => {
@@ -105,6 +108,7 @@ describe('VideosPage', () => {
     expect(screen.getByText('Video 1')).toBeInTheDocument()
     expect(screen.getByText('Video 2')).toBeInTheDocument()
     expect(screen.getByText('Video 3')).toBeInTheDocument()
+    expect(screen.getByText('Video 4')).toBeInTheDocument()
   })
 
   it('should render tag filter panel', () => {


### PR DESCRIPTION
## 概要
Video.status に追加された `indexing` をフロントエンド全体で扱えるように修正しました。

## 変更内容
- API型定義に `indexing` を追加（`Video` / `VideoList` / `VideoInGroup`）
- ステータス集計フック `useVideoStats` に `indexing` カウントを追加
- Home / Videos 画面の統計カードに `indexing` を追加
- VideoGroupDetail のステータスフィルタに `indexing` を追加
- VideoDetail の文字起こし状態表示に `indexing` メッセージを追加
- i18n（ja/en）に以下の翻訳キーを追加
  - `common.messages.transcriptionIndexing`
  - `home.stats.indexing`
  - `videos.list.stats.indexing`
  - `videos.groupDetail.statusFilter.indexing`
- 関連ユニットテストを更新

## 動作確認
- `npm run test -- src/hooks/__tests__/useVideoStats.test.ts src/pages/__tests__/HomePage.test.tsx src/pages/__tests__/VideosPage.test.tsx src/lib/utils/__tests__/video.test.ts`
  - 35 tests passed
- `npm run typecheck`
  - 成功

## 目的
バックエンドで `indexing` が返る場合でも、型エラー・集計漏れ・フィルタ不可・表示不整合が出ないようにするため。
