### PR TITLE
fix(security): upgrade pip version in backend Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y \
 
 COPY requirements.txt ./
 
+RUN python -m pip install --no-cache-dir --upgrade "pip>=26.0"
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 RUN python -m nltk.downloader -d /usr/local/nltk_data averaged_perceptron_tagger_eng punkt_tab


### PR DESCRIPTION
## Summary
- upgrade pip in backend Docker image before installing requirements
- mitigate vulnerable pip version included in base image

## Changes
- add "python -m pip install --no-cache-dir --upgrade \"pip>=26.0\"" to backend/Dockerfile

## Related
- Closes #424