### PR TITLE
fix: /remove/ サフィックスを削除してDELETEメソッドのみで表現する

### DIFF
--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -11,6 +11,7 @@ Tag = apps.get_model("app", "Tag")
 Video = apps.get_model("app", "Video")
 VideoGroup = apps.get_model("app", "VideoGroup")
 VideoGroupMember = apps.get_model("app", "VideoGroupMember")
+VideoTag = apps.get_model("app", "VideoTag")
 
 
 class VideoGroupAPITestCase(APITestCase):
@@ -208,11 +209,11 @@ class VideoGroupMemberAPITestCase(APITestCase):
         mock_logger_exception.assert_called_once()
 
     def test_remove_video_from_group(self):
-        """Test removing video from group"""
+        """Test removing video from group via DELETE /videos/groups/<id>/videos/<vid_id>/"""
         VideoGroupMember.objects.create(group=self.group, video=self.video)
 
         url = reverse(
-            "remove-video-from-group",
+            "add-video-to-group",
             kwargs={"group_id": self.group.pk, "video_id": self.video.pk},
         )
         response = self.client.delete(url)
@@ -223,7 +224,7 @@ class VideoGroupMemberAPITestCase(APITestCase):
     def test_remove_video_from_group_not_member(self):
         """Test error when trying to remove video not in the group"""
         url = reverse(
-            "remove-video-from-group",
+            "add-video-to-group",
             kwargs={"group_id": self.group.pk, "video_id": self.video.pk},
         )
         response = self.client.delete(url)
@@ -501,6 +502,32 @@ class TagViewTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["error"]["message"], "Tag name cannot be empty")
+
+    def test_remove_tag_from_video(self):
+        """Test removing a tag from a video via DELETE /videos/<id>/tags/<tag_id>/"""
+        tag = Tag.objects.create(user=self.user, name="Tag 1", color="#111111")
+        VideoTag.objects.create(video=self.video, tag=tag)
+
+        url = reverse(
+            "remove-tag-from-video",
+            kwargs={"video_id": self.video.pk, "tag_id": tag.pk},
+        )
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(VideoTag.objects.count(), 0)
+
+    def test_remove_tag_from_video_not_attached(self):
+        """Test 404 when tag is not attached to the video"""
+        tag = Tag.objects.create(user=self.user, name="Tag 1", color="#111111")
+
+        url = reverse(
+            "remove-tag-from-video",
+            kwargs={"video_id": self.video.pk, "tag_id": tag.pk},
+        )
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @patch("app.infrastructure.external.vector_gateway.delete_video_vectors")
     def test_delete_video_deletes_vectors(self, mock_delete):

--- a/backend/app/presentation/video/urls.py
+++ b/backend/app/presentation/video/urls.py
@@ -16,7 +16,6 @@ from .views import (
     delete_share_link,
     get_shared_group,
     remove_tag_from_video,
-    remove_video_from_group,
     reorder_videos_in_group,
 )
 
