### PR TITLE
Security: signup に email 単位の追加レート制限を導入する

### DIFF
--- a/backend/app/domain/auth/services.py
+++ b/backend/app/domain/auth/services.py
@@ -30,7 +30,7 @@ class SignupPolicy:
     email: str
 
     def normalized_email(self) -> str:
-        return self.email.strip()
+        return self.email.strip().lower()
 
     def assert_email_available(self, *, email_exists: bool) -> None:
         if email_exists:

--- a/backend/app/domain/auth/tests/test_services.py
+++ b/backend/app/domain/auth/tests/test_services.py
@@ -20,7 +20,7 @@ from app.domain.auth.services import (
 
 class AuthDomainServicesTests(TestCase):
     def test_signup_policy_normalizes_email(self):
-        policy = SignupPolicy(email="  user@example.com  ")
+        policy = SignupPolicy(email="  User@Example.COM  ")
         self.assertEqual(policy.normalized_email(), "user@example.com")
 
     def test_signup_policy_raises_when_email_exists(self):
@@ -43,9 +43,9 @@ class AuthDomainServicesTests(TestCase):
             policy.require_user_id(user_id=None)
         self.assertEqual(policy.require_user_id(user_id=10), 10)
 
-    def test_normalize_signup_email_trims_whitespace(self):
+    def test_normalize_signup_email_trims_whitespace_and_lowercases(self):
         self.assertEqual(
-            normalize_signup_email("  user@example.com  "), "user@example.com"
+            normalize_signup_email("  User@Example.COM  "), "user@example.com"
         )
 
     def test_assert_signup_email_available_raises_when_email_exists(self):

--- a/backend/app/presentation/auth/views.py
+++ b/backend/app/presentation/auth/views.py
@@ -28,7 +28,9 @@ from app.presentation.common.exceptions import ErrorCode
 from app.presentation.common.responses import create_error_response, create_success_response
 from app.presentation.common.throttles import (LoginIPThrottle, LoginUsernameThrottle,
                                                PasswordResetEmailThrottle,
-                                               PasswordResetIPThrottle, SignupIPThrottle)
+                                               PasswordResetIPThrottle,
+                                               SignupEmailThrottle,
+                                               SignupIPThrottle)
 from app.use_cases.shared.exceptions import ResourceNotFound
 from app.presentation.common.mixins import (
     AuthenticatedViewMixin,
@@ -53,7 +55,7 @@ class UserSignupView(PublicAPIView):
     """User registration view"""
 
     serializer_class = UserSignupSerializer
-    throttle_classes = [SignupIPThrottle]
+    throttle_classes = [SignupIPThrottle, SignupEmailThrottle]
     signup_use_case = None
 
     @extend_schema(

--- a/backend/app/presentation/common/tests/test_throttles.py
+++ b/backend/app/presentation/common/tests/test_throttles.py
@@ -30,6 +30,7 @@ _TEST_THROTTLE_RATES = {
     "login_ip": "2/minute",
     "login_username": "2/minute",
     "signup_ip": "2/minute",
+    "signup_email": "2/minute",
     "password_reset_ip": "2/minute",
     "password_reset_email": "2/minute",
 }
@@ -219,7 +220,7 @@ class LoginThrottleTest(APITestCase):
 @override_settings(CACHES=_TEST_CACHES, ENABLE_SIGNUP=True)
 @patch.dict(SimpleRateThrottle.THROTTLE_RATES, _TEST_THROTTLE_RATES)
 class SignupThrottleTest(APITestCase):
-    """Tests for SignupIPThrottle."""
+    """Tests for signup throttles."""
 
     def setUp(self):
         cache.clear()
@@ -249,6 +250,61 @@ class SignupThrottleTest(APITestCase):
                 "password_confirm": "StrongP@ss1",
             },
             format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_email_throttle_blocks_same_email_across_different_ips(self):
+        """Same normalized email from different IPs should still be blocked."""
+        target_email = "  Victim@Example.COM  "
+
+        for i in range(2):
+            resp = self.client.post(
+                self.url,
+                {
+                    "username": f"newuser{i}",
+                    "email": target_email,
+                    "password": "StrongP@ss1",
+                },
+                format="json",
+                REMOTE_ADDR=f"10.0.0.{i + 1}",
+            )
+            self.assertNotEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+        resp = self.client.post(
+            self.url,
+            {
+                "username": "newuser99",
+                "email": "victim@example.com",
+                "password": "StrongP@ss1",
+            },
+            format="json",
+            REMOTE_ADDR="10.0.0.99",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(resp.json()["error"]["code"], "LIMIT_EXCEEDED")
+
+    def test_email_throttle_falls_back_to_ip_when_email_missing(self):
+        """Invalid payloads without email should still share an IP-based throttle key."""
+        for i in range(2):
+            resp = self.client.post(
+                self.url,
+                {
+                    "username": f"newuser{i}",
+                    "password": "StrongP@ss1",
+                },
+                format="json",
+                REMOTE_ADDR="10.0.0.5",
+            )
+            self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+        resp = self.client.post(
+            self.url,
+            {
+                "username": "newuser99",
+                "password": "StrongP@ss1",
+            },
+            format="json",
+            REMOTE_ADDR="10.0.0.5",
         )
         self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 

--- a/backend/app/presentation/common/throttles.py
+++ b/backend/app/presentation/common/throttles.py
@@ -2,7 +2,8 @@
 
 from rest_framework.throttling import SimpleRateThrottle
 
-from app.domain.auth.services import normalize_signup_email
+def _normalize_signup_throttle_email(email: str) -> str:
+    return email.strip().lower()
 
 
 class ShareTokenIPThrottle(SimpleRateThrottle):
@@ -87,7 +88,7 @@ class SignupEmailThrottle(SimpleRateThrottle):
         if not email:
             ident = self.get_ident(request)
         else:
-            ident = normalize_signup_email(str(email))
+            ident = _normalize_signup_throttle_email(str(email))
 
         return self.cache_format % {
             "scope": self.scope,

--- a/backend/app/presentation/common/throttles.py
+++ b/backend/app/presentation/common/throttles.py
@@ -2,6 +2,8 @@
 
 from rest_framework.throttling import SimpleRateThrottle
 
+from app.domain.auth.services import normalize_signup_email
+
 
 class ShareTokenIPThrottle(SimpleRateThrottle):
     scope = "chat_share_token_ip"
@@ -74,6 +76,22 @@ class SignupIPThrottle(SimpleRateThrottle):
         return self.cache_format % {
             "scope": self.scope,
             "ident": self.get_ident(request),
+        }
+
+
+class SignupEmailThrottle(SimpleRateThrottle):
+    scope = "signup_email"
+
+    def get_cache_key(self, request, view):
+        email = request.data.get("email")
+        if not email:
+            ident = self.get_ident(request)
+        else:
+            ident = normalize_signup_email(str(email))
+
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": ident,
         }
 
 

--- a/backend/app/use_cases/auth/tests/test_signup.py
+++ b/backend/app/use_cases/auth/tests/test_signup.py
@@ -57,7 +57,7 @@ class SignupUserUseCaseTests(TestCase):
         email_sender = _StubEmailSenderGateway()
         use_case = SignupUserUseCase(user_gateway, email_sender)
 
-        use_case.execute("alice", "  alice@example.com  ", "password")
+        use_case.execute("alice", "  Alice@Example.COM  ", "password")
 
         self.assertEqual(
             user_gateway.created_args,

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -274,6 +274,7 @@ REST_FRAMEWORK = {
         "login_ip": "5/minute",
         "login_username": "5/minute",
         "signup_ip": "3/hour",
+        "signup_email": "3/hour",
         "password_reset_ip": "3/hour",
         "password_reset_email": "3/hour",
     },


### PR DESCRIPTION
## 概要
- signup に email 単位の throttle を追加
- signup 本体の email 正規化を `strip().lower()` に統一
- 同一 email を大文字小文字や前後空白の差分で回避できないように修正

## 変更内容
- `SignupEmailThrottle` を追加して `UserSignupView` で `SignupIPThrottle` と併用
- `DEFAULT_THROTTLE_RATES` に `signup_email` を追加
- signup の正規化ロジックを更新
- throttle / domain / use case テストを追加・更新

## テスト
- `docker compose exec backend python manage.py test app.domain.auth.tests.test_services app.use_cases.auth.tests.test_signup app.presentation.common.tests.test_throttles`
- `cd frontend && npm test -- src/pages/__tests__/SignupPage.test.tsx`

Closes #446