### PR TITLE
Security: fail fast when SECRET_KEY is missing in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,14 @@ CELERY_RESULT_BACKEND=redis://redis:6379/0
 CACHE_URL=redis://redis:6379/0
 
 # Django settings
-# SECRET_KEY: Must be set. Generate with:
+# SECRET_KEY:
+# - development: optional (falls back to an insecure default in settings.py)
+# - production: required (startup fails if missing/blank)
+# Generate with:
 #   docker compose run --rm backend python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
-SECRET_KEY=
-# DJANGO_ENV: set to "production" in production deployment (HTTPS hardening is enforced in settings.py).
+# SECRET_KEY=
+# DJANGO_ENV: set to "production" in production deployment.
+# In production, backend startup fails if SECRET_KEY is missing/blank.
 DJANGO_ENV=development
 ALLOWED_HOSTS=localhost,127.0.0.1
 CORS_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1

--- a/README.md
+++ b/README.md
@@ -47,15 +47,19 @@ cd videoq
 cp .env.example .env
 ```
 
-`.env` ファイルを開いて、最低限次の2つを設定します。
+`.env` ファイルを開いて、まずは次を設定します。
 
 ```bash
-# SECRET_KEYを生成して設定（必須）
-docker compose run --rm backend python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
-
 # .env に設定する値
-SECRET_KEY=ここに生成した値
 OPENAI_API_KEY=sk-your-key-here
