### PR TITLE
fix: /share/delete/ の冗長な動詞を削除し /shared/ を /share/ に統一する

### DIFF
--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -612,13 +612,13 @@ class ShareLinkTests(APITestCase):
         self.assertIsNotNone(self.group.share_token)
 
     def test_delete_share_link(self):
-        """Test deleting a share link"""
+        """Test deleting a share link via DELETE /groups/<id>/share/"""
         import secrets
 
         self.group.share_token = secrets.token_urlsafe(32)
         self.group.save()
 
-        url = reverse("delete-share-link", kwargs={"group_id": self.group.pk})
+        url = reverse("create-share-link", kwargs={"group_id": self.group.pk})
 
         response = self.client.delete(url)
 
@@ -626,18 +626,18 @@ class ShareLinkTests(APITestCase):
         self.group.refresh_from_db()
         self.assertIsNone(self.group.share_token)
 
-    @patch("app.presentation.common.decorators.logger.exception")
+    @patch("app.presentation.video.views.logger.exception")
     @patch("app.presentation.video.views.DependencyResolverMixin.resolve_dependency")
     def test_delete_share_link_unexpected_error_returns_generic_500(
         self, mock_resolve_dependency, mock_logger_exception
     ):
-        """Decorator-handled 500s must not expose internal exception text."""
+        """View-level 500s must not expose internal exception text."""
         use_case = MagicMock()
         use_case.execute.side_effect = RuntimeError("share token backend detail")
         mock_resolve_dependency.return_value = use_case
 
         response = self.client.delete(
-            reverse("delete-share-link", kwargs={"group_id": self.group.pk})
+            reverse("create-share-link", kwargs={"group_id": self.group.pk})
         )
 
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -652,8 +652,16 @@ class ShareLinkTests(APITestCase):
         )
         mock_logger_exception.assert_called_once()
 
+    def test_old_delete_share_link_url_not_found(self):
+        """Test that the old /share/delete/ URL no longer exists."""
+        url = f"/api/videos/groups/{self.group.pk}/share/delete/"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_get_shared_group(self):
-        """Test getting shared group by token"""
+        """Test getting shared group via GET /groups/share/<token>/"""
         import secrets
 
         share_token = secrets.token_urlsafe(32)
@@ -672,6 +680,19 @@ class ShareLinkTests(APITestCase):
         url = reverse("get-shared-group", kwargs={"share_token": "invalid-token"})
 
         response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_old_shared_url_not_found(self):
