### PR TITLE
Cookie 認証に CSRF 防御を追加

### DIFF
--- a/backend/app/presentation/auth/tests/test_views.py
+++ b/backend/app/presentation/auth/tests/test_views.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from rest_framework import status
+from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 
 from app.use_cases.auth.signup import VerificationEmailSendFailed
@@ -79,6 +80,13 @@ class LoginViewTests(APITestCase):
             password="testpass123",
         )
         self.url = reverse("auth-login")
+        self.csrf_url = reverse("auth-csrf")
+
+    def _get_csrf_client(self) -> APIClient:
+        client = APIClient(enforce_csrf_checks=True)
+        csrf_response = client.get(self.csrf_url)
+        self.assertEqual(csrf_response.status_code, status.HTTP_204_NO_CONTENT)
+        return client
 
     def test_login_success(self):
         """Test successful login"""
@@ -88,6 +96,34 @@ class LoginViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {})
         # Check cookies are set
+        self.assertIn("access_token", response.cookies)
+        self.assertIn("refresh_token", response.cookies)
+
+    def test_login_rejects_missing_csrf_token_when_checks_are_enforced(self):
+        """Cookie-based login must reject unsafe requests without a CSRF token."""
+        client = APIClient(enforce_csrf_checks=True)
+
+        response = client.post(
+            self.url,
+            {"username": "testuser", "password": "testpass123"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_login_accepts_matching_csrf_cookie_and_header(self):
+        """Login should succeed when the CSRF cookie/header pair is present."""
+        client = self._get_csrf_client()
+        csrf_token = client.cookies["csrftoken"].value
+
+        response = client.post(
+            self.url,
+            {"username": "testuser", "password": "testpass123"},
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("access_token", response.cookies)
         self.assertIn("refresh_token", response.cookies)
 
@@ -108,17 +144,40 @@ class LogoutViewTests(APITestCase):
             email="test@example.com",
             password="testpass123",
         )
-        self.client.force_authenticate(user=self.user)
         self.url = reverse("auth-logout")
+        self.csrf_url = reverse("auth-csrf")
+
+    def _build_cookie_authenticated_client(self) -> tuple[APIClient, str]:
+        client = APIClient(enforce_csrf_checks=True)
+        csrf_response = client.get(self.csrf_url)
+        self.assertEqual(csrf_response.status_code, status.HTTP_204_NO_CONTENT)
+        csrf_token = client.cookies["csrftoken"].value
+        login_response = client.post(
+            reverse("auth-login"),
+            {"username": "testuser", "password": "testpass123"},
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+        self.assertEqual(login_response.status_code, status.HTTP_200_OK)
+        return client, csrf_token
 
     def test_logout_success(self):
         """Test successful logout"""
-        response = self.client.post(self.url)
+        client, csrf_token = self._build_cookie_authenticated_client()
+        response = client.post(self.url, HTTP_X_CSRFTOKEN=csrf_token)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Check cookies are deleted
         self.assertEqual(response.cookies.get("access_token").value, "")
         self.assertEqual(response.cookies.get("refresh_token").value, "")
+
+    def test_logout_rejects_missing_csrf_token(self):
+        """Cookie-authenticated logout must reject missing CSRF headers."""
+        client, _ = self._build_cookie_authenticated_client()
+
+        response = client.post(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_logout_invalidates_refresh_token_on_server(self):
         """Test logout invalidates refresh token for future reuse"""
@@ -126,6 +185,7 @@ class LogoutViewTests(APITestCase):
 
         refresh = RefreshToken.for_user(self.user)
         refresh_token = str(refresh)
+        self.client.force_authenticate(user=self.user)
         self.client.cookies["refresh_token"] = refresh_token
 
         response = self.client.post(self.url)
@@ -148,6 +208,13 @@ class RefreshViewTests(APITestCase):
             password="testpass123",
         )
         self.url = reverse("auth-refresh")
+        self.csrf_url = reverse("auth-csrf")
+
+    def _get_csrf_client(self) -> APIClient:
+        client = APIClient(enforce_csrf_checks=True)
+        csrf_response = client.get(self.csrf_url)
+        self.assertEqual(csrf_response.status_code, status.HTTP_204_NO_CONTENT)
+        return client
 
     def test_refresh_with_cookie(self):
         """Test token refresh using cookie"""
@@ -160,6 +227,30 @@ class RefreshViewTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {})
+        self.assertIn("access_token", response.cookies)
+
+    def test_refresh_rejects_missing_csrf_token_when_checks_are_enforced(self):
+        """Refresh must reject requests without the CSRF cookie/header pair."""
+        from rest_framework_simplejwt.tokens import RefreshToken
+
+        client = self._get_csrf_client()
+        client.cookies["refresh_token"] = str(RefreshToken.for_user(self.user))
+
+        response = client.post(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_refresh_accepts_matching_csrf_cookie_and_header(self):
+        """Refresh should succeed when CSRF cookie/header pair is provided."""
+        from rest_framework_simplejwt.tokens import RefreshToken
+
+        client = self._get_csrf_client()
+        csrf_token = client.cookies["csrftoken"].value
+        client.cookies["refresh_token"] = str(RefreshToken.for_user(self.user))
+
+        response = client.post(self.url, HTTP_X_CSRFTOKEN=csrf_token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("access_token", response.cookies)
 
     def test_refresh_without_cookie_rejects_request_body_token(self):
@@ -229,6 +320,16 @@ class EmailVerificationViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.user.refresh_from_db()
         self.assertTrue(self.user.is_active)
+
+
+class CsrfTokenViewTests(APITestCase):
+    """Tests for the CSRF bootstrap endpoint."""
+
+    def test_csrf_endpoint_sets_cookie(self):
+        response = self.client.get(reverse("auth-csrf"))
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIn("csrftoken", response.cookies)
 
 
 class PasswordResetRequestViewTests(APITestCase):

--- a/backend/app/presentation/auth/urls.py
+++ b/backend/app/presentation/auth/urls.py
@@ -7,6 +7,7 @@ from .views import (
     AccountDeleteView,
     ApiKeyDetailView,
     ApiKeyListCreateView,
+    CsrfTokenView,
     EmailVerificationView,
     LoginView,
     LogoutView,
@@ -18,6 +19,11 @@ from .views import (
 )
 
 urlpatterns = [
+    path(
+        "csrf/",
+        CsrfTokenView.as_view(),
+        name="auth-csrf",
+    ),
     path(
         "login/",
         LoginView.as_view(login_use_case=auth_dependencies.get_login_use_case),

--- a/backend/app/presentation/auth/views.py
+++ b/backend/app/presentation/auth/views.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
 from django.http import Http404
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics, status
@@ -82,6 +84,7 @@ class UserSignupView(PublicAPIView):
         )
 
 
+@method_decorator(csrf_protect, name="dispatch")
 class LoginView(PublicAPIView):
     """Login view"""
 
@@ -196,6 +199,7 @@ class AccountDeleteView(AuthenticatedAPIView):
         return response
 
 
+@method_decorator(csrf_protect, name="dispatch")
 class RefreshView(PublicAPIView):
     """Token refresh view"""
 
@@ -253,6 +257,22 @@ class RefreshView(PublicAPIView):
         )
 
         return response
+
+
+@method_decorator(ensure_csrf_cookie, name="dispatch")
+class CsrfTokenView(PublicAPIView):
+    """Bootstrap endpoint for the CSRF cookie used by cookie-based auth."""
+
+    serializer_class = None
+
+    @extend_schema(
+        request=None,
+        responses={204: None},
+        summary="Issue CSRF cookie",
+        description="Ensure the CSRF cookie is set for subsequent unsafe requests.",
+    )
+    def get(self, request):
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class EmailVerificationView(PublicAPIView):

--- a/backend/app/presentation/common/authentication.py
+++ b/backend/app/presentation/common/authentication.py
@@ -3,8 +3,9 @@
 from dataclasses import dataclass
 
 from django.utils.translation import gettext_lazy as _
-from rest_framework.authentication import BaseAuthentication
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.authentication import BaseAuthentication, CSRFCheck
+from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
+from rest_framework.permissions import SAFE_METHODS
 from rest_framework.request import Request
 
 from app.dependencies.common import get_cookie_jwt_validator, get_resolve_api_key_use_case
@@ -89,6 +90,17 @@ class CookieJWTAuthentication(BaseAuthentication):
         if cookie_jwt_validator_factory is not None:
             self.cookie_jwt_validator_factory = cookie_jwt_validator_factory
 
+    def enforce_csrf(self, request: Request) -> None:
+        """Apply Django's CSRF check to unsafe cookie-authenticated requests."""
+        if request.method in SAFE_METHODS:
+            return
+
+        check = CSRFCheck(lambda _request: None)
+        check.process_request(request)
+        reason = check.process_view(request, None, (), {})
+        if reason:
+            raise PermissionDenied(f"CSRF Failed: {reason}")
+
     def authenticate(self, request: Request):
         validator = self.cookie_jwt_validator_factory()
 
@@ -102,7 +114,12 @@ class CookieJWTAuthentication(BaseAuthentication):
         if raw_token is None:
             return None
 
-        return validator.validate_raw_token(raw_token)
+        validated = validator.validate_raw_token(raw_token)
+        if validated is None:
+            return None
+
+        self.enforce_csrf(request)
+        return validated
 
     def authenticate_header(self, request: Request) -> str:
         return 'Bearer realm="api"'

--- a/backend/app/presentation/common/tests/test_authentication.py
+++ b/backend/app/presentation/common/tests/test_authentication.py
@@ -5,6 +5,7 @@ Tests for common authentication module
 from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.test import APITestCase
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -86,6 +87,30 @@ class CookieJWTAuthenticationTests(APITestCase):
 
         request = self.factory.get("/", HTTP_AUTHORIZATION=f"Bearer {access_token}")
         request.COOKIES = {"access_token": other_access_token}
+
+        result = self.auth.authenticate(request)
+
+        self.assertIsNotNone(result)
+        user, token = result
+        self.assertEqual(user, self.user)
+
+    def test_cookie_authentication_rejects_unsafe_request_without_csrf(self):
+        """Unsafe requests using cookie auth must pass Django's CSRF check."""
+        refresh = RefreshToken.for_user(self.user)
+        access_token = str(refresh.access_token)
+
+        request = self.factory.post("/")
+        request.COOKIES = {"access_token": access_token}
+
+        with self.assertRaises(PermissionDenied):
+            self.auth.authenticate(request)
+
+    def test_header_authentication_allows_unsafe_request_without_csrf(self):
+        """Bearer-header auth should not require CSRF because it is not cookie-based."""
+        refresh = RefreshToken.for_user(self.user)
+        access_token = str(refresh.access_token)
+
+        request = self.factory.post("/", HTTP_AUTHORIZATION=f"Bearer {access_token}")
 
         result = self.auth.authenticate(request)
 

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -23,6 +23,10 @@ describe('ApiClient', () => {
 
   beforeEach(() => {
     fetchMock.mockReset();
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'csrftoken=test-csrf-token',
+    });
 
     // Reset window.location mock
     Object.defineProperty(window, 'location', {
@@ -78,6 +82,7 @@ describe('ApiClient', () => {
     });
 
     it('login should return response on success', async () => {
+      document.cookie = 'csrftoken=test-csrf-token';
       const mockResponse = {};
       fetchMock.mockResolvedValueOnce({
         ok: true,
@@ -89,7 +94,40 @@ describe('ApiClient', () => {
       expect(result).toEqual(mockResponse);
       expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/login/', expect.objectContaining({
         method: 'POST',
+        headers: expect.objectContaining({
+          'X-CSRFToken': 'test-csrf-token',
+        }),
         body: JSON.stringify({ username: 'user', password: 'pw' }),
+      }));
+    });
+
+    it('login should fetch csrf cookie before unsafe requests when missing', async () => {
+      document.cookie = '';
+      fetchMock.mockImplementationOnce(async () => {
+        document.cookie = 'csrftoken=fetched-csrf-token';
+        return {
+          ok: true,
+          status: 204,
+          headers: new Headers(),
+          text: async () => Promise.resolve(''),
+        } as Response;
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve('{}'),
+      });
+
+      await apiClient.login({ username: 'user', password: 'pw' });
+
+      expect(fetchMock).toHaveBeenNthCalledWith(1, 'http://localhost:8000/api/auth/csrf/', expect.objectContaining({
+        method: 'GET',
+        credentials: 'include',
+      }));
+      expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost:8000/api/auth/login/', expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-CSRFToken': 'fetched-csrf-token',
+        }),
       }));
     });
 
@@ -130,6 +168,7 @@ describe('ApiClient', () => {
     });
 
     it('refreshToken should call refresh endpoint', async () => {
+      document.cookie = 'csrftoken=test-csrf-token';
       const mockResponse = {};
       fetchMock.mockResolvedValueOnce({
         ok: true,
@@ -142,6 +181,9 @@ describe('ApiClient', () => {
         method: 'POST',
         body: undefined,
         credentials: 'include',
+        headers: expect.objectContaining({
+          'X-CSRFToken': 'test-csrf-token',
+        }),
       }));
     });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -249,11 +249,13 @@ class ApiClient {
 
   async logout(): Promise<void> {
     try {
+      const csrfToken = await this.ensureCsrfToken();
       await fetch(`${this.baseUrl}/auth/logout/`, {
         method: 'POST',
         credentials: 'include', // Send HttpOnly Cookie
         headers: {
           'Content-Type': 'application/json',
+          ...(csrfToken ? { 'X-CSRFToken': csrfToken } : {}),
         },
       });
     } catch {
@@ -284,6 +286,31 @@ class ApiClient {
   // Common method to generate basic JSON headers
   private getJsonHeaders(): Record<string, string> {
     return { 'Content-Type': 'application/json' };
+  }
+
+  private isSafeMethod(method?: string): boolean {
+    const normalizedMethod = (method ?? 'GET').toUpperCase();
+    return ['GET', 'HEAD', 'OPTIONS', 'TRACE'].includes(normalizedMethod);
+  }
+
+  private getCsrfTokenFromCookie(): string | null {
+    const match = document.cookie.match(/(?:^|; )csrftoken=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+  }
+
+  private async ensureCsrfToken(): Promise<string | null> {
+    const existingToken = this.getCsrfTokenFromCookie();
+    if (existingToken) {
+      return existingToken;
+    }
+
+    await fetch(this.buildUrl('/auth/csrf/'), {
+      method: 'GET',
+      credentials: 'include',
+      headers: {},
+    });
+
+    return this.getCsrfTokenFromCookie();
   }
 
   private buildHeaders(additionalHeaders?: HeadersInit): Record<string, string> {
@@ -400,6 +427,13 @@ class ApiClient {
     // Use common method to build URL
     const url = this.buildUrl(endpoint);
     const headers = this.buildHeaders(options.headers);
+
+    if (!this.isSafeMethod(options.method)) {
+      const csrfToken = await this.ensureCsrfToken();
+      if (csrfToken) {
+        headers['X-CSRFToken'] = csrfToken;
+      }
+    }
 
     // Use common method to stringify body
     const body = this.stringifyBody(options.body);
@@ -622,6 +656,10 @@ class ApiClient {
 
     // Authorization header not needed with HttpOnly Cookie-based authentication
     const headers: Record<string, string> = {};
+    const csrfToken = await this.ensureCsrfToken();
+    if (csrfToken) {
+      headers['X-CSRFToken'] = csrfToken;
+    }
 
     try {
       const response = await this.executeRequest(url, {


### PR DESCRIPTION
## 概要
- access token Cookie で認証された unsafe request に対して Django の CSRF チェックを必須化
- login / refresh エンドポイントを CSRF 保護し、Cookie ベース認証向けの CSRF 初期化エンドポイントを追加
- フロントエンドの API クライアントで CSRF トークンの取得と送信に対応し、関連するバックエンド / フロントエンドのテストを追加

## テスト
- npm test -- src/lib/__tests__/api.test.ts
- docker compose exec backend python manage.py test app.presentation.common.tests.test_authentication app.presentation.auth.tests.test_views videoq.tests.test_security_settings