### PR TITLE
Refine video use-case transaction boundaries and user domain exceptions

### DIFF
--- a/backend/app/composition_root/_video_core_providers.py
+++ b/backend/app/composition_root/_video_core_providers.py
@@ -58,6 +58,7 @@ def get_update_video_use_case() -> UpdateVideoUseCase:
     return UpdateVideoUseCase(
         shared.new_video_repository(),
         shared.new_vector_store_gateway(),
+        DjangoTransactionPort(),
     )
 
 
@@ -65,6 +66,7 @@ def get_delete_video_use_case() -> DeleteVideoUseCase:
     return DeleteVideoUseCase(
         shared.new_video_repository(),
         shared.new_vector_store_gateway(),
+        DjangoTransactionPort(),
     )
 
 

--- a/backend/app/domain/user/entities.py
+++ b/backend/app/domain/user/entities.py
@@ -4,7 +4,7 @@ Domain entity for the user context.
 
 from dataclasses import dataclass, field
 
-from app.domain.video.exceptions import VideoLimitExceeded
+from app.domain.user.exceptions import UserVideoLimitExceeded
 
 
 @dataclass
@@ -19,4 +19,4 @@ class UserEntity:
     def assert_can_upload_video(self, current_count: int | None = None) -> None:
         count = self.video_count if current_count is None else current_count
         if self.video_limit is not None and count >= self.video_limit:
-            raise VideoLimitExceeded(self.video_limit)
+            raise UserVideoLimitExceeded(self.video_limit)

--- a/backend/app/domain/user/exceptions.py
+++ b/backend/app/domain/user/exceptions.py
@@ -1,0 +1,9 @@
+"""Domain exceptions for user context."""
+
+
+class UserVideoLimitExceeded(Exception):
+    """Raised when user has reached allowed video uploads."""
+
+    def __init__(self, limit: int):
+        self.limit = limit
+        super().__init__(f"Video upload limit reached: {limit}")

--- a/backend/app/domain/user/tests/test_entities.py
+++ b/backend/app/domain/user/tests/test_entities.py
@@ -3,7 +3,7 @@
 from unittest import TestCase
 
 from app.domain.user.entities import UserEntity
-from app.domain.video.exceptions import VideoLimitExceeded
+from app.domain.user.exceptions import UserVideoLimitExceeded
 
 
 class UserEntityTests(TestCase):
@@ -16,7 +16,7 @@ class UserEntityTests(TestCase):
             video_limit=2,
             video_count=2,
         )
-        with self.assertRaises(VideoLimitExceeded):
+        with self.assertRaises(UserVideoLimitExceeded):
             user.assert_can_upload_video()
 
     def test_assert_can_upload_video_uses_current_count_when_given(self):
@@ -28,7 +28,7 @@ class UserEntityTests(TestCase):
             video_limit=3,
             video_count=0,
         )
-        with self.assertRaises(VideoLimitExceeded):
+        with self.assertRaises(UserVideoLimitExceeded):
             user.assert_can_upload_video(current_count=3)
 
     def test_assert_can_upload_video_allows_unlimited_users(self):

--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -367,7 +367,8 @@ class VideoDetailViewTests(APITestCase):
         url = reverse("video-detail", kwargs={"pk": self.video.pk})
         data = {"title": "Updated Title"}
 
-        response = self.client.patch(url, data, format="json")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["id"], self.video.id)
@@ -479,7 +480,8 @@ class TagViewTests(APITestCase):
         url = reverse("video-detail", kwargs={"pk": self.video.pk})
         video_id = self.video.id
 
-        response = self.client.delete(url)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         # Video should be hard deleted (record no longer exists)
@@ -494,7 +496,8 @@ class TagViewTests(APITestCase):
         mock_delete.side_effect = Exception("Vector deletion failed")
         url = reverse("video-detail", kwargs={"pk": self.video.pk})
 
-        response = self.client.delete(url)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(url)
 
         # Video should still be hard deleted even if vector deletion fails
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -514,7 +517,8 @@ class TagViewTests(APITestCase):
         self.assertEqual(VideoGroupMember.objects.filter(video=self.video).count(), 2)
 
         url = reverse("video-detail", kwargs={"pk": self.video.pk})
