### PR TITLE
fix: protected media のパストラバーサル脆弱性を修正し認可前のファイルアクセスを排除する

### DIFF
--- a/backend/app/infrastructure/storage/local_media_storage.py
+++ b/backend/app/infrastructure/storage/local_media_storage.py
@@ -3,6 +3,7 @@ Local filesystem implementation of MediaStorageGateway.
 """
 
 import os
+from pathlib import Path
 
 from django.conf import settings
 
@@ -13,7 +14,16 @@ class LocalMediaStorage(MediaStorageGateway):
     """Media storage backed by Django MEDIA_ROOT."""
 
     def _full_path(self, path: str) -> str:
-        return os.path.join(settings.MEDIA_ROOT, path)
+        if os.path.isabs(path):
+            raise ValueError(f"Absolute path not allowed: {path!r}")
+        parts = Path(path).parts
+        if ".." in parts:
+            raise ValueError(f"Path traversal not allowed: {path!r}")
+        media_root = Path(settings.MEDIA_ROOT).resolve()
+        full = (media_root / path).resolve()
+        if not full.is_relative_to(media_root):
+            raise ValueError(f"Path escapes MEDIA_ROOT: {path!r}")
+        return str(full)
 
     def exists(self, path: str) -> bool:
         return os.path.exists(self._full_path(path))

--- a/backend/app/infrastructure/storage/tests/test_local_media_storage.py
+++ b/backend/app/infrastructure/storage/tests/test_local_media_storage.py
@@ -1,0 +1,88 @@
+"""
+Tests for LocalMediaStorage path traversal protection.
+"""
+
+import tempfile
+
+from django.test import TestCase, override_settings
+
+from app.infrastructure.storage.local_media_storage import LocalMediaStorage
+
+
+class LocalMediaStoragePathValidationTests(TestCase):
+    """LocalMediaStorage が危険なパスを拒否することを確認する。"""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.storage = LocalMediaStorage()
+
+    @override_settings(MEDIA_ROOT="/tmp/media_root")
+    def test_absolute_path_raises_on_exists(self):
+        with self.assertRaises(ValueError):
+            self.storage.exists("/etc/passwd")
+
+    @override_settings(MEDIA_ROOT="/tmp/media_root")
+    def test_absolute_path_raises_on_open(self):
+        with self.assertRaises(ValueError):
+            self.storage.open("/etc/passwd")
+
+    @override_settings(MEDIA_ROOT="/tmp/media_root")
+    def test_dotdot_path_raises_on_exists(self):
+        with self.assertRaises(ValueError):
+            self.storage.exists("../secret")
+
+    @override_settings(MEDIA_ROOT="/tmp/media_root")
+    def test_double_dotdot_raises_on_exists(self):
+        with self.assertRaises(ValueError):
+            self.storage.exists("../../etc/passwd")
+
+    @override_settings(MEDIA_ROOT="/tmp/media_root")
+    def test_embedded_dotdot_raises_on_exists(self):
+        with self.assertRaises(ValueError):
+            self.storage.exists("videos/../../../etc/passwd")
+
+    def test_valid_path_does_not_raise_on_exists(self):
+        with override_settings(MEDIA_ROOT=self.tmp):
+            result = self.storage.exists("videos/test.mp4")
+        self.assertFalse(result)
+
+    def test_valid_nested_path_does_not_raise_on_exists(self):
+        with override_settings(MEDIA_ROOT=self.tmp):
+            result = self.storage.exists("2024/01/videos/test.mp4")
+        self.assertFalse(result)
+
+    @override_settings(MEDIA_ROOT="/tmp/media_root")
+    def test_path_with_escaped_traversal_raises(self):
+        """解決後に MEDIA_ROOT 外に出るパスは拒否する。"""
+        with self.assertRaises(ValueError):
+            self.storage.exists("videos/../../../../etc/passwd")
+
+    def test_startswith_false_positive_is_rejected(self):
+        """
+        MEDIA_ROOT が /tmp/media の場合、/tmp/media_evil/file は
+        str.startswith("/tmp/media") が True になるが、正しく拒否されなければならない。
+        Path.is_relative_to() を使っていれば False になる。
+        """
+        import os
+        import tempfile
+
+        # /tmp/media_<suffix> と /tmp/media_<suffix>_evil のような2つのディレクトリを作る
+        base = tempfile.mkdtemp()
+        sibling = base + "_evil"
+        os.makedirs(sibling, exist_ok=True)
+        # sibling 内にファイルを作る
+        evil_file = os.path.join(sibling, "secret.txt")
+        with open(evil_file, "w") as f:
+            f.write("secret")
+        # MEDIA_ROOT = base, path = ../base_evil/secret.txt
+        # .. は拒否されるので、symlink で試みる
+        link_path = os.path.join(base, "evil_link")
+        os.symlink(sibling, link_path)
+        try:
+            with override_settings(MEDIA_ROOT=base):
+                with self.assertRaises(ValueError):
+                    self.storage.exists("evil_link/secret.txt")
+        finally:
+            os.unlink(link_path)
+            os.remove(evil_file)
+            os.rmdir(sibling)

--- a/backend/app/presentation/media/tests/test_views.py
+++ b/backend/app/presentation/media/tests/test_views.py
@@ -175,3 +175,22 @@ class ProtectedMediaViewTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response["Content-Type"], "video/mp4")
+
+    def test_path_traversal_dotdot_returns_404(self):
+        """../secret のようなパストラバーサルは 404 を返す。"""
+        self.client.force_authenticate(user=self.user)
+        # Django の URLconf が <path:path> を受け取るため直接 get を使う
+        response = self.client.get("/api/media/../secret")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_path_traversal_double_dotdot_returns_404(self):
+        """../../etc/passwd のようなパスは 404 を返す。"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get("/api/media/../../etc/passwd")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_path_traversal_embedded_dotdot_returns_404(self):
+        """videos/../../../etc/passwd のようなパスは 404 を返す。"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get("/api/media/videos/../../../etc/passwd")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/app/use_cases/media/resolve_protected_media.py
+++ b/backend/app/use_cases/media/resolve_protected_media.py
@@ -2,8 +2,10 @@
 Use case: resolve access to a protected media file.
 """
 
