### PR TITLE
Fix docs redirect for unauthenticated users

### DIFF
--- a/frontend/src/hooks/__tests__/useAuth.test.ts
+++ b/frontend/src/hooks/__tests__/useAuth.test.ts
@@ -48,8 +48,20 @@ describe('useAuth', () => {
       expect(result.current.loading).toBe(false)
     })
 
-    // For public routes, getMe should not be called
-    // Note: This test may need adjustment based on actual behavior
+    expect(apiClient.getMe).not.toHaveBeenCalled()
+  })
+
+  it('should not load user data for docs routes', async () => {
+    ;(globalThis as any).__setMockPathname?.('/docs')
+    window.history.pushState({}, '', '/docs')
+
+    const { result } = renderHook(() => useAuth())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(apiClient.getMe).not.toHaveBeenCalled()
   })
 
   it('should redirect to login on authentication error', async () => {
@@ -110,4 +122,3 @@ describe('useAuth', () => {
     })
   })
 })
-

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -39,6 +39,7 @@ export function useAuth(options: UseAuthOptions = {}): UseAuthReturn {
     '/reset-password',
     '/verify-email',
     '/share',
+    '/docs',
   ];
   const authRequired = !publicPaths.some((path) => pathname.startsWith(path));
 


### PR DESCRIPTION
## Summary
- treat `/docs` as a public route in `useAuth`
- prevent auth check (`getMe`) from running on docs routes
- add/strengthen tests to assert `getMe` is not called on public routes, including `/docs`

## Background
The Developer Docs link was clickable when logged out but redirected to login immediately. This happened because auth checks still ran on docs routes and triggered the global 401 login redirect.

## Changes
- `frontend/src/hooks/useAuth.ts`
  - add `/docs` to `publicPaths`
- `frontend/src/hooks/__tests__/useAuth.test.ts`
  - assert `getMe` is not called on existing public route test
  - add a dedicated `/docs` public-route test

## Test
- attempted: `npm test -- --run src/hooks/__tests__/useAuth.test.ts`
- note: test execution failed in current environment due to module resolution error for `@tanstack/react-query` in `vitest.setup.ts`
