### PR TITLE
security: refresh endpointをCookie専用に変更

### DIFF
--- a/backend/app/presentation/auth/serializers.py
+++ b/backend/app/presentation/auth/serializers.py
@@ -47,10 +47,6 @@ class UserSerializer(serializers.Serializer):
         return videos.count()
 
 
-class RefreshSerializer(serializers.Serializer):
-    refresh = serializers.CharField()
-
-
 class EmailVerificationSerializer(serializers.Serializer):
     uid = serializers.CharField()
     token = serializers.CharField()

--- a/backend/app/presentation/auth/tests/test_serializers.py
+++ b/backend/app/presentation/auth/tests/test_serializers.py
@@ -13,7 +13,6 @@ from app.presentation.auth.serializers import (EmailVerificationSerializer,
                                                LoginSerializer,
                                                PasswordResetConfirmSerializer,
                                                PasswordResetRequestSerializer,
-                                               RefreshSerializer,
                                                UserSerializer,
                                                UserSignupSerializer)
 
@@ -97,21 +96,6 @@ class UserSerializerTests(APITestCase):
         )
         serializer = UserSerializer(entity)
         self.assertEqual(serializer.data["video_count"], 7)
-
-
-class RefreshSerializerTests(APITestCase):
-    """Tests for RefreshSerializer field-level validation only."""
-
-    def test_refresh_token_string_is_accepted(self):
-        """Test that any non-empty token string passes serializer validation."""
-        serializer = RefreshSerializer(data={"refresh": "any-token-string"})
-        self.assertTrue(serializer.is_valid())
-
-    def test_validate_refresh_token_empty(self):
-        """Test validation with empty refresh token"""
-        serializer = RefreshSerializer(data={"refresh": ""})
-        self.assertFalse(serializer.is_valid())
-        self.assertIn("refresh", serializer.errors)
 
 
 class EmailVerificationSerializerTests(APITestCase):

--- a/backend/app/presentation/auth/tests/test_views.py
+++ b/backend/app/presentation/auth/tests/test_views.py
@@ -162,8 +162,8 @@ class RefreshViewTests(APITestCase):
         self.assertEqual(response.data, {})
         self.assertIn("access_token", response.cookies)
 
-    def test_refresh_with_body(self):
-        """Test token refresh using request body"""
+    def test_refresh_without_cookie_rejects_request_body_token(self):
+        """Refresh requires the HttpOnly refresh cookie and ignores body tokens."""
         from rest_framework_simplejwt.tokens import RefreshToken
 
         refresh = RefreshToken.for_user(self.user)