-from dataclasses import dataclass
 import mimetypes
+import os
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 from app.domain.media.ports import MediaStorageGateway, ProtectedMediaRepository
@@ -24,6 +26,15 @@ class ResolveProtectedMediaOutput:
     content_type: Optional[str] = None
 
 
+def _is_safe_path(path: str) -> bool:
+    """絶対パスや .. を含むパスを拒否する。"""
+    if os.path.isabs(path):
+        return False
+    if ".." in Path(path).parts:
+        return False
+    return True
+
+
 class ResolveProtectedMediaUseCase:
     """
     Authorises access to a protected media file.
@@ -35,6 +46,12 @@ class ResolveProtectedMediaUseCase:
 
     Raises ResourceNotFound for any denial (file missing, not in group,
     not owned by user) so the caller can map it uniformly to HTTP 404.
+
+    Execution order (defense-in-depth):
+        1. Path safety check — reject traversal before any I/O
+        2. DB lookup — find the associated video
+        3. Authorization — confirm ownership or group membership
+        4. Storage existence check — confirm the file is present
     """
 
     def __init__(
@@ -46,18 +63,16 @@ class ResolveProtectedMediaUseCase:
         self.media_storage = media_storage
 
     def execute(self, input: ResolveProtectedMediaInput) -> ResolveProtectedMediaOutput:
-        if not self.media_storage.exists(input.path):
-            raise ResourceNotFound("Media")
-        try:
-            with self.media_storage.open(input.path):
-                pass
-        except OSError:
+        # 1. パス検証 — ファイルシステムアクセスより前に実行する
+        if not _is_safe_path(input.path):
             raise ResourceNotFound("Media")
 
+        # 2. DB lookup
         video_id = self.media_repo.find_video_id_by_file_path(input.path)
         if video_id is None:
             raise ResourceNotFound("Media")
 
+        # 3. 認可チェック
         if input.group_id is not None:
             if not self.media_repo.is_video_in_group(video_id, input.group_id):
                 raise ResourceNotFound("Media")
@@ -65,6 +80,10 @@ class ResolveProtectedMediaUseCase:
             if not self.media_repo.is_video_owned_by_user(video_id, input.user_id):
                 raise ResourceNotFound("Media")
         else:
+            raise ResourceNotFound("Media")
+
+        # 4. ファイル存在確認 — 認可後に実行
+        if not self.media_storage.exists(input.path):
             raise ResourceNotFound("Media")
 
         content_type, _ = mimetypes.guess_type(input.path)

--- a/backend/app/use_cases/media/tests/test_resolve_protected_media.py
+++ b/backend/app/use_cases/media/tests/test_resolve_protected_media.py
@@ -37,6 +37,22 @@ class _FakeStorage:
         return io.BytesIO(b"dummy")
 
 
+class _TrackingStorage:
+    """ファイルシステムアクセスの呼び出しを追跡するストレージ。"""
+
+    def __init__(self):
+        self.exists_called = False
+        self.open_called = False
+
+    def exists(self, path: str) -> bool:
+        self.exists_called = True
+        return False
+
+    def open(self, path: str, mode: str = "rb"):
+        self.open_called = True
+        return io.BytesIO(b"")
+
+
 class ResolveProtectedMediaUseCaseTests(unittest.TestCase):
     def test_missing_file_raises_not_found(self):
         use_case = ResolveProtectedMediaUseCase(
@@ -72,3 +88,67 @@ class ResolveProtectedMediaUseCaseTests(unittest.TestCase):
             use_case.execute(
                 ResolveProtectedMediaInput(path="videos/test.mp4", group_id=99)
             )
+
+    def test_dotdot_path_raises_not_found_without_filesystem_access(self):
+        """../secret のようなパスはストレージを呼び出す前に拒否する。"""
+        storage = _TrackingStorage()
+        use_case = ResolveProtectedMediaUseCase(
+            media_repo=_FakeMediaRepo(),
+            media_storage=storage,
+        )
+
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(
+                ResolveProtectedMediaInput(path="../secret", user_id=1)
+            )
+
+        self.assertFalse(storage.exists_called, "exists() must not be called for traversal paths")
+        self.assertFalse(storage.open_called, "open() must not be called for traversal paths")
+
+    def test_double_dotdot_to_etc_passwd_raises_not_found_without_filesystem_access(self):
+        """../../etc/passwd のようなパスはストレージを呼び出す前に拒否する。"""
+        storage = _TrackingStorage()
+        use_case = ResolveProtectedMediaUseCase(
+            media_repo=_FakeMediaRepo(),
+            media_storage=storage,
+        )
+
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(
+                ResolveProtectedMediaInput(path="../../etc/passwd", user_id=1)
+            )
+
+        self.assertFalse(storage.exists_called)
+        self.assertFalse(storage.open_called)
+
+    def test_absolute_path_raises_not_found_without_filesystem_access(self):
+        """/etc/passwd のような絶対パスはストレージを呼び出す前に拒否する。"""
+        storage = _TrackingStorage()
+        use_case = ResolveProtectedMediaUseCase(
+            media_repo=_FakeMediaRepo(),
+            media_storage=storage,
+        )
+
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(
+                ResolveProtectedMediaInput(path="/etc/passwd", user_id=1)
+            )
+
+        self.assertFalse(storage.exists_called)
+        self.assertFalse(storage.open_called)
+
+    def test_embedded_dotdot_raises_not_found_without_filesystem_access(self):
+        """videos/../../../etc/passwd のようなパスも拒否する。"""
+        storage = _TrackingStorage()
+        use_case = ResolveProtectedMediaUseCase(
+            media_repo=_FakeMediaRepo(),
+            media_storage=storage,
+        )
+
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(
+                ResolveProtectedMediaInput(path="videos/../../../etc/passwd", user_id=1)
+            )
+
+        self.assertFalse(storage.exists_called)
+        self.assertFalse(storage.open_called)


### PR DESCRIPTION
## 概要

closes #454

protected media エンドポイントのパス検証不足により、認可前に attacker-controlled path に対して `exists()` / `open()` が実行される脆弱性を修正しました。

## 変更内容

### `LocalMediaStorage._full_path()` にパス検証を追加

3段階の検証を実施し、検証が通ったパスのみファイルシステムへアクセスします。

1. **絶対パス拒否** — `os.path.isabs()`
2. **`..` コンポーネント拒否** — `Path(path).parts`
3. **`resolve()` 後に MEDIA_ROOT 外へ出るパスを拒否** — `Path.is_relative_to()` を使用（`str.startswith()` による誤検知・シンボリックリンク経由の脱出も防止）

### `ResolveProtectedMediaUseCase.execute()` の実行順序を変更

**Before（問題のある順序）:**
```
exists()     ← 認可前にファイルシステムアクセス
open()       ← 認可前にファイルシステムアクセス
DB lookup
認可チェック
```

**After（修正後）:**
```
パス検証     ← I/O なしで即拒否
DB lookup
認可チェック
exists()     ← 認可後にはじめてファイルシステムアクセス
```

不要だった `open()` による冗長な存在確認も削除しました。

## テスト

| テストファイル | 追加内容 |
|---|---|
| `infrastructure/storage/tests/test_local_media_storage.py` (新規) | `../secret`・`../../etc/passwd`・絶対パス・シンボリックリンク脱出など9ケース |
| `use_cases/media/tests/test_resolve_protected_media.py` | トラバーサルパスで `exists()`/`open()` が呼ばれないことを `_TrackingStorage` で確認する4ケース |
| `presentation/media/tests/test_views.py` | HTTP レベルで 404 になることを確認する3ケース |

全27テストパス。