### PR TITLE
Fix #450 500エラーレスポンスで内部例外メッセージを返さないようにする

### DIFF
--- a/backend/app/presentation/auth/tests/test_views.py
+++ b/backend/app/presentation/auth/tests/test_views.py
@@ -91,7 +91,15 @@ class UserSignupViewTests(APITestCase):
         response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-        self.assertIn("error", response.data)
+        self.assertEqual(
+            response.data,
+            {
+                "error": {
+                    "code": "INTERNAL_ERROR",
+                    "message": "An internal server error occurred.",
+                }
+            },
+        )
 
 
 class LoginViewTests(APITestCase):

--- a/backend/app/presentation/chat/tests/test_views.py
+++ b/backend/app/presentation/chat/tests/test_views.py
@@ -13,6 +13,7 @@ from rest_framework.test import APIClient, APITestCase
 
 from app.domain.chat.dtos import RelatedVideoDTO
 from app.domain.chat.gateways import LLMConfigurationError, RagResult
+from app.use_cases.chat.exceptions import LLMProviderError
 
 User = get_user_model()
 ChatLog = apps.get_model("app", "ChatLog")
@@ -144,6 +145,30 @@ class ChatViewTests(APITestCase):
         response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.generate_reply")
+    def test_chat_provider_error_returns_generic_500_message(self, mock_generate_reply):
+        """500 responses must not expose internal provider error details."""
+        mock_generate_reply.side_effect = LLMProviderError("provider stack trace detail")
+
+        url = reverse("chat")
+        data = {
+            "messages": [{"role": "user", "content": "Test question"}],
+            "group_id": self.group.id,
+        }
+
+        response = self.client.post(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(
+            response.data,
+            {
+                "error": {
+                    "code": "INTERNAL_ERROR",
+                    "message": "An internal server error occurred.",
+                }
+            },
+        )
 
     @patch("app.infrastructure.external.rag_gateway.RagChatGateway.generate_reply")
     def test_chat_with_share_token(self, mock_generate_reply):
@@ -304,3 +329,28 @@ class ChatSearchViewTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["query_text"], "q")
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.search_related_videos")
+    def test_search_related_scenes_provider_error_returns_generic_500_message(
+        self, mock_search_related_videos
+    ):
+        mock_search_related_videos.side_effect = LLMProviderError(
+            "provider retrieval detail"
+        )
+
+        response = self.client.post(
+            reverse("chat-search"),
+            {"query_text": "q", "group_id": self.group.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(
+            response.data,
+            {
+                "error": {
+                    "code": "INTERNAL_ERROR",
+                    "message": "An internal server error occurred.",
+                }
+            },
+        )

--- a/backend/app/presentation/common/decorators.py
+++ b/backend/app/presentation/common/decorators.py
@@ -1,10 +1,13 @@
 """Presentation-layer view decorators."""
 
+import logging
 from functools import wraps
 
 from rest_framework import status
 
 from app.presentation.common.responses import create_error_response
+
+logger = logging.getLogger(__name__)
 
 
 def authenticated_api_view(methods):
@@ -41,6 +44,7 @@ def with_error_handling(view_func):
         try:
             return view_func(*args, **kwargs)
         except Exception as e:
+            logger.exception("Unhandled exception in %s", view_func.__name__)
             return create_error_response(str(e), status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     return wrapper

--- a/backend/app/presentation/common/exceptions.py
+++ b/backend/app/presentation/common/exceptions.py
@@ -4,6 +4,8 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
+from app.presentation.common.responses import INTERNAL_ERROR_MESSAGE
+
 
 class ErrorCode:
     VALIDATION_ERROR = "VALIDATION_ERROR"
@@ -84,6 +86,9 @@ def _get_error_code(status_code: int, exc) -> str:
 
 
 def _get_error_message(exc, response) -> str:
+    if getattr(response, "status_code", 0) >= status.HTTP_500_INTERNAL_SERVER_ERROR:
+        return INTERNAL_ERROR_MESSAGE
+
     if hasattr(exc, "detail"):
         detail = exc.detail
 

--- a/backend/app/presentation/common/responses.py
+++ b/backend/app/presentation/common/responses.py
@@ -5,6 +5,8 @@ from typing import Any
 from rest_framework import status
 from rest_framework.response import Response
 
+INTERNAL_ERROR_MESSAGE = "An internal server error occurred."
+
 
 def create_error_response(
     message: str,
@@ -13,6 +15,11 @@ def create_error_response(
     fields: dict | None = None,
 ) -> Response:
     """Generate unified error response."""
+    if status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR:
+        message = INTERNAL_ERROR_MESSAGE
+        if code == "VALIDATION_ERROR":
+            code = "INTERNAL_ERROR"
+
     error_data: dict[str, Any] = {
         "code": code,
         "message": message,

--- a/backend/app/presentation/common/tests/test_responses.py
+++ b/backend/app/presentation/common/tests/test_responses.py
@@ -47,6 +47,19 @@ class ResponseHelpersTests(unittest.TestCase):
             response.data["error"]["fields"]["email"], ["Invalid email format"]
         )
 
+    def test_create_error_response_500_sanitizes_message_and_code(self):
+        """500 responses must not expose internal exception details."""
+        response = create_error_response(
+            "sensitive internal detail",
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.data["error"]["code"], "INTERNAL_ERROR")
+        self.assertEqual(
+            response.data["error"]["message"], "An internal server error occurred."
+        )
+
     def test_create_success_response_with_data(self):
         """Test create_success_response with data"""
         data = {"key": "value", "number": 123}

--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.apps import apps
 from django.contrib.auth import get_user_model
@@ -178,6 +178,34 @@ class VideoGroupMemberAPITestCase(APITestCase):
         self.assertEqual(VideoGroupMember.objects.count(), 3)
         self.assertEqual(response.data["added_count"], 3)
         self.assertEqual(response.data["skipped_count"], 0)
+
+    @patch("app.presentation.common.decorators.logger.exception")
+    @patch("app.presentation.video.views.DependencyResolverMixin.resolve_dependency")
+    def test_add_multiple_videos_to_group_unexpected_error_returns_generic_500(
+        self, mock_resolve_dependency, mock_logger_exception
+    ):
+        """Unexpected exceptions must be logged and sanitized."""
+        use_case = MagicMock()
+        use_case.execute.side_effect = RuntimeError("database internals leaked")
+        mock_resolve_dependency.return_value = use_case
+
+        response = self.client.post(
+            reverse("add-videos-to-group", kwargs={"group_id": self.group.pk}),
+            {"video_ids": [self.video.pk]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(
+            response.data,
+            {
+                "error": {
+                    "code": "INTERNAL_ERROR",
+                    "message": "An internal server error occurred.",
+                }
+            },
+        )
+        mock_logger_exception.assert_called_once()
 
     def test_remove_video_from_group(self):
         """Test removing video from group"""
@@ -570,6 +598,32 @@ class ShareLinkTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.group.refresh_from_db()
         self.assertIsNone(self.group.share_token)
+
+    @patch("app.presentation.common.decorators.logger.exception")
+    @patch("app.presentation.video.views.DependencyResolverMixin.resolve_dependency")
+    def test_delete_share_link_unexpected_error_returns_generic_500(
+        self, mock_resolve_dependency, mock_logger_exception
+    ):
+        """Decorator-handled 500s must not expose internal exception text."""
+        use_case = MagicMock()
+        use_case.execute.side_effect = RuntimeError("share token backend detail")
+        mock_resolve_dependency.return_value = use_case
+
+        response = self.client.delete(
+            reverse("delete-share-link", kwargs={"group_id": self.group.pk})
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(
+            response.data,
+            {
+                "error": {
+                    "code": "INTERNAL_ERROR",
+                    "message": "An internal server error occurred.",
+                }
+            },
+        )
+        mock_logger_exception.assert_called_once()
 
     def test_get_shared_group(self):
         """Test getting shared group by token"""


### PR DESCRIPTION
## 概要
500エラーレスポンスで内部例外メッセージをそのまま返さないように修正しました。

## 変更内容
- 500系レスポンスを `INTERNAL_ERROR / An internal server error occurred.` に統一
- `with_error_handling()` で予期しない例外を `logger.exception(...)` で記録
- 既存の安全な 4xx エラーハンドリングは維持
- 予期しない例外経路の回帰テストを追加
  - common response helpers
  - auth views
  - chat views
  - video presentation endpoints

## 背景
一部の認証済み動画系エンドポイントで、予期しない例外を catch した際に `str(e)` をそのままクライアントへ返しており、内部実装の詳細が漏れる可能性がありました。

## テスト
### バックエンド
```bash
docker compose exec backend python manage.py test app.presentation.common.tests.test_responses app.presentation.auth.tests.test_views app.presentation.chat.tests.test_views app.presentation.video.tests.test_views
```

### フロントエンド
```bash
cd frontend
npm test -- --run src/lib/__tests__/api.test.ts
```

## Issue
Closes #450