@@ -171,8 +171,7 @@ class RefreshViewTests(APITestCase):
 
         response = self.client.post(self.url, data, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_refresh_invalid_token(self):
         """Test token refresh with invalid token"""
@@ -188,26 +187,23 @@ class RefreshViewTests(APITestCase):
 
         response = self.client.post(self.url, {"refresh": ""}, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_refresh_rotates_token_and_rejects_reuse_of_old_token(self):
         """Refresh should rotate token and reject old refresh token reuse"""
         from rest_framework_simplejwt.tokens import RefreshToken
 
         original_refresh = str(RefreshToken.for_user(self.user))
-        first_response = self.client.post(
-            self.url, {"refresh": original_refresh}, format="json"
-        )
+        self.client.cookies["refresh_token"] = original_refresh
+        first_response = self.client.post(self.url)
         self.assertEqual(first_response.status_code, status.HTTP_200_OK)
         self.assertIn("refresh_token", first_response.cookies)
 
         rotated_refresh = first_response.cookies["refresh_token"].value
         self.assertNotEqual(rotated_refresh, original_refresh)
 
-        self.client.cookies["refresh_token"] = ""
-        reuse_response = self.client.post(
-            self.url, {"refresh": original_refresh}, format="json"
-        )
+        self.client.cookies["refresh_token"] = original_refresh
+        reuse_response = self.client.post(self.url)
         self.assertEqual(reuse_response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 

--- a/backend/app/presentation/auth/views.py
+++ b/backend/app/presentation/auth/views.py
@@ -15,7 +15,6 @@ from app.presentation.auth.serializers import (AccountDeleteSerializer,
                                                PasswordResetConfirmSerializer,
                                                PasswordResetRequestSerializer,
                                                RefreshResponseSerializer,
-                                               RefreshSerializer,
                                                UserSerializer,
                                                UserSignupSerializer)
 from app.use_cases.auth.signup import EmailAlreadyRegistered, VerificationEmailSendFailed
@@ -200,15 +199,14 @@ class AccountDeleteView(AuthenticatedAPIView):
 class RefreshView(PublicAPIView):
     """Token refresh view"""
 
-    serializer_class = RefreshSerializer
     refresh_token_use_case = None
 
     @extend_schema(
-        request=RefreshSerializer,
+        request=None,
         responses={200: RefreshResponseSerializer, 401: MessageResponseSerializer},
         summary="Refresh access token",
         description=(
-            "Refresh access token using refresh token from cookie or request body, "
+            "Refresh access token using the HttpOnly refresh token cookie, "
             "then rotate tokens in HttpOnly cookies. "
             "Refresh token is rotated and old token is invalidated."
         ),
@@ -217,9 +215,11 @@ class RefreshView(PublicAPIView):
         refresh_token = request.COOKIES.get("refresh_token")
 
         if not refresh_token:
-            serializer = self.get_serializer(data=request.data)
-            serializer.is_valid(raise_exception=True)
-            refresh_token = serializer.validated_data["refresh"]
+            return create_error_response(
+                message="Invalid refresh token",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                code=ErrorCode.AUTHENTICATION_FAILED,
+            )
 
         use_case = self.resolve_dependency(self.refresh_token_use_case)
         try:

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -140,6 +140,8 @@ describe('ApiClient', () => {
       expect(result).toEqual(mockResponse);
       expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/refresh/', expect.objectContaining({
         method: 'POST',
+        body: undefined,
+        credentials: 'include',
       }));
     });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -479,7 +479,6 @@ class ApiClient {
 
     const response = await this.request<RefreshResponse>('/auth/refresh/', {
       method: 'POST',
-      body: {}, // Backend gets refresh token from Cookie
     });
 
     return response;


### PR DESCRIPTION
## 概要
- `/api/auth/refresh/` の request body fallback を削除し、`refresh_token` の HttpOnly Cookie のみを受け付けるようにしました
- バックエンドの refresh テストを cookie-only 契約に合わせて更新しました
- フロントエンドの `refreshToken()` から空の JSON body 送信を削除しました
- 不要になった presentation 層の `RefreshSerializer` とそのテストを削除しました

## 背景
Issue #439 では、refresh endpoint を HttpOnly Cookie のみを使う認証モデルに厳密に合わせることが求められていました。
これまでは Cookie が無い場合に `request.data["refresh"]` を受け付けていたため、JavaScript から refresh token を直接送れる状態が残っていました。

## 変更内容
- backend
  - `RefreshView` は `request.COOKIES["refresh_token"]` のみを利用するように変更
  - refresh cookie が無いリクエストは `401` を返すように変更
  - OpenAPI schema から refresh request body を削除
- frontend
  - `apiClient.refreshToken()` は Cookie のみで refresh するように変更
- cleanup
  - 未使用の `RefreshSerializer` を削除
  - 関連する不要テストを削除

## テスト
- `npm test -- src/lib/__tests__/api.test.ts`
- `docker compose exec backend python manage.py test app.presentation.auth.tests.test_views.RefreshViewTests`
- `docker compose exec backend python manage.py test app.presentation.auth.tests.test_serializers app.presentation.auth.tests.test_views.RefreshViewTests`

## 関連Issue
- Closes #439
