### PR TITLE
Refactor tag creation to use TagCreateDialog

### DIFF
--- a/frontend/src/hooks/useVideoEditing.ts
+++ b/frontend/src/hooks/useVideoEditing.ts
@@ -1,13 +1,11 @@
 import { useState, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient, type Tag, type Video } from '@/lib/api';
+import { apiClient, type Video } from '@/lib/api';
 import { queryKeys } from '@/lib/queryKeys';
 
 interface UseVideoEditingOptions {
   video: Video | null;
   videoId: number | null;
-  createTag: (name: string) => Promise<unknown>;
 }
 
 interface UseVideoEditingReturn {
@@ -21,11 +19,9 @@ interface UseVideoEditingReturn {
   startEditing: () => void;
   cancelEditing: () => void;
   handleUpdateVideo: () => Promise<void>;
-  handleCreateTag: () => Promise<void>;
 }
 
-export function useVideoEditing({ video, videoId, createTag }: UseVideoEditingOptions): UseVideoEditingReturn {
-  const { t } = useTranslation();
+export function useVideoEditing({ video, videoId }: UseVideoEditingOptions): UseVideoEditingReturn {
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [editedTitle, setEditedTitle] = useState('');
@@ -83,21 +79,6 @@ export function useVideoEditing({ video, videoId, createTag }: UseVideoEditingOp
     await saveVideoMutation.mutateAsync();
   }, [videoId, video, saveVideoMutation]);
 
-  const handleCreateTag = useCallback(async () => {
-    const tagName = prompt(t('tags.create.prompt', 'Enter new tag name:'));
-    if (tagName && tagName.trim()) {
-      try {
-        const newTag = (await createTag(tagName.trim())) as Tag;
-        if (newTag) {
-          setEditedTagIds(prev => [...prev, newTag.id]);
-        }
-      } catch (error) {
-        console.error('Failed to create tag:', error);
-        alert(t('tags.create.error', 'Failed to create tag'));
-      }
-    }
-  }, [createTag, t]);
-
   return {
     isEditing,
     editedTitle,
@@ -109,6 +90,5 @@ export function useVideoEditing({ video, videoId, createTag }: UseVideoEditingOp
     startEditing,
     cancelEditing,
     handleUpdateVideo,
-    handleCreateTag,
   };
 }

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Link, useI18nNavigate, useLocale } from '@/lib/i18n';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -15,6 +15,7 @@ import { InlineSpinner } from '@/components/common/InlineSpinner';
 import { getStatusBadgeClassName, getStatusLabel, formatDate } from '@/lib/utils/video';
 import { TagBadge } from '@/components/video/TagBadge';
 import { TagSelector } from '@/components/video/TagSelector';
+import { TagCreateDialog } from '@/components/video/TagCreateDialog';
 import { useTags } from '@/hooks/useTags';
 import { useVideoEditing } from '@/hooks/useVideoEditing';
 import { useVideoDetailPageMutations } from '@/hooks/useVideoDetailPageData';
@@ -141,6 +142,7 @@ export default function VideoDetailPage() {
 
   const { video, isLoading, error } = useVideo(videoId);
   const { tags, createTag } = useTags();
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 
   const {
     isEditing,
@@ -153,8 +155,12 @@ export default function VideoDetailPage() {
     startEditing,
     cancelEditing,
     handleUpdateVideo,
-    handleCreateTag,
-  } = useVideoEditing({ video, videoId, createTag });
+  } = useVideoEditing({ video, videoId });
+
+  const handleCreateTag = useCallback(async (name: string, color: string) => {
+    const newTag = await createTag(name, color);
+    setEditedTagIds((prev) => (prev.includes(newTag.id) ? prev : [...prev, newTag.id]));
+  }, [createTag, setEditedTagIds]);
 
   const handleVideoLoaded = () => {
     if (videoRef.current && startTime) {
@@ -280,7 +286,7 @@ export default function VideoDetailPage() {
                         : [...prev, tagId]
                     );
                   }}
-                  onCreateTag={handleCreateTag}
+                  onCreateTag={() => setIsCreateDialogOpen(true)}
                   onSave={() => void updateMutation.mutateAsync()}
                   onCancel={cancelEditing}
                 />
@@ -357,6 +363,11 @@ export default function VideoDetailPage() {
           )}
         </div>
       </div>
+      <TagCreateDialog
+        isOpen={isCreateDialogOpen}
+        onClose={() => setIsCreateDialogOpen(false)}
+        onCreate={handleCreateTag}
+      />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary

- `useVideoEditing` フックから `createTag` prop と `handleCreateTag`（ブラウザの `prompt()` を使用）を削除
- `VideoDetailPage` に `TagCreateDialog` コンポーネントを追加し、タグ作成のUIを改善
- タグ作成時にカラー選択が可能になり、UXが向上

## Test plan

- [x] 動画詳細ページで編集モードに入り、タグセレクターの「新規タグ作成」をクリック
- [x] `TagCreateDialog` が開くことを確認
- [x] タグ名と色を入力して作成できることを確認
- [x] 作成したタグが編集中のタグリストに追加されることを確認
- [x] キャンセルでダイアログが閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)