### PR TITLE
feat: Developer docs portal, MCP server, chat retrieval endpoint, and tag create dialog

### DIFF
--- a/frontend/src/hooks/useVideoEditing.ts
+++ b/frontend/src/hooks/useVideoEditing.ts
@@ -1,13 +1,11 @@
 import { useState, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient, type Tag, type Video } from '@/lib/api';
+import { apiClient, type Video } from '@/lib/api';
 import { queryKeys } from '@/lib/queryKeys';
 
 interface UseVideoEditingOptions {
   video: Video | null;
   videoId: number | null;
-  createTag: (name: string) => Promise<unknown>;
 }
 
 interface UseVideoEditingReturn {
@@ -21,11 +19,9 @@ interface UseVideoEditingReturn {
   startEditing: () => void;
   cancelEditing: () => void;
   handleUpdateVideo: () => Promise<void>;
-  handleCreateTag: () => Promise<void>;
 }
 
-export function useVideoEditing({ video, videoId, createTag }: UseVideoEditingOptions): UseVideoEditingReturn {
-  const { t } = useTranslation();
+export function useVideoEditing({ video, videoId }: UseVideoEditingOptions): UseVideoEditingReturn {
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [editedTitle, setEditedTitle] = useState('');
@@ -83,21 +79,6 @@ export function useVideoEditing({ video, videoId, createTag }: UseVideoEditingOp
     await saveVideoMutation.mutateAsync();
   }, [videoId, video, saveVideoMutation]);
 
-  const handleCreateTag = useCallback(async () => {
-    const tagName = prompt(t('tags.create.prompt', 'Enter new tag name:'));
-    if (tagName && tagName.trim()) {
-      try {
-        const newTag = (await createTag(tagName.trim())) as Tag;
-        if (newTag) {
-          setEditedTagIds(prev => [...prev, newTag.id]);
-        }
-      } catch (error) {
-        console.error('Failed to create tag:', error);
-        alert(t('tags.create.error', 'Failed to create tag'));
-      }
-    }
-  }, [createTag, t]);
-
   return {
     isEditing,
     editedTitle,
@@ -109,6 +90,5 @@ export function useVideoEditing({ video, videoId, createTag }: UseVideoEditingOp
     startEditing,
     cancelEditing,
     handleUpdateVideo,
-    handleCreateTag,
   };
 }

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Link, useI18nNavigate, useLocale } from '@/lib/i18n';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -15,6 +15,7 @@ import { InlineSpinner } from '@/components/common/InlineSpinner';
 import { getStatusBadgeClassName, getStatusLabel, formatDate } from '@/lib/utils/video';
 import { TagBadge } from '@/components/video/TagBadge';
 import { TagSelector } from '@/components/video/TagSelector';
+import { TagCreateDialog } from '@/components/video/TagCreateDialog';
 import { useTags } from '@/hooks/useTags';
 import { useVideoEditing } from '@/hooks/useVideoEditing';
 import { useVideoDetailPageMutations } from '@/hooks/useVideoDetailPageData';
@@ -141,6 +142,7 @@ export default function VideoDetailPage() {
 
   const { video, isLoading, error } = useVideo(videoId);
   const { tags, createTag } = useTags();
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 
   const {
     isEditing,
@@ -153,8 +155,12 @@ export default function VideoDetailPage() {
     startEditing,
     cancelEditing,
     handleUpdateVideo,
-    handleCreateTag,
-  } = useVideoEditing({ video, videoId, createTag });
+  } = useVideoEditing({ video, videoId });
+
+  const handleCreateTag = useCallback(async (name: string, color: string) => {
+    const newTag = await createTag(name, color);
+    setEditedTagIds((prev) => (prev.includes(newTag.id) ? prev : [...prev, newTag.id]));
+  }, [createTag, setEditedTagIds]);
 
   const handleVideoLoaded = () => {
     if (videoRef.current && startTime) {
@@ -280,7 +286,7 @@ export default function VideoDetailPage() {
                         : [...prev, tagId]
                     );
                   }}
-                  onCreateTag={handleCreateTag}
+                  onCreateTag={() => setIsCreateDialogOpen(true)}
                   onSave={() => void updateMutation.mutateAsync()}
                   onCancel={cancelEditing}
                 />
@@ -357,6 +363,11 @@ export default function VideoDetailPage() {
           )}
         </div>
       </div>
+      <TagCreateDialog
+        isOpen={isCreateDialogOpen}
+        onClose={() => setIsCreateDialogOpen(false)}
+        onCreate={handleCreateTag}
+      />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary

- **Developer docs portal** (#412): Add multilingual (EN/JA) developer documentation portal with OpenAPI-generated code samples
- **Auth & header fixes** (#413, #414): Treat docs routes as public in auth hook; keep user nav visible on docs page
- **Chat retrieval endpoint** (#415): Add retrieval-only chat search endpoint for related video search without LLM response
- **VideoQ MCP server** (#416): Add MCP server exposing 6 VideoQ API endpoints for AI assistant integration
- **Tag create dialog** (#418): Refactor tag creation to use `TagCreateDialog` component instead of browser `prompt()`

## Changes

### Backend
- New `search_related_videos` use case with retrieval-only RAG gateway
- New `/api/chat/retrieve/` endpoint
- MCP server (`mcp/videoq_mcp_server.py`) with 6 tool endpoints

### Frontend
- `DeveloperDocsPage` and `DeveloperDocsSectionPage` with `ApiEndpointList` component
- Auth hook updated to treat `/docs` routes as public
- Header user nav preserved on docs pages
- `TagCreateDialog` component replacing native browser prompt
- i18n translations added (EN/JA) for docs and tag dialog

### Docs
- README restructured with API integration section at top and links to developer docs

## Test plan
- [x] Developer docs portal renders correctly in EN and JA
- [x] Unauthenticated users can access `/docs` routes
- [x] `/api/chat/retrieve/` returns related videos without LLM call
- [x] MCP server tools connect and return correct responses
- [x] Tag creation dialog works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)