+```
+
+`SECRET_KEY` は `development` では省略可能です（`settings.py` の開発用デフォルトへフォールバック）。  
+ただし `DJANGO_ENV=production` では必須なので、次で生成して設定してください。
+
+```bash
+docker compose run --rm backend python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+SECRET_KEY=ここに生成した値
 ```
 
 ### ステップ3: VideoQを起動
@@ -219,6 +223,17 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 </details>
 
 </details>
+
+## 🔐 本番環境の必須設定
+
+本番デプロイ時は、少なくとも以下を設定してください。
+
+```bash
+DJANGO_ENV=production
+SECRET_KEY=<十分にランダムな長い文字列>
+```
+
+`DJANGO_ENV=production` で `SECRET_KEY` が未設定または空文字の場合、バックエンドは起動時に明示的にエラー終了します。
 
 <a id="developer-api"></a>
 

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -15,6 +15,7 @@ from datetime import timedelta
 from pathlib import Path
 
 import dj_database_url
+from django.core.exceptions import ImproperlyConfigured
 
 
 class DefaultSettings:
@@ -71,9 +72,21 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
+DJANGO_ENV = os.environ.get("DJANGO_ENV", "development").lower()
+IS_PRODUCTION = DJANGO_ENV == "production"
+
+_secret_key = os.environ.get("SECRET_KEY")
+if IS_PRODUCTION and not _secret_key:
+    raise ImproperlyConfigured(
+        "SECRET_KEY must be set when DJANGO_ENV=production."
+    )
+if IS_PRODUCTION and not _secret_key.strip():
+    raise ImproperlyConfigured(
+        "SECRET_KEY must not be blank when DJANGO_ENV=production."
+    )
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("SECRET_KEY", DefaultSettings.SECRET_KEY)
+SECRET_KEY = _secret_key if _secret_key else DefaultSettings.SECRET_KEY
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
@@ -275,8 +288,6 @@ CELERY_TASK_SOFT_TIME_LIMIT = 25 * 60  # 25 minutes
 ENABLE_SIGNUP = os.environ.get("ENABLE_SIGNUP", "true").lower() == "true"
 
 # Security profile: enforce secure defaults for production deployments.
-DJANGO_ENV = os.environ.get("DJANGO_ENV", "development").lower()
-IS_PRODUCTION = DJANGO_ENV == "production"
 
 SECURE_COOKIES = IS_PRODUCTION
 SECURE_SSL_REDIRECT = IS_PRODUCTION

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -76,14 +76,15 @@ DJANGO_ENV = os.environ.get("DJANGO_ENV", "development").lower()
 IS_PRODUCTION = DJANGO_ENV == "production"
 
 _secret_key = os.environ.get("SECRET_KEY")
-if IS_PRODUCTION and not _secret_key:
-    raise ImproperlyConfigured(
-        "SECRET_KEY must be set when DJANGO_ENV=production."
-    )
-if IS_PRODUCTION and not _secret_key.strip():
-    raise ImproperlyConfigured(
-        "SECRET_KEY must not be blank when DJANGO_ENV=production."
-    )
+if IS_PRODUCTION:
+    if _secret_key is None:
+        raise ImproperlyConfigured(
+            "SECRET_KEY must be set when DJANGO_ENV=production."
+        )
+    if not _secret_key.strip():
+        raise ImproperlyConfigured(
+            "SECRET_KEY must not be blank when DJANGO_ENV=production."
+        )
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = _secret_key if _secret_key else DefaultSettings.SECRET_KEY

--- a/backend/videoq/tests/test_security_settings.py
+++ b/backend/videoq/tests/test_security_settings.py
@@ -3,6 +3,8 @@ import os
 import sys
 import unittest
 
+from django.core.exceptions import ImproperlyConfigured
+
 
 class SecuritySettingsTests(unittest.TestCase):
     SETTINGS_MODULE = "videoq.settings"
@@ -12,6 +14,7 @@ class SecuritySettingsTests(unittest.TestCase):
         "SECURE_HSTS_SECONDS",
         "SECURE_HSTS_INCLUDE_SUBDOMAINS",
         "SECURE_HSTS_PRELOAD",
+        "SECRET_KEY",
     ]
 
     def setUp(self):
@@ -34,7 +37,9 @@ class SecuritySettingsTests(unittest.TestCase):
         return importlib.import_module(self.SETTINGS_MODULE)
 
     def test_production_defaults_enable_https_hardening(self):
-        settings = self._load_settings(DJANGO_ENV="production")
+        settings = self._load_settings(
+            DJANGO_ENV="production", SECRET_KEY="test-production-secret-key"
+        )
 
         self.assertTrue(settings.SECURE_COOKIES)
         self.assertTrue(settings.SESSION_COOKIE_SECURE)
@@ -62,6 +67,7 @@ class SecuritySettingsTests(unittest.TestCase):
     def test_security_env_overrides_are_ignored(self):
         production_settings = self._load_settings(
             DJANGO_ENV="production",
+            SECRET_KEY="test-production-secret-key",
             SECURE_SSL_REDIRECT="false",
             SECURE_HSTS_SECONDS="0",
             SECURE_HSTS_INCLUDE_SUBDOMAINS="false",
@@ -91,6 +97,18 @@ class SecuritySettingsTests(unittest.TestCase):
         self.assertEqual(development_settings.SECURE_HSTS_SECONDS, 0)
         self.assertFalse(development_settings.SECURE_HSTS_INCLUDE_SUBDOMAINS)
         self.assertFalse(development_settings.SECURE_HSTS_PRELOAD)
+
+    def test_production_raises_when_secret_key_is_missing(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self._load_settings(DJANGO_ENV="production")
+
+    def test_production_raises_when_secret_key_is_blank(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self._load_settings(DJANGO_ENV="production", SECRET_KEY="   ")
+
+    def test_development_allows_missing_secret_key(self):
+        settings = self._load_settings(DJANGO_ENV="development")
+        self.assertEqual(settings.SECRET_KEY, settings.DefaultSettings.SECRET_KEY)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add fail-fast validation in `videoq/settings.py` for production startup
- Raise `ImproperlyConfigured` when `DJANGO_ENV=production` and `SECRET_KEY` is missing or blank
- Keep development behavior unchanged (fallback to development default key)
- Update `.env.example` and `README.md` to document production requirements

## Changes
- `backend/videoq/settings.py`
  - Determine `DJANGO_ENV`/`IS_PRODUCTION` before assigning `SECRET_KEY`
  - Validate `SECRET_KEY` for production and raise explicit errors
- `backend/videoq/tests/test_security_settings.py`
  - Add tests for production missing/blank `SECRET_KEY`
  - Keep and adjust existing production tests to provide explicit `SECRET_KEY`
  - Add test confirming development allows missing `SECRET_KEY`
- `.env.example`
  - Clarify `SECRET_KEY` is optional in development, required in production
- `README.md`
  - Clarify quickstart setup for development
  - Add production required settings section (`DJANGO_ENV=production`, `SECRET_KEY`)

## Test
- `docker compose run --rm backend python manage.py test videoq.tests.test_security_settings -v 2`
- Result: `Ran 6 tests ... OK`

Closes #432
