### PR TITLE
docs: clarify frontend module boundaries

### DIFF
--- a/docs/architecture/system-configuration-diagram.md
+++ b/docs/architecture/system-configuration-diagram.md
@@ -120,16 +120,19 @@ graph TB
         P4[Custom Hooks]
     end
 
-    subgraph Lib["Libraries"]
-        L1[apiClient]
-        L2[TanStack Query]
+    subgraph FrontendModules["Frontend Internal Modules"]
+        F1[apiClient]
+    end
+
+    subgraph Lib["External Libraries"]
+        L1[TanStack Query]
     end
 
     P1 --> P2
     P2 --> P3
     P3 --> P4
+    P4 --> F1
     P4 --> L1
-    P4 --> L2
 ```
 
 ### バックエンド（クリーンアーキテクチャ）

--- a/docs/design/component-diagram.md
+++ b/docs/design/component-diagram.md
@@ -105,10 +105,14 @@ graph TB
             QueryHooks[TanStack Query Hooks]
         end
         
-        subgraph Lib["Libraries"]
+        subgraph FrontendModules["Frontend Internal Modules"]
             apiClient[apiClient]
             errorUtils[errorUtils]
             formUtils[formUtils]
+        end
+
+        subgraph Lib["External Libraries"]
+            TanStackQuery[TanStack Query]
         end
         
         subgraph Providers["Providers"]
@@ -119,10 +123,11 @@ graph TB
     
     Pages --> Components
     Components --> Hooks
-    Components --> Lib
+    Components --> FrontendModules
     Components --> Providers
+    Hooks --> FrontendModules
     Hooks --> Lib
-    Lib --> apiClient
+    Providers --> Lib
 ```
 
 ## バックエンドコンポーネント構成（クリーンアーキテクチャ）


### PR DESCRIPTION
## Summary
- separate `apiClient` from external libraries in the frontend architecture diagram
- model `TanStack Query` as an external library and `apiClient` as an internal frontend module
- align the component diagram with the actual implementation layering

## Background
The current diagrams place `apiClient` and `TanStack Query` side by side under Libraries, but the implementation uses them for different concerns:
- `apiClient`: internal HTTP client and URL utility layer
- `TanStack Query`: async state and cache management used by hooks

This PR updates the documentation to reflect that boundary more accurately.

## Testing
- not run (documentation-only changes)