### PR TITLE
fix: stop returning JWTs in auth response bodies

### DIFF
--- a/backend/app/presentation/auth/serializers.py
+++ b/backend/app/presentation/auth/serializers.py
@@ -74,13 +74,17 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
 
 # Response serializers for API documentation
 class LoginResponseSerializer(serializers.Serializer):
-    access = serializers.CharField(help_text="Access token")
-    refresh = serializers.CharField(help_text="Refresh token")
+    message = serializers.CharField(
+        required=False,
+        help_text="Optional response message. JWT tokens are set in HttpOnly cookies.",
+    )
 
 
 class RefreshResponseSerializer(serializers.Serializer):
-    access = serializers.CharField(help_text="New access token")
-    refresh = serializers.CharField(help_text="New refresh token")
+    message = serializers.CharField(
+        required=False,
+        help_text="Optional response message. Rotated JWT tokens are set in HttpOnly cookies.",
+    )
 
 
 class MessageResponseSerializer(serializers.Serializer):

--- a/backend/app/presentation/auth/tests/test_views.py
+++ b/backend/app/presentation/auth/tests/test_views.py
@@ -86,8 +86,7 @@ class LoginViewTests(APITestCase):
         response = self.client.post(self.url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("access", response.data)
-        self.assertIn("refresh", response.data)
+        self.assertEqual(response.data, {})
         # Check cookies are set
         self.assertIn("access_token", response.cookies)
         self.assertIn("refresh_token", response.cookies)
@@ -160,7 +159,7 @@ class RefreshViewTests(APITestCase):
         response = self.client.post(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("access", response.data)
+        self.assertEqual(response.data, {})
         self.assertIn("access_token", response.cookies)
 
     def test_refresh_with_body(self):
@@ -173,7 +172,7 @@ class RefreshViewTests(APITestCase):
         response = self.client.post(self.url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("access", response.data)
+        self.assertEqual(response.data, {})
 
     def test_refresh_invalid_token(self):
         """Test token refresh with invalid token"""

--- a/backend/app/presentation/auth/views.py
+++ b/backend/app/presentation/auth/views.py
@@ -94,7 +94,7 @@ class LoginView(PublicAPIView):
         request=LoginSerializer,
         responses={200: LoginResponseSerializer},
         summary="User login",
-        description="Authenticate user and return JWT tokens. Tokens are also set in HttpOnly cookies.",
+        description="Authenticate user and set JWT tokens in HttpOnly cookies.",
     )
     def post(self, request):
         serializer = self.get_serializer(data=request.data)
@@ -113,7 +113,7 @@ class LoginView(PublicAPIView):
                 code=ErrorCode.AUTHENTICATION_FAILED,
             )
 
-        response = Response({"access": token_pair.access, "refresh": token_pair.refresh})
+        response = Response({})
 
         samesite_value = "None" if settings.SECURE_COOKIES else "Lax"
 
@@ -208,7 +208,8 @@ class RefreshView(PublicAPIView):
         responses={200: RefreshResponseSerializer, 401: MessageResponseSerializer},
         summary="Refresh access token",
         description=(
-            "Refresh access token using refresh token from cookie or request body. "
+            "Refresh access token using refresh token from cookie or request body, "
+            "then rotate tokens in HttpOnly cookies. "
             "Refresh token is rotated and old token is invalidated."
         ),
     )
@@ -230,7 +231,7 @@ class RefreshView(PublicAPIView):
                 code=ErrorCode.AUTHENTICATION_FAILED,
             )
 
-        response = Response({"access": token_pair.access, "refresh": token_pair.refresh})
+        response = Response({})
 
         samesite_value = "None" if settings.SECURE_COOKIES else "Lax"
 

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -78,7 +78,7 @@ describe('ApiClient', () => {
     });
 
     it('login should return response on success', async () => {
-      const mockResponse = { access: 'atk', refresh: 'rtk' };
+      const mockResponse = {};
       fetchMock.mockResolvedValueOnce({
         ok: true,
         headers: new Headers({ 'content-type': 'application/json' }),
@@ -130,7 +130,7 @@ describe('ApiClient', () => {
     });
 
     it('refreshToken should call refresh endpoint', async () => {
-      const mockResponse = { access: 'new_token' };
+      const mockResponse = {};
       fetchMock.mockResolvedValueOnce({
         ok: true,
         headers: new Headers({ 'content-type': 'application/json' }),
@@ -239,7 +239,7 @@ describe('ApiClient', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         headers: new Headers({ 'content-type': 'application/json' }),
-        text: () => Promise.resolve(JSON.stringify({ access: 'new' })),
+        text: () => Promise.resolve('{}'),
       });
 
       // Retry original call succeeds

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,14 +2,9 @@ export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/ap
 
 type RequestBody = BodyInit | object | null | undefined;
 
-export interface LoginResponse {
-  access: string;
-  refresh: string;
-}
+export interface LoginResponse {}
 
-export interface RefreshResponse {
-  access: string;
-}
+export interface RefreshResponse {}
 
 export interface User {
   id: number;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,9 +2,9 @@ export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/ap
 
 type RequestBody = BodyInit | object | null | undefined;
 
-export interface LoginResponse {}
+export type LoginResponse = Record<string, never>;
 
-export interface RefreshResponse {}
+export type RefreshResponse = Record<string, never>;
 
 export interface User {
   id: number;


### PR DESCRIPTION
## 概要
- login / refresh API が JWT をレスポンス本文で返さないよう修正
- JWT は `HttpOnly` Cookie のみで受け渡すよう統一
- バックエンド・フロントエンドのテストと型定義を新仕様に合わせて更新

## 変更内容
- `POST /api/auth/login/` のレスポンス本文から `access` / `refresh` を削除
- `POST /api/auth/refresh/` のレスポンス本文から token を削除
- OpenAPI 用レスポンス serializer / description を Cookie ベースの仕様に更新
- フロントの `LoginResponse` / `RefreshResponse` と API テストを空レスポンス前提に変更

## テスト
- `cd frontend && npm test -- --run src/lib/__tests__/api.test.ts`
- `docker compose exec backend python manage.py test app.presentation.auth.tests.test_views`

Closes #438
