### PR TITLE
Harden production HTTPS settings via DJANGO_ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,10 @@ CACHE_URL=redis://redis:6379/0
 # SECRET_KEY: Must be set. Generate with:
 #   docker compose run --rm backend python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
 SECRET_KEY=
+# DJANGO_ENV: set to "production" in production deployment (HTTPS hardening is enforced in settings.py).
+DJANGO_ENV=development
 ALLOWED_HOSTS=localhost,127.0.0.1
 CORS_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1
-SECURE_COOKIES=False
 USE_S3_STORAGE=False
 FRONTEND_URL=http://localhost
 AWS_STORAGE_BUCKET_NAME=

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -30,8 +30,6 @@ class DefaultSettings:
 
     # Security
     SECRET_KEY = "django-insecure-644978l%$qgjwpo$w!5i7l#y(m&h)e$u#3en_a%ln^4!js$-*+"
-    SECURE_COOKIES = False  # Set to True in production with HTTPS
-
     # CORS
     CORS_ALLOWED_ORIGINS = [
         "http://localhost:3000",
@@ -276,11 +274,15 @@ CELERY_TASK_SOFT_TIME_LIMIT = 25 * 60  # 25 minutes
 # Feature flags
 ENABLE_SIGNUP = os.environ.get("ENABLE_SIGNUP", "true").lower() == "true"
 
-# Security: Cookie secure flag (set to True in production with HTTPS)
-SECURE_COOKIES = (
-    os.environ.get("SECURE_COOKIES", str(DefaultSettings.SECURE_COOKIES)).lower()
-    == "true"
-)
+# Security profile: enforce secure defaults for production deployments.
+DJANGO_ENV = os.environ.get("DJANGO_ENV", "development").lower()
+IS_PRODUCTION = DJANGO_ENV == "production"
+
+SECURE_COOKIES = IS_PRODUCTION
+SECURE_SSL_REDIRECT = IS_PRODUCTION
+SECURE_HSTS_SECONDS = 31536000 if IS_PRODUCTION else 0
+SECURE_HSTS_INCLUDE_SUBDOMAINS = IS_PRODUCTION
+SECURE_HSTS_PRELOAD = IS_PRODUCTION
 
 # Session Cookie settings for cross-origin deployment
 # When frontend and backend are on different origins, SameSite must be 'None' and Secure must be True

--- a/backend/videoq/tests/test_security_settings.py
+++ b/backend/videoq/tests/test_security_settings.py
@@ -1,0 +1,97 @@
+import importlib
+import os
+import sys
+import unittest
+
+
+class SecuritySettingsTests(unittest.TestCase):
+    SETTINGS_MODULE = "videoq.settings"
+    TARGET_ENV_KEYS = [
+        "DJANGO_ENV",
+        "SECURE_SSL_REDIRECT",
+        "SECURE_HSTS_SECONDS",
+        "SECURE_HSTS_INCLUDE_SUBDOMAINS",
+        "SECURE_HSTS_PRELOAD",
+    ]
+
+    def setUp(self):
+        self._original_env = {key: os.environ.get(key) for key in self.TARGET_ENV_KEYS}
+
+    def tearDown(self):
+        for key, value in self._original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        sys.modules.pop(self.SETTINGS_MODULE, None)
+
+    def _load_settings(self, **env):
+        for key in self.TARGET_ENV_KEYS:
+            os.environ.pop(key, None)
+        os.environ.update(env)
+
+        sys.modules.pop(self.SETTINGS_MODULE, None)
+        return importlib.import_module(self.SETTINGS_MODULE)
+
+    def test_production_defaults_enable_https_hardening(self):
+        settings = self._load_settings(DJANGO_ENV="production")
+
+        self.assertTrue(settings.SECURE_COOKIES)
+        self.assertTrue(settings.SESSION_COOKIE_SECURE)
+        self.assertTrue(settings.CSRF_COOKIE_SECURE)
+        self.assertEqual(settings.SESSION_COOKIE_SAMESITE, "None")
+        self.assertEqual(settings.CSRF_COOKIE_SAMESITE, "None")
+        self.assertTrue(settings.SECURE_SSL_REDIRECT)
+        self.assertGreaterEqual(settings.SECURE_HSTS_SECONDS, 31536000)
+        self.assertTrue(settings.SECURE_HSTS_INCLUDE_SUBDOMAINS)
+        self.assertTrue(settings.SECURE_HSTS_PRELOAD)
+
+    def test_development_defaults_keep_hardening_disabled(self):
+        settings = self._load_settings(DJANGO_ENV="development")
+
+        self.assertFalse(settings.SECURE_COOKIES)
+        self.assertFalse(settings.SESSION_COOKIE_SECURE)
+        self.assertFalse(settings.CSRF_COOKIE_SECURE)
+        self.assertEqual(settings.SESSION_COOKIE_SAMESITE, "Lax")
+        self.assertEqual(settings.CSRF_COOKIE_SAMESITE, "Lax")
+        self.assertFalse(settings.SECURE_SSL_REDIRECT)
+        self.assertEqual(settings.SECURE_HSTS_SECONDS, 0)
+        self.assertFalse(settings.SECURE_HSTS_INCLUDE_SUBDOMAINS)
+        self.assertFalse(settings.SECURE_HSTS_PRELOAD)
+
+    def test_security_env_overrides_are_ignored(self):
+        production_settings = self._load_settings(
+            DJANGO_ENV="production",
+            SECURE_SSL_REDIRECT="false",
+            SECURE_HSTS_SECONDS="0",
+            SECURE_HSTS_INCLUDE_SUBDOMAINS="false",
+            SECURE_HSTS_PRELOAD="false",
+        )
+
+        self.assertTrue(production_settings.SECURE_COOKIES)
+        self.assertTrue(production_settings.SESSION_COOKIE_SECURE)
+        self.assertTrue(production_settings.CSRF_COOKIE_SECURE)
+        self.assertTrue(production_settings.SECURE_SSL_REDIRECT)
+        self.assertEqual(production_settings.SECURE_HSTS_SECONDS, 31536000)
+        self.assertTrue(production_settings.SECURE_HSTS_INCLUDE_SUBDOMAINS)
+        self.assertTrue(production_settings.SECURE_HSTS_PRELOAD)
+
+        development_settings = self._load_settings(
+            DJANGO_ENV="development",
+            SECURE_SSL_REDIRECT="true",
+            SECURE_HSTS_SECONDS="999999999",
+            SECURE_HSTS_INCLUDE_SUBDOMAINS="true",
+            SECURE_HSTS_PRELOAD="true",
+        )
+
+        self.assertFalse(development_settings.SECURE_COOKIES)
+        self.assertFalse(development_settings.SESSION_COOKIE_SECURE)
+        self.assertFalse(development_settings.CSRF_COOKIE_SECURE)
+        self.assertFalse(development_settings.SECURE_SSL_REDIRECT)
+        self.assertEqual(development_settings.SECURE_HSTS_SECONDS, 0)
+        self.assertFalse(development_settings.SECURE_HSTS_INCLUDE_SUBDOMAINS)
+        self.assertFalse(development_settings.SECURE_HSTS_PRELOAD)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement #425 by enforcing deploy-time HTTPS hardening in production profile
- centralize security behavior on `DJANGO_ENV` (`production` vs `development`)
- add settings tests to lock behavior and prevent regression
- update `.env.example` to document production profile switch

## Changes
- `backend/videoq/settings.py`
  - add `DJANGO_ENV`/`IS_PRODUCTION` profile handling
  - enforce in production:
    - `SECURE_SSL_REDIRECT = True`
    - `SESSION_COOKIE_SECURE = True`
    - `CSRF_COOKIE_SECURE = True`
    - `SECURE_HSTS_SECONDS = 31536000`
    - `SECURE_HSTS_INCLUDE_SUBDOMAINS = True`
    - `SECURE_HSTS_PRELOAD = True`
  - development keeps relaxed defaults
  - remove security env overrides for these values (profile-driven only)
- `backend/videoq/tests/test_security_settings.py` (new)
  - production hardening enabled
  - development defaults remain disabled
  - security env overrides are ignored
- `.env.example`
  - add `DJANGO_ENV=development`
  - align comments with profile-driven hardening

## Verification
- `docker compose exec backend python manage.py test videoq.tests.test_security_settings -v 2`
- `docker compose exec -e DJANGO_ENV=production backend python manage.py check --deploy`
  - target warnings from #425 (`security.W004/W008/W012/W016`) are resolved

Closes #425
