### PR TITLE
ログイン名とパスワードリセット用メールアドレスのスロットルキーを正規化

### DIFF
--- a/backend/app/presentation/common/tests/test_throttles.py
+++ b/backend/app/presentation/common/tests/test_throttles.py
@@ -216,6 +216,28 @@ class LoginThrottleTest(APITestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
+    def test_username_throttle_normalizes_case_and_whitespace(self):
+        """Username throttle should treat casing and surrounding spaces as the same key."""
+        attempts = ["  LoginUser  ", "loginuser"]
+
+        for i, username in enumerate(attempts):
+            resp = self.client.post(
+                self.url,
+                {"username": username, "password": "wrong"},
+                format="json",
+                REMOTE_ADDR=f"10.0.0.{i + 1}",
+            )
+            self.assertNotEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+        resp = self.client.post(
+            self.url,
+            {"username": "LOGINUSER", "password": "wrong"},
+            format="json",
+            REMOTE_ADDR="10.0.0.99",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(resp.json()["error"]["code"], "LIMIT_EXCEEDED")
+
 
 @override_settings(CACHES=_TEST_CACHES, ENABLE_SIGNUP=True)
 @patch.dict(SimpleRateThrottle.THROTTLE_RATES, _TEST_THROTTLE_RATES)
@@ -355,6 +377,28 @@ class PasswordResetThrottleTest(APITestCase):
             REMOTE_ADDR="10.0.0.99",
         )
         self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_email_throttle_normalizes_case_and_whitespace(self):
+        """Password reset throttle should normalize email casing and spaces."""
+        attempts = ["  Victim@Example.com  ", "victim@example.com"]
+
+        for i, email in enumerate(attempts):
+            resp = self.client.post(
+                self.url,
+                {"email": email},
+                format="json",
+                REMOTE_ADDR=f"10.0.0.{i + 1}",
+            )
+            self.assertNotEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+        resp = self.client.post(
+            self.url,
+            {"email": "VICTIM@EXAMPLE.COM"},
+            format="json",
+            REMOTE_ADDR="10.0.0.99",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(resp.json()["error"]["code"], "LIMIT_EXCEEDED")
 
     def test_429_response_format(self):
         """429 response should have LIMIT_EXCEEDED error format with Retry-After header."""

--- a/backend/app/presentation/common/throttles.py
+++ b/backend/app/presentation/common/throttles.py
@@ -2,8 +2,20 @@
 
 from rest_framework.throttling import SimpleRateThrottle
 
-def _normalize_signup_throttle_email(email: str) -> str:
-    return email.strip().lower()
+
+def _normalize_throttle_identifier(value: str, *, lowercase: bool) -> str:
+    normalized = value.strip()
+    if lowercase:
+        normalized = normalized.lower()
+    return normalized
+
+
+def _normalize_throttle_email(email: str) -> str:
+    return _normalize_throttle_identifier(email, lowercase=True)
+
+
+def _normalize_throttle_username(username: str) -> str:
+    return _normalize_throttle_identifier(username, lowercase=True)
 
 
 class ShareTokenIPThrottle(SimpleRateThrottle):
@@ -66,7 +78,7 @@ class LoginUsernameThrottle(SimpleRateThrottle):
             }
         return self.cache_format % {
             "scope": self.scope,
-            "ident": username,
+            "ident": _normalize_throttle_username(str(username)),
         }
 
 
@@ -88,7 +100,7 @@ class SignupEmailThrottle(SimpleRateThrottle):
         if not email:
             ident = self.get_ident(request)
         else:
-            ident = _normalize_signup_throttle_email(str(email))
+            ident = _normalize_throttle_email(str(email))
 
         return self.cache_format % {
             "scope": self.scope,
@@ -118,5 +130,5 @@ class PasswordResetEmailThrottle(SimpleRateThrottle):
             }
         return self.cache_format % {
             "scope": self.scope,
-            "ident": email,
+            "ident": _normalize_throttle_email(str(email)),
         }


### PR DESCRIPTION
## 概要

issue #451 の対応です。

ログイン試行とパスワードリセットのレート制限キーが入力値そのままになっており、
大文字小文字や前後空白の違いで throttle を回避できる状態だったため、
識別子の正規化を共通化して揃えました。

## 変更内容

- backend/app/presentation/common/throttles.py
  - throttle 用の識別子正規化 helper を共通化
  - LoginUsernameThrottle で username を strip().lower() で正規化
  - PasswordResetEmailThrottle で email を strip().lower() で正規化
  - SignupEmailThrottle も同じ helper を使うように統一
- backend/app/presentation/common/tests/test_throttles.py
  - login throttle で username の大文字小文字・前後空白違いを同一視する回帰テストを追加
  - password reset throttle で email の大文字小文字・前後空白違いを同一視する回帰テストを追加

## 背景

修正前は以下のような表記揺れが別 throttle key として扱われていました。

- User
- user
-  user 

このため、ブルートフォース対策やアカウント列挙対策が想定より弱くなる余地がありました。

## テスト

バックエンド:
docker compose exec backend python manage.py test app.presentation.common.tests.test_throttles

フロントエンド:
cd frontend
npm test -- src/pages/__tests__/LoginPage.test.tsx src/pages/__tests__/ForgotPasswordPage.test.tsx src/pages/__tests__/ResetPasswordPage.test.tsx

## 確認ポイント

- 同一 username の表記揺れが login throttle で同一キーとして扱われること
- 同一 email の表記揺れが password reset throttle で同一キーとして扱われること
- signup 側と email 正規化の挙動が揃っていること