### PR TITLE
signup で登録済みメールの列挙を防止

### DIFF
--- a/backend/app/presentation/auth/tests/test_views.py
+++ b/backend/app/presentation/auth/tests/test_views.py
@@ -49,6 +49,30 @@ class UserSignupViewTests(APITestCase):
         self.assertTrue(User.objects.filter(username="newuser").exists())
         self.assertEqual(len(mail.outbox), 1)
 
+    def test_signup_with_existing_email_returns_generic_success(self):
+        """Existing email should not be disclosed by the signup response."""
+        User.objects.create_user(
+            username="existinguser",
+            email="existing@example.com",
+            password="SecurePass123",
+        )
+        url = reverse("signup")
+        data = {
+            "username": "newuser",
+            "email": "existing@example.com",
+            "password": "SecurePass123",
+        }
+
+        response = self.client.post(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            response.data,
+            {"message": "Verification email sent. Please check your email."},
+        )
+        self.assertFalse(User.objects.filter(username="newuser").exists())
+        self.assertEqual(len(mail.outbox), 0)
+
     @patch("app.presentation.auth.views.UserSignupView.resolve_dependency")
     def test_signup_email_send_failed_returns_500(self, mock_resolve_dependency):
         """Verification mail send failure should be handled as expected 500 response."""

--- a/backend/app/presentation/auth/views.py
+++ b/backend/app/presentation/auth/views.py
@@ -71,8 +71,11 @@ class UserSignupView(PublicAPIView):
             use_case.execute(
                 username=d["username"], email=d["email"], password=d["password"]
             )
-        except EmailAlreadyRegistered as e:
-            return create_error_response(str(e), status.HTTP_400_BAD_REQUEST)
+        except EmailAlreadyRegistered:
+            return create_success_response(
+                message="Verification email sent. Please check your email.",
+                status_code=status.HTTP_201_CREATED,
+            )
         except VerificationEmailSendFailed:
             return create_error_response(
                 "Failed to send verification email. Please try again later.",


### PR DESCRIPTION
## 概要
- signup で登録済みメールアドレスが指定された場合でも、通常の新規登録時と同じ成功レスポンスを返すように変更
- signup からメールアドレスの存在有無を判別できないことを回帰テストで担保
- 検証メール送信失敗時は従来どおり 500 を返す挙動を維持

## テスト
- npm test -- --run src/pages/__tests__/SignupPage.test.tsx src/lib/__tests__/api.test.ts
- docker compose exec backend python manage.py test app.presentation.auth.tests.test_views

## 関連
- Closes #444