-        response = self.client.delete(url)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         # Video should be removed from all groups

--- a/backend/app/tests/test_import_rules.py
+++ b/backend/app/tests/test_import_rules.py
@@ -504,6 +504,23 @@ class ImportRulesTest(unittest.TestCase):
             ),
         )
 
+    def _check_domain_cross_context(self, context_path, forbidden_contexts):
+        """Verify that a domain context does not import from other domain contexts directly."""
+        all_violations = {}
+        for fp in sorted(self._iter_layer_source_files(f"domain/{context_path}")):
+            rel = os.path.relpath(fp, BASE)
+            v = check_forbidden_imports(fp, forbidden_contexts)
+            if v:
+                all_violations[rel] = v
+        self.assertEqual(
+            {},
+            all_violations,
+            f"Cross-context domain imports found in domain/{context_path}:\n"
+            + "\n".join(
+                f"  {f}: {vs}" for f, vs in all_violations.items()
+            ),
+        )
+
     def test_use_cases_chat_no_cross_context_imports(self):
         """use_cases/chat must not import from use_cases/video or use_cases/auth."""
         self._check_cross_context(
@@ -530,6 +547,13 @@ class ImportRulesTest(unittest.TestCase):
         self._check_cross_context(
             "media",
             ["app.use_cases.video", "app.use_cases.auth", "app.use_cases.chat"],
+        )
+
+    def test_domain_user_no_cross_context_imports(self):
+        """domain/user must not import app.domain.video/auth/chat/media directly."""
+        self._check_domain_cross_context(
+            "user",
+            ["app.domain.video", "app.domain.auth", "app.domain.chat", "app.domain.media"],
         )
 
     def test_infrastructure_has_no_drf_imports(self):

--- a/backend/app/use_cases/video/create_video.py
+++ b/backend/app/use_cases/video/create_video.py
@@ -5,9 +5,9 @@ Use case: Create a new video and dispatch transcription.
 import logging
 
 from app.domain.shared.transaction import TransactionPort
+from app.domain.user.exceptions import UserVideoLimitExceeded
 from app.domain.user.repositories import UserRepository
 from app.domain.video.dto import CreateVideoParams
-from app.domain.video.exceptions import VideoLimitExceeded as DomainVideoLimitExceeded
 from app.domain.video.gateways import VideoTaskGateway
 from app.domain.video.repositories import VideoRepository
 from app.use_cases.video.dto import CreateVideoInput, VideoResponseDTO
@@ -58,7 +58,7 @@ class CreateVideoUseCase:
             current_count = self.video_repo.count_for_user(user_id)
             try:
                 user.assert_can_upload_video(current_count)
-            except DomainVideoLimitExceeded as e:
+            except UserVideoLimitExceeded as e:
                 raise VideoLimitExceeded(e.limit) from e
 
             params = CreateVideoParams(

--- a/backend/app/use_cases/video/delete_video.py
+++ b/backend/app/use_cases/video/delete_video.py
@@ -4,6 +4,7 @@ Use case: Delete a video (hard delete) and clean up its file.
 
 import logging
 
+from app.domain.shared.transaction import TransactionPort
 from app.domain.video.gateways import VectorStoreGateway
 from app.domain.video.repositories import VideoRepository
 from app.use_cases.video.exceptions import ResourceNotFound
@@ -20,9 +21,15 @@ class DeleteVideoUseCase:
     4. File cleanup is handled by the repository after the transaction commits
     """
 
-    def __init__(self, video_repo: VideoRepository, vector_gateway: VectorStoreGateway):
+    def __init__(
+        self,
+        video_repo: VideoRepository,
+        vector_gateway: VectorStoreGateway,
+        tx: TransactionPort,
+    ):
         self.video_repo = video_repo
         self.vector_gateway = vector_gateway
+        self.tx = tx
 
     def execute(self, video_id: int, user_id: int) -> None:
         """
@@ -33,12 +40,17 @@ class DeleteVideoUseCase:
         if video is None:
             raise ResourceNotFound("Video")
 
-        self.video_repo.delete(video)
-        try:
-            self.vector_gateway.delete_video_vectors(video.id)
-        except Exception:
-            logger.warning(
-                "Failed to delete vectors for video %s after video deletion",
-                video.id,
-                exc_info=True,
-            )
+        with self.tx.atomic():
+            self.video_repo.delete(video)
+
+            def _cleanup_vectors() -> None:
+                try:
+                    self.vector_gateway.delete_video_vectors(video.id)
+                except Exception:
+                    logger.warning(
+                        "Failed to delete vectors for video %s after video deletion",
+                        video.id,
+                        exc_info=True,
+                    )
+
+            self.tx.on_commit(_cleanup_vectors)

--- a/backend/app/use_cases/video/tests/test_delete_video.py
+++ b/backend/app/use_cases/video/tests/test_delete_video.py
@@ -1,5 +1,7 @@
 """Unit tests for DeleteVideoUseCase."""
 
+from contextlib import contextmanager
+from typing import Callable
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -8,11 +10,24 @@ from app.use_cases.video.delete_video import DeleteVideoUseCase
 from app.use_cases.video.exceptions import ResourceNotFound
 
 
+class _FakeTransactionPort:
+    @contextmanager
+    def atomic(self):
+        yield
+
+    def on_commit(self, fn: Callable[[], None]) -> None:
+        fn()
+
+
 class DeleteVideoUseCaseTests(TestCase):
     def setUp(self):
         self.video_repo = MagicMock()
         self.vector_gateway = MagicMock()
-        self.use_case = DeleteVideoUseCase(self.video_repo, self.vector_gateway)
+        self.use_case = DeleteVideoUseCase(
+            self.video_repo,
+            self.vector_gateway,
+            _FakeTransactionPort(),
+        )
 
     def test_raises_when_video_not_found(self):
         self.video_repo.get_by_id.return_value = None

--- a/backend/app/use_cases/video/tests/test_update_video.py
+++ b/backend/app/use_cases/video/tests/test_update_video.py
@@ -1,0 +1,98 @@
+"""Unit tests for UpdateVideoUseCase."""
+
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Callable
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from app.domain.video.entities import VideoEntity
+from app.use_cases.video.dto import UpdateVideoInput
+from app.use_cases.video.exceptions import ResourceNotFound
+from app.use_cases.video.update_video import UpdateVideoUseCase
+
+
+class _FakeTransactionPort:
+    @contextmanager
+    def atomic(self):
+        yield
+
+    def on_commit(self, fn: Callable[[], None]) -> None:
+        fn()
+
+
+class UpdateVideoUseCaseTests(TestCase):
+    def setUp(self):
+        self.video_repo = MagicMock()
+        self.vector_gateway = MagicMock()
+        self.use_case = UpdateVideoUseCase(
+            self.video_repo,
+            self.vector_gateway,
+            _FakeTransactionPort(),
+        )
+
+    def test_raises_when_video_not_found(self):
+        self.video_repo.get_by_id.return_value = None
+
+        with self.assertRaises(ResourceNotFound):
+            self.use_case.execute(
+                video_id=1,
+                user_id=10,
+                input=UpdateVideoInput(title="new"),
+            )
+
+    def test_updates_video_and_syncs_vector_title_when_title_changed(self):
+        before = VideoEntity(
+            id=7,
+            user_id=10,
+            title="old",
+            status="completed",
+            uploaded_at=datetime(2026, 1, 1),
+        )
+        after = VideoEntity(
+            id=7,
+            user_id=10,
+            title="new",
+            status="completed",
+            uploaded_at=datetime(2026, 1, 1),
+        )
+        self.video_repo.get_by_id.return_value = before
+        self.video_repo.update.return_value = after
+
+        result = self.use_case.execute(
+            video_id=7,
+            user_id=10,
+            input=UpdateVideoInput(title="new"),
+        )
+
+        self.assertEqual(result.title, "new")
+        self.vector_gateway.update_video_title.assert_called_once_with(7, "new")
+
+    def test_does_not_sync_vector_title_when_title_is_unchanged(self):
+        video = VideoEntity(id=7, user_id=10, title="same", status="completed")
+        self.video_repo.get_by_id.return_value = video
+        self.video_repo.update.return_value = video
+
+        self.use_case.execute(
+            video_id=7,
+            user_id=10,
+            input=UpdateVideoInput(description="only description update"),
+        )
+
+        self.vector_gateway.update_video_title.assert_not_called()
+
+    def test_vector_sync_failure_is_non_fatal(self):
+        before = VideoEntity(id=7, user_id=10, title="old", status="completed")
+        after = VideoEntity(id=7, user_id=10, title="new", status="completed")
+        self.video_repo.get_by_id.return_value = before
+        self.video_repo.update.return_value = after
+        self.vector_gateway.update_video_title.side_effect = RuntimeError("boom")
+
+        result = self.use_case.execute(
+            video_id=7,
+            user_id=10,
+            input=UpdateVideoInput(title="new"),
+        )
+
+        self.assertEqual(result.title, "new")
+        self.video_repo.update.assert_called_once()

--- a/backend/app/use_cases/video/update_video.py
+++ b/backend/app/use_cases/video/update_video.py
@@ -2,12 +2,17 @@
 Use case: Update a video and sync PGVector metadata when the title changes.
 """
 
+import logging
+
+from app.domain.shared.transaction import TransactionPort
 from app.domain.video.dto import UpdateVideoParams
 from app.domain.video.gateways import VectorStoreGateway
 from app.domain.video.repositories import VideoRepository
 from app.use_cases.video.dto import UpdateVideoInput, VideoResponseDTO
 from app.use_cases.video.exceptions import ResourceNotFound
 from app.use_cases.video.file_url import to_video_response_dto
+
+logger = logging.getLogger(__name__)
 
 
 class UpdateVideoUseCase:
@@ -22,9 +27,11 @@ class UpdateVideoUseCase:
         self,
         video_repo: VideoRepository,
         vector_gateway: VectorStoreGateway,
+        tx: TransactionPort,
     ):
         self.video_repo = video_repo
         self.vector_gateway = vector_gateway
+        self.tx = tx
 
     def execute(self, video_id: int, user_id: int, input: UpdateVideoInput) -> VideoResponseDTO:
         """
@@ -38,11 +45,22 @@ class UpdateVideoUseCase:
         if video is None:
             raise ResourceNotFound("Video")
 
-        old_title = video.title
-        params = UpdateVideoParams(title=input.title, description=input.description)
-        video = self.video_repo.update(video, params)
+        with self.tx.atomic():
+            old_title = video.title
+            params = UpdateVideoParams(title=input.title, description=input.description)
+            video = self.video_repo.update(video, params)
 
-        if input.title is not None and old_title != video.title:
-            self.vector_gateway.update_video_title(video.id, video.title)
+            if input.title is not None and old_title != video.title:
+                def _sync_vector_title() -> None:
+                    try:
+                        self.vector_gateway.update_video_title(video.id, video.title)
+                    except Exception:
+                        logger.warning(
+                            "Failed to sync vector title for video %s after update",
+                            video.id,
+                            exc_info=True,
+                        )
+
+                self.tx.on_commit(_sync_vector_title)
 
         return to_video_response_dto(video)


### PR DESCRIPTION
## Summary

- **Transaction boundaries**: `DeleteVideoUseCase` and `UpdateVideoUseCase` now wrap DB writes in `tx.atomic()` and defer vector-store side-effects to `tx.on_commit()`, ensuring vector cleanup only runs after a successful commit
- **User domain isolation**: `UserVideoLimitExceeded` extracted to `domain/user/exceptions.py`, removing the cross-context import from `domain/user → domain/video`
- **Tests**: Added `UpdateVideoUseCaseTests` unit tests; updated `DeleteVideoUseCaseTests` and presentation view tests to use `_FakeTransactionPort` / `captureOnCommitCallbacks`; added `test_domain_user_no_cross_context_imports` boundary rule

## Test plan

- [x] `docker compose run --rm backend python manage.py test app` — all tests pass
- [x] Verify `DeleteVideoUseCase` does not delete vectors if the DB transaction rolls back
- [x] Verify `UpdateVideoUseCase` does not sync vector title if the DB transaction rolls back
- [x] Confirm `UserVideoLimitExceeded` is raised (not `VideoLimitExceeded`) when upload limit is reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)