@@ -66,19 +65,10 @@ urlpatterns = [
     path(
         "groups/<int:group_id>/videos/<int:video_id>/",
         AddVideoToGroupView.as_view(
-            add_video_to_group_use_case=video_dependencies.get_add_video_to_group_use_case
+            add_video_to_group_use_case=video_dependencies.get_add_video_to_group_use_case,
+            remove_video_from_group_use_case=video_dependencies.get_remove_video_from_group_use_case,
         ),
         name="add-video-to-group",
-    ),
-    path(
-        "groups/<int:group_id>/videos/<int:video_id>/remove/",
-        remove_video_from_group,
-        {
-            "remove_video_from_group_use_case": (
-                video_dependencies.get_remove_video_from_group_use_case
-            )
-        },
-        name="remove-video-from-group",
     ),
     path(
         "groups/<int:group_id>/reorder/",
@@ -129,7 +119,7 @@ urlpatterns = [
         name="add-tags-to-video",
     ),
     path(
-        "<int:video_id>/tags/<int:tag_id>/remove/",
+        "<int:video_id>/tags/<int:tag_id>/",
         remove_tag_from_video,
         {
             "remove_tag_from_video_use_case": video_dependencies.get_remove_tag_from_video_use_case

--- a/backend/app/presentation/video/views.py
+++ b/backend/app/presentation/video/views.py
@@ -316,10 +316,11 @@ class VideoGroupDetailView(DependencyResolverMixin, AuthenticatedViewMixin, APIV
 
 
 class AddVideoToGroupView(DependencyResolverMixin, AuthenticatedViewMixin, APIView):
-    """Add a single video to a group."""
+    """Add or remove a single video from a group."""
 
     serializer_class = AddVideoToGroupResponseSerializer
     add_video_to_group_use_case = None
+    remove_video_from_group_use_case = None
 
     @extend_schema(
         responses={201: AddVideoToGroupResponseSerializer},
@@ -343,6 +344,24 @@ class AddVideoToGroupView(DependencyResolverMixin, AuthenticatedViewMixin, APIVi
             {"message": "Video added to group", "id": member.id},
             status=status.HTTP_201_CREATED,
         )
+
+    @extend_schema(
+        responses={200: VideoActionMessageResponseSerializer},
+        summary="Remove video from group",
+        description="Remove a video from a group.",
+    )
+    def delete(self, request, group_id, video_id):
+        use_case = self.resolve_dependency(self.remove_video_from_group_use_case)
+        try:
+            use_case.execute(group_id, video_id, request.user.id)
+        except ResourceNotFound as e:
+            return create_error_response(_not_found_message(e), status.HTTP_404_NOT_FOUND)
+        except VideoNotInGroup:
+            return create_error_response(
+                "This video is not added to the group", status.HTTP_404_NOT_FOUND
+            )
+
+        return Response({"message": "Video removed from group"}, status=status.HTTP_200_OK)
 
 
 @extend_schema(

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -476,7 +476,7 @@ describe('ApiClient', () => {
     it('removeVideoFromGroup calls correct endpoint', async () => {
       fetchMock.mockResolvedValueOnce({ ok: true, headers: new Headers() });
       await apiClient.removeVideoFromGroup(1, 100);
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/groups/1/videos/100/remove/', expect.objectContaining({ method: 'DELETE' }));
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/groups/1/videos/100/', expect.objectContaining({ method: 'DELETE' }));
     });
 
     it('reorderVideosInGroup calls correct endpoint', async () => {
@@ -550,7 +550,7 @@ describe('ApiClient', () => {
     it('removeTagFromVideo calls correct endpoint', async () => {
       fetchMock.mockResolvedValueOnce({ ok: true, headers: new Headers() });
       await apiClient.removeTagFromVideo(1, 10);
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/1/tags/10/remove/', expect.objectContaining({ method: 'DELETE' }));
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/1/tags/10/', expect.objectContaining({ method: 'DELETE' }));
     });
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -733,7 +733,7 @@ class ApiClient {
   }
 
   async removeVideoFromGroup(groupId: number, videoId: number): Promise<void> {
-    return this.request<void>(`/videos/groups/${groupId}/videos/${videoId}/remove/`, {
+    return this.request<void>(`/videos/groups/${groupId}/videos/${videoId}/`, {
       method: 'DELETE',
     });
   }
@@ -872,7 +872,7 @@ class ApiClient {
   }
 
   async removeTagFromVideo(videoId: number, tagId: number): Promise<void> {
-    return this.request<void>(`/videos/${videoId}/tags/${tagId}/remove/`, {
+    return this.request<void>(`/videos/${videoId}/tags/${tagId}/`, {
       method: 'DELETE',
     });
   }


### PR DESCRIPTION
## 概要

URLに含まれていた動詞 `/remove/` サフィックスを削除し、HTTPの `DELETE` メソッドのみで削除操作を表現するよう修正しました。

Closes #457

## 変更内容

| 変更前 | 変更後 |
|--------|--------|
| `DELETE /api/videos/groups/<id>/videos/<vid_id>/remove/` | `DELETE /api/videos/groups/<id>/videos/<vid_id>/` |
| `DELETE /api/videos/<id>/tags/<tag_id>/remove/` | `DELETE /api/videos/<id>/tags/<tag_id>/` |

## 実装詳細

- `AddVideoToGroupView` に `delete` メソッドを追加し、POST（追加）と DELETE（削除）を同一 URL で処理
- `/remove/` サフィックス付きの URL エントリを削除
- フロントエンドの API 呼び出し URL を合わせて修正

## テスト計画

- [x] TDD で実装（テスト先行）
- [x] フロントエンドテスト: 新 URL を期待するようテストを更新 → 446件すべてパス
- [x] バックエンドテスト: `remove-tag-from-video` の新規テスト追加、既存テスト更新 → 65件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)