### PR TITLE
Add retrieval-only RAG search endpoint for chat

### DIFF
--- a/backend/app/composition_root/__init__.py
+++ b/backend/app/composition_root/__init__.py
@@ -29,6 +29,7 @@ from app.composition_root.chat import (
     get_chat_history_use_case,
     get_export_history_use_case,
     get_popular_scenes_use_case,
+    get_search_related_videos_use_case,
     get_send_message_use_case,
     get_submit_feedback_use_case,
 )
@@ -98,6 +99,7 @@ __all__ = [
     "get_remove_tag_from_video_use_case",
     # chat
     "get_send_message_use_case",
+    "get_search_related_videos_use_case",
     "get_chat_history_use_case",
     "get_chat_analytics_use_case",
     "get_popular_scenes_use_case",

--- a/backend/app/composition_root/chat.py
+++ b/backend/app/composition_root/chat.py
@@ -22,6 +22,7 @@ from app.use_cases.chat.export_history import ExportChatHistoryUseCase
 from app.use_cases.chat.get_analytics import GetChatAnalyticsUseCase
 from app.use_cases.chat.get_history import GetChatHistoryUseCase
 from app.use_cases.chat.get_popular_scenes import GetPopularScenesUseCase
+from app.use_cases.chat.search_related_videos import SearchRelatedVideosUseCase
 from app.use_cases.chat.send_message import SendMessageUseCase
 from app.use_cases.chat.submit_feedback import SubmitFeedbackUseCase
 
@@ -57,6 +58,13 @@ def _get_scene_video_info_provider() -> DjangoSceneVideoInfoProvider:
 def get_send_message_use_case() -> SendMessageUseCase:
     return SendMessageUseCase(
         _new_chat_repository(),
+        _new_video_group_query_repository(),
+        _get_rag_gateway(),
+    )
+
+
+def get_search_related_videos_use_case() -> SearchRelatedVideosUseCase:
+    return SearchRelatedVideosUseCase(
         _new_video_group_query_repository(),
         _get_rag_gateway(),
     )

--- a/backend/app/dependencies/chat.py
+++ b/backend/app/dependencies/chat.py
@@ -7,6 +7,10 @@ def get_send_message_use_case():
     return _cr.get_send_message_use_case()
 
 
+def get_search_related_videos_use_case():
+    return _cr.get_search_related_videos_use_case()
+
+
 def get_submit_feedback_use_case():
     return _cr.get_submit_feedback_use_case()
 

--- a/backend/app/domain/chat/gateways.py
+++ b/backend/app/domain/chat/gateways.py
@@ -60,3 +60,27 @@ class RagGateway(ABC):
             LLMProviderError: If the LLM provider returns an error.
         """
         ...
+
+    @abstractmethod
+    def search_related_videos(
+        self,
+        query_text: str,
+        user_id: int,
+        video_ids: Optional[Sequence[int]] = None,
+    ) -> Optional[Sequence[RelatedVideoDTO]]:
+        """
+        Execute retrieval-only search and return related video scenes.
+
+        Args:
+            query_text: User query text used for vector retrieval.
+            user_id: ID of the user making the request (for retrieval scoping).
+            video_ids: Optional list of video IDs to scope retrieval to.
+
+        Returns:
+            Related video scene list or None when no retrieval target exists.
+
+        Raises:
+            RagUserNotFoundError: If the user context does not exist.
+            LLMProviderError: If the retrieval provider returns an error.
+        """
+        ...

--- a/backend/app/infrastructure/external/rag_gateway.py
+++ b/backend/app/infrastructure/external/rag_gateway.py
@@ -80,3 +80,39 @@ class RagChatGateway(RagGateway):
             query_text=result.query_text,
             related_videos=related_videos,
         )
+
+    def search_related_videos(
+        self,
+        query_text: str,
+        user_id: int,
+        video_ids: Optional[Sequence[int]] = None,
+    ) -> Optional[Sequence[RelatedVideoDTO]]:
+        User = get_user_model()
+        try:
+            user = User.objects.get(pk=user_id)
+        except User.DoesNotExist as exc:
+            raise RagUserNotFoundError(f"User not found: {user_id}") from exc
+
+        service = RagChatService(user=user)
+        raw_video_ids = list(video_ids) if video_ids is not None else None
+
+        try:
+            related_videos = service.search_related_videos(
+                query_text=query_text,
+                video_ids=raw_video_ids,
+            )
+        except Exception as exc:
+            raise LLMProviderError(str(exc)) from exc
+
+        if not related_videos:
+            return None
+
+        return [
+            RelatedVideoDTO(
+                video_id=int(raw_video.get("video_id", 0) or 0),
+                title=str(raw_video.get("title", "")),
+                start_time=raw_video.get("start_time"),
+                end_time=raw_video.get("end_time"),
+            )
+            for raw_video in related_videos
+        ]

--- a/backend/app/infrastructure/external/rag_service.py
+++ b/backend/app/infrastructure/external/rag_service.py
@@ -33,7 +33,7 @@ class RagChatResult:
 class RagChatService:
     """Service class that handles RAG logic for chat."""
 
-    def __init__(self, user, llm):
+    def __init__(self, user, llm=None):
         self.user = user
         self.llm = llm
         self.prompt = ChatPromptTemplate.from_messages(
@@ -50,6 +50,9 @@ class RagChatService:
         locale: Optional[str] = None,
         video_ids: Optional[List[int]] = None,
     ) -> RagChatResult:
+        if self.llm is None:
+            raise RuntimeError("LLM is required for full RAG response generation.")
+
         query_text = self._extract_latest_user_query(messages)
         # video_ids takes precedence over group (allows gateway to pass IDs directly)
         retriever = self._get_retriever(group, video_ids=video_ids)
@@ -90,6 +93,23 @@ class RagChatService:
             query_text=query_text,
             related_videos=related_videos,
         )
+
+    def search_related_videos(
+        self,
+        query_text: str,
+        group: Optional["VideoGroup"] = None,
+        video_ids: Optional[List[int]] = None,
+    ) -> Optional[List[Dict[str, str]]]:
+        if not query_text.strip():
+            return None
+
+        retriever = self._get_retriever(group, video_ids=video_ids)
+        if retriever is None:
+            return None
+
+        docs_obj = retriever.invoke(query_text)
+        docs = cast(Sequence[Any], docs_obj or [])
+        return self._extract_related_videos(docs)
 
     def _extract_latest_user_query(self, messages: Sequence[Dict[str, str]]) -> str:
         for msg in reversed(messages):

--- a/backend/app/presentation/chat/serializers.py
+++ b/backend/app/presentation/chat/serializers.py
@@ -26,6 +26,18 @@ class ChatResponseSerializer(serializers.Serializer):
     feedback = serializers.CharField(required=False, allow_null=True)
 
 
+class ChatSearchRequestSerializer(serializers.Serializer):
+    query_text = serializers.CharField()
+    group_id = serializers.IntegerField(required=True)
+
+
+class ChatSearchResponseSerializer(serializers.Serializer):
+    query_text = serializers.CharField()
+    related_videos = serializers.ListField(
+        child=serializers.DictField(), required=False, allow_null=True
+    )
+
+
 class RelatedVideoSerializer(serializers.Serializer):
     video_id = serializers.IntegerField()
     title = serializers.CharField()

--- a/backend/app/presentation/chat/tests/test_views.py
+++ b/backend/app/presentation/chat/tests/test_views.py
@@ -223,3 +223,84 @@ class ChatViewTests(APITestCase):
         self.assertIsInstance(related[0], dict)
         self.assertEqual(related[0]["video_id"], self.video.id)
         self.assertEqual(related[0]["start_time"], "00:00:10")
+
+
+class ChatSearchViewTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="searchuser",
+            email="search@example.com",
+            password="testpass123",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Search Video",
+            description="Search Description",
+            status="completed",
+        )
+        share_token = secrets.token_urlsafe(32)
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="Search Group",
+            description="Test",
+            share_token=share_token,
+        )
+        VideoGroupMember.objects.create(group=self.group, video=self.video, order=0)
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.search_related_videos")
+    def test_search_related_scenes(self, mock_search_related_videos):
+        mock_search_related_videos.return_value = [
+            RelatedVideoDTO(
+                video_id=self.video.id,
+                title=self.video.title,
+                start_time="00:00:30",
+                end_time="00:00:45",
+            )
+        ]
+
+        response = self.client.post(
+            reverse("chat-search"),
+            {
+                "query_text": "この部分の説明を探して",
+                "group_id": self.group.id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["query_text"], "この部分の説明を探して")
+        self.assertEqual(response.data["related_videos"][0]["video_id"], self.video.id)
+
+    def test_search_related_scenes_rejects_empty_query(self):
+        response = self.client.post(
+            reverse("chat-search"),
+            {"query_text": "", "group_id": self.group.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)
+
+    def test_search_related_scenes_group_not_found(self):
+        response = self.client.post(
+            reverse("chat-search"),
+            {"query_text": "q", "group_id": 99999},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.search_related_videos")
+    def test_search_related_scenes_with_share_token(self, mock_search_related_videos):
+        mock_search_related_videos.return_value = []
+        self.client.force_authenticate(user=None)
+
+        response = self.client.post(
+            f"{reverse('chat-search')}?share_token={self.group.share_token}",
+            {"query_text": "q", "group_id": self.group.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["query_text"], "q")

--- a/backend/app/presentation/chat/urls.py
+++ b/backend/app/presentation/chat/urls.py
@@ -7,6 +7,7 @@ from .views import (
     ChatFeedbackView,
     ChatHistoryExportView,
     ChatHistoryView,
+    ChatSearchView,
     ChatView,
     PopularScenesView,
 )
@@ -16,6 +17,13 @@ urlpatterns = [
         "",
         ChatView.as_view(send_message_use_case=chat_dependencies.get_send_message_use_case),
         name="chat",
+    ),
+    path(
+        "search/",
+        ChatSearchView.as_view(
+            search_related_videos_use_case=chat_dependencies.get_search_related_videos_use_case
+        ),
+        name="chat-search",
     ),
     path(
         "history/",

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -45,6 +45,8 @@ from .serializers import (
     ChatLogSerializer,
     ChatRequestSerializer,
     ChatResponseSerializer,
+    ChatSearchRequestSerializer,
+    ChatSearchResponseSerializer,
 )
 
 
@@ -130,6 +132,72 @@ class ChatView(DependencyResolverMixin, APIView):
         if result.chat_log_id is not None:
             response_data["chat_log_id"] = result.chat_log_id
             response_data["feedback"] = result.feedback
+
+        return Response(response_data)
+
+
+class ChatSearchView(DependencyResolverMixin, APIView):
+    """Retrieval-only endpoint for related video scenes."""
+
+    authentication_classes = [
+        APIKeyAuthentication,
+        CookieJWTAuthentication,
+        ShareTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticatedOrSharedAccess, ApiKeyScopePermission]
+    required_scope = "read"
+    throttle_classes = [
+        ShareTokenIPThrottle,
+        ShareTokenGlobalThrottle,
+        AuthenticatedChatThrottle,
+    ]
+    search_related_videos_use_case = None
+
+    @extend_schema(
+        request=ChatSearchRequestSerializer,
+        responses={200: ChatSearchResponseSerializer},
+        summary="Search related scenes",
+        description=(
+            "Run retrieval-only search for related scenes within a group. "
+            "No LLM answer generation is performed."
+        ),
+    )
+    def post(self, request):
+        share_token = request.query_params.get("share_token")
+        is_shared = share_token is not None
+
+        serializer = ChatSearchRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        use_case = self.resolve_dependency(self.search_related_videos_use_case)
+        try:
+            result = use_case.execute(
+                user_id=getattr(request.user, "id", None),
+                query_text=serializer.validated_data["query_text"],
+                group_id=serializer.validated_data["group_id"],
+                share_token=share_token,
+                is_shared=is_shared,
+            )
+        except InvalidChatRequestError as e:
+            return create_error_response(str(e), status.HTTP_400_BAD_REQUEST)
+        except ResourceNotFound as e:
+            return create_error_response(str(e), status.HTTP_404_NOT_FOUND)
+        except PermissionDenied as e:
+            return create_error_response(str(e), status.HTTP_403_FORBIDDEN)
+        except LLMProviderError as e:
+            return create_error_response(str(e), status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        response_data = {"query_text": result.query_text}
+        if result.related_videos:
+            response_data["related_videos"] = [
+                {
+                    "video_id": v.video_id,
+                    "title": v.title,
+                    "start_time": v.start_time,
+                    "end_time": v.end_time,
+                }
+                for v in result.related_videos
+            ]
 
         return Response(response_data)
 

--- a/backend/app/use_cases/chat/dto.py
+++ b/backend/app/use_cases/chat/dto.py
@@ -41,6 +41,14 @@ class SendMessageResultDTO:
 
 
 @dataclass
+class SearchRelatedVideosResultDTO:
+    """Use-case output DTO for retrieval-only related video search."""
+
+    query_text: str
+    related_videos: Optional[Sequence[RelatedVideoResponseDTO]]
+
+
+@dataclass
 class ChatHistoryExportRow:
     """A single row of chat history returned by ExportChatHistoryUseCase."""
 

--- a/backend/app/use_cases/chat/search_related_videos.py
+++ b/backend/app/use_cases/chat/search_related_videos.py
@@ -1,0 +1,108 @@
+"""Use case: Retrieval-only related video search for chat/RAG."""
+
+from typing import Optional, Sequence
+
+from app.domain.chat.gateways import LLMProviderError as _DomainLLMProviderError
+from app.domain.chat.gateways import RagGateway
+from app.domain.chat.gateways import RagUserNotFoundError as _DomainRagUserNotFoundError
+from app.domain.chat.repositories import VideoGroupQueryRepository
+from app.domain.chat.services import (
+    ChatRequestPolicy,
+    GroupContextNotFound as _DomainGroupContextNotFound,
+    InvalidSendMessageRequest as _DomainInvalidSendMessageRequest,
+    OwnerUserResolutionError as _DomainOwnerUserResolutionError,
+    require_group_context,
+)
+from app.use_cases.chat.dto import RelatedVideoResponseDTO, SearchRelatedVideosResultDTO
+from app.use_cases.chat.exceptions import InvalidChatRequestError, LLMProviderError
+from app.use_cases.shared.exceptions import PermissionDenied, ResourceNotFound
+
+
+class SearchRelatedVideosUseCase:
+    """Execute only the retrieval step of the RAG pipeline."""
+
+    def __init__(
+        self,
+        group_query_repo: VideoGroupQueryRepository,
+        rag_gateway: RagGateway,
+    ):
+        self.group_query_repo = group_query_repo
+        self.rag_gateway = rag_gateway
+
+    def execute(
+        self,
+        *,
+        user_id: Optional[int],
+        query_text: str,
+        group_id: Optional[int],
+        share_token: Optional[str] = None,
+        is_shared: bool = False,
+    ) -> SearchRelatedVideosResultDTO:
+        if not query_text.strip():
+            raise InvalidChatRequestError("Query text is empty.")
+
+        policy = ChatRequestPolicy(
+            is_shared=is_shared,
+            authenticated_user_id=user_id,
+            share_token=share_token,
+            group_id=group_id,
+        )
+
+        try:
+            # Reuse shared-access/group precondition rules.
+            policy.validate_send_message_preconditions(messages_count=1)
+        except _DomainInvalidSendMessageRequest as e:
+            raise InvalidChatRequestError(str(e)) from e
+
+        if group_id is None:
+            raise InvalidChatRequestError("Group ID not specified.")
+
+        if is_shared and share_token:
+            group_candidate = self.group_query_repo.get_with_members(
+                group_id=group_id,
+                share_token=share_token,
+            )
+        else:
+            group_candidate = self.group_query_repo.get_with_members(
+                group_id=group_id,
+                user_id=user_id,
+            )
+
+        try:
+            group = require_group_context(group_candidate)
+        except _DomainGroupContextNotFound:
+            raise ResourceNotFound("Group")
+
+        try:
+            owner_user_id = policy.resolve_owner_user_id(group_user_id=group.user_id)
+        except _DomainOwnerUserResolutionError as e:
+            raise PermissionDenied(str(e)) from e
+
+        video_ids: Sequence[int] = group.member_video_ids
+
+        try:
+            related_videos = self.rag_gateway.search_related_videos(
+                query_text=query_text,
+                user_id=owner_user_id,
+                video_ids=video_ids,
+            )
+        except _DomainRagUserNotFoundError as e:
+            raise ResourceNotFound("User") from e
+        except _DomainLLMProviderError as e:
+            raise LLMProviderError(str(e)) from e
+
+        return SearchRelatedVideosResultDTO(
+            query_text=query_text,
+            related_videos=(
+                [
+                    RelatedVideoResponseDTO(
+                        video_id=v.video_id,
+                        title=v.title,
+                        start_time=v.start_time,
+                        end_time=v.end_time,
+                    )
+                    for v in (related_videos or [])
+                ]
+                or None
+            ),
+        )

--- a/backend/app/use_cases/chat/tests/test_search_related_videos.py
+++ b/backend/app/use_cases/chat/tests/test_search_related_videos.py
@@ -1,0 +1,100 @@
+"""Tests for SearchRelatedVideosUseCase."""
+
+import unittest
+
+from app.domain.chat.dtos import RelatedVideoDTO
+from app.domain.chat.entities import VideoGroupContextEntity, VideoGroupMemberRef
+from app.domain.chat.gateways import RagGateway, RagUserNotFoundError
+from app.domain.chat.repositories import VideoGroupQueryRepository
+from app.use_cases.chat.exceptions import InvalidChatRequestError
+from app.use_cases.chat.search_related_videos import SearchRelatedVideosUseCase
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+
+class _StubGroupRepository(VideoGroupQueryRepository):
+    def __init__(self, group):
+        self.group = group
+
+    def get_with_members(self, group_id: int, user_id=None, share_token=None):
+        return self.group
+
+
+class _StubRagGateway(RagGateway):
+    def generate_reply(self, messages, user_id, video_ids=None, locale=None):
+        raise NotImplementedError
+
+    def search_related_videos(self, query_text, user_id, video_ids=None):
+        return [
+            RelatedVideoDTO(
+                video_id=video_ids[0],
+                title="Video",
+                start_time="00:00:10",
+                end_time="00:00:20",
+            )
+        ]
+
+
+class _RagGatewayUserNotFound(RagGateway):
+    def generate_reply(self, messages, user_id, video_ids=None, locale=None):
+        raise NotImplementedError
+
+    def search_related_videos(self, query_text, user_id, video_ids=None):
+        raise RagUserNotFoundError(f"User not found: {user_id}")
+
+
+class SearchRelatedVideosUseCaseTests(unittest.TestCase):
+    def setUp(self):
+        self.group = VideoGroupContextEntity(
+            id=10,
+            user_id=20,
+            name="g",
+            members=[VideoGroupMemberRef(video_id=111)],
+        )
+
+    def test_execute_raises_when_query_empty(self):
+        use_case = SearchRelatedVideosUseCase(
+            group_query_repo=_StubGroupRepository(self.group),
+            rag_gateway=_StubRagGateway(),
+        )
+
+        with self.assertRaises(InvalidChatRequestError) as cm:
+            use_case.execute(user_id=20, query_text="   ", group_id=10)
+
+        self.assertEqual(str(cm.exception), "Query text is empty.")
+
+    def test_execute_raises_when_group_not_found(self):
+        use_case = SearchRelatedVideosUseCase(
+            group_query_repo=_StubGroupRepository(None),
+            rag_gateway=_StubRagGateway(),
+        )
+
+        with self.assertRaises(ResourceNotFound) as cm:
+            use_case.execute(user_id=20, query_text="hello", group_id=10)
+
+        self.assertEqual(str(cm.exception), "Group not found.")
+
+    def test_execute_maps_rag_user_not_found_to_resource_not_found(self):
+        use_case = SearchRelatedVideosUseCase(
+            group_query_repo=_StubGroupRepository(self.group),
+            rag_gateway=_RagGatewayUserNotFound(),
+        )
+
+        with self.assertRaises(ResourceNotFound) as cm:
+            use_case.execute(user_id=20, query_text="hello", group_id=10)
+
+        self.assertEqual(str(cm.exception), "User not found.")
+
+    def test_execute_returns_related_videos(self):
+        use_case = SearchRelatedVideosUseCase(
+            group_query_repo=_StubGroupRepository(self.group),
+            rag_gateway=_StubRagGateway(),
+        )
+
+        result = use_case.execute(user_id=20, query_text="hello", group_id=10)
+
+        self.assertEqual(result.query_text, "hello")
+        self.assertEqual(result.related_videos[0].video_id, 111)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/app/use_cases/chat/tests/test_send_message.py
+++ b/backend/app/use_cases/chat/tests/test_send_message.py
@@ -39,6 +39,9 @@ class _RagGatewayUserNotFound(RagGateway):
     def generate_reply(self, messages, user_id, video_ids=None, locale=None):
         raise RagUserNotFoundError(f"User not found: {user_id}")
 
+    def search_related_videos(self, query_text, user_id, video_ids=None):
+        raise NotImplementedError
+
 
 class SendMessageUseCaseTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- add `POST /api/chat/search/` as a retrieval-only endpoint for related scenes (no LLM generation)
- add `SearchRelatedVideosUseCase` and DI wiring in chat composition/dependencies
- extend `RagGateway` / `RagChatGateway` / `RagChatService` with retrieval-only search path
- add request/response serializers and route for chat search
- add tests for the new use case and presentation layer

## API
- endpoint: `POST /api/chat/search/`
- request: `{ "query_text": string, "group_id": number }`
- response: `{ "query_text": string, "related_videos"?: [...] }`
- auth: same as chat (JWT/API key/share token)
- scope: read-only (`required_scope = "read"`)

## Verification
- docker test run:
  - `python manage.py test --keepdb app.use_cases.chat.tests.test_search_related_videos app.presentation.chat.tests.test_views app.use_cases.chat.tests.test_send_message`
- manual API check with API key:
  - `GET /api/videos/groups/` to resolve `group_id`
  - `POST /api/chat/search/` returned 200 with `related_videos`