+        """Test that the old /groups/shared/<token>/ URL no longer exists."""
+        import secrets
+
+        share_token = secrets.token_urlsafe(32)
+        self.group.share_token = share_token
+        self.group.save()
+
+        # 有効なトークンで旧URLを叩いてもルーティングレベルで404になるべき
+        response = self.client.get(f"/api/videos/groups/shared/{share_token}/")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/backend/app/presentation/video/urls.py
+++ b/backend/app/presentation/video/urls.py
@@ -13,7 +13,6 @@ from .views import (
     VideoListView,
     add_tags_to_video,
     add_videos_to_group,
-    delete_share_link,
     get_shared_group,
     remove_tag_from_video,
     reorder_videos_in_group,
@@ -79,18 +78,13 @@ urlpatterns = [
     path(
         "groups/<int:group_id>/share/",
         CreateShareLinkView.as_view(
-            create_share_link_use_case=video_dependencies.get_create_share_link_use_case
+            create_share_link_use_case=video_dependencies.get_create_share_link_use_case,
+            delete_share_link_use_case=video_dependencies.get_delete_share_link_use_case,
         ),
         name="create-share-link",
     ),
     path(
-        "groups/<int:group_id>/share/delete/",
-        delete_share_link,
-        {"delete_share_link_use_case": video_dependencies.get_delete_share_link_use_case},
-        name="delete-share-link",
-    ),
-    path(
-        "groups/shared/<str:share_token>/",
+        "groups/share/<str:share_token>/",
         get_shared_group,
         {"shared_group_use_case": video_dependencies.get_shared_group_use_case},
         name="get-shared-group",

--- a/backend/app/presentation/video/views.py
+++ b/backend/app/presentation/video/views.py
@@ -454,10 +454,11 @@ def reorder_videos_in_group(
 
 
 class CreateShareLinkView(DependencyResolverMixin, AuthenticatedViewMixin, APIView):
-    """Generate a share link for a group."""
+    """Manage share link for a group (create and delete)."""
 
     serializer_class = ShareLinkResponseSerializer
     create_share_link_use_case = None
+    delete_share_link_use_case = None
 
     @extend_schema(
         responses={201: ShareLinkResponseSerializer},
@@ -476,26 +477,22 @@ class CreateShareLinkView(DependencyResolverMixin, AuthenticatedViewMixin, APIVi
             status=status.HTTP_201_CREATED,
         )
 
+    @extend_schema(
+        responses={200: VideoActionMessageResponseSerializer},
+        summary="Delete share link",
+        description="Disable the current share link for a group.",
+    )
+    def delete(self, request, group_id):
+        use_case = self.resolve_dependency(self.delete_share_link_use_case)
+        try:
+            use_case.execute(group_id, request.user.id)
+        except ResourceNotFound as e:
+            return create_error_response(_not_found_message(e), status.HTTP_404_NOT_FOUND)
+        except Exception:
+            logger.exception("Unhandled exception in CreateShareLinkView.delete")
+            return create_error_response("", status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-@extend_schema(
-    responses={200: VideoActionMessageResponseSerializer},
-    summary="Delete share link",
-    description="Disable the current share link for a group.",
-)
-@authenticated_view_with_error_handling(["DELETE"])
-def delete_share_link(
-    request,
-    group_id,
-    delete_share_link_use_case,
-):
-    """Disable share link for group."""
-    use_case = DependencyResolverMixin.resolve_dependency(delete_share_link_use_case)
-    try:
-        use_case.execute(group_id, request.user.id)
-    except ResourceNotFound as e:
-        return create_error_response(_not_found_message(e), status.HTTP_404_NOT_FOUND)
-
-    return Response({"message": "Share link disabled"}, status=status.HTTP_200_OK)
+        return Response({"message": "Share link disabled"}, status=status.HTTP_200_OK)
 
 
 @extend_schema(

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -643,7 +643,7 @@ describe('ApiClient', () => {
         text: () => Promise.resolve(JSON.stringify({}))
       });
       await apiClient.deleteShareLink(1);
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/groups/1/share/delete/', expect.objectContaining({ method: 'DELETE' }));
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/groups/1/share/', expect.objectContaining({ method: 'DELETE' }));
     });
 
     it('getSharedGroup calls correct endpoint', async () => {
@@ -654,7 +654,7 @@ describe('ApiClient', () => {
         json: () => Promise.resolve({ id: 1 })
       });
       await apiClient.getSharedGroup('token');
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/groups/shared/token/');
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/groups/share/token/');
     });
 
     it('getSharedGroup should throw on error', async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -756,14 +756,14 @@ class ApiClient {
   }
 
   async deleteShareLink(groupId: number): Promise<{ message: string }> {
-    return this.request<{ message: string }>(`/videos/groups/${groupId}/share/delete/`, {
+    return this.request<{ message: string }>(`/videos/groups/${groupId}/share/`, {
       method: 'DELETE',
     });
   }
 
   async getSharedGroup(shareToken: string): Promise<VideoGroup> {
     // Shared groups don't require authentication, so don't include credentials
-    const url = this.buildUrl(`/videos/groups/shared/${shareToken}/`);
+    const url = this.buildUrl(`/videos/groups/share/${shareToken}/`);
     const response = await fetch(url);
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Closes #458

RESTの原則に従い、URLから冗長な動詞を除去しました。

| 変更前 | 変更後 |
|--------|--------|
| `DELETE /api/videos/groups/<id>/share/delete/` | `DELETE /api/videos/groups/<id>/share/` |
| `GET /api/videos/groups/shared/<token>/` | `GET /api/videos/groups/share/<token>/` |

## Changes

### Backend
- `delete_share_link` 関数ビューを廃止し、`CreateShareLinkView.delete` メソッドに統合
- `/share/delete/` URLパターンを削除
- `/groups/shared/<token>/` → `/groups/share/<token>/` に変更

### Frontend
- `deleteShareLink`: `/share/delete/` → `/share/`
- `getSharedGroup`: `/groups/shared/` → `/groups/share/`

## Test plan

- [x] TDDで実装（Red → Green）
- [x] 旧URLが404を返すことをテストで確認
- [x] バックエンド全テスト通過（47件）
- [x] フロントエンド全テスト通過（446件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)