### PR TITLE
fix: /reorder/ エンドポイントをリソース指向の /videos/order/ に変更する

### DIFF
--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -727,7 +727,7 @@ class ReorderVideosTests(APITestCase):
         VideoGroupMember.objects.create(group=self.group, video=self.video3, order=2)
 
     def test_reorder_videos(self):
-        """Test reordering videos in group"""
+        """Test reordering videos in group via new URL"""
         url = reverse("reorder-videos-in-group", kwargs={"group_id": self.group.pk})
         data = {"video_ids": [self.video3.pk, self.video1.pk, self.video2.pk]}
 
@@ -745,6 +745,24 @@ class ReorderVideosTests(APITestCase):
         self.assertEqual(member1.order, 1)
         self.assertEqual(member2.order, 2)
         self.assertEqual(member3.order, 0)
+
+    def test_reorder_videos_url_is_resource_oriented(self):
+        """New URL /videos/groups/<id>/videos/order/ must work"""
+        url = f"/api/videos/groups/{self.group.pk}/videos/order/"
+        data = {"video_ids": [self.video3.pk, self.video1.pk, self.video2.pk]}
+
+        response = self.client.patch(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_old_reorder_url_not_found(self):
+        """Old URL /videos/groups/<id>/reorder/ must return 404"""
+        url = f"/api/videos/groups/{self.group.pk}/reorder/"
+        data = {"video_ids": [self.video1.pk]}
+
+        response = self.client.patch(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
 class VideoUploadTests(APITestCase):

--- a/backend/app/presentation/video/urls.py
+++ b/backend/app/presentation/video/urls.py
@@ -70,7 +70,7 @@ urlpatterns = [
         name="add-video-to-group",
     ),
     path(
-        "groups/<int:group_id>/reorder/",
+        "groups/<int:group_id>/videos/order/",
         reorder_videos_in_group,
         {"reorder_videos_use_case": video_dependencies.get_reorder_videos_use_case},
         name="reorder-videos-in-group",

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -486,7 +486,7 @@ describe('ApiClient', () => {
         text: () => Promise.resolve(JSON.stringify({ message: "OK" }))
       });
       await apiClient.reorderVideosInGroup(1, [101, 100]);
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/groups/1/reorder/', expect.objectContaining({ method: 'PATCH' }));
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/videos/groups/1/videos/order/', expect.objectContaining({ method: 'PATCH' }));
     });
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -739,7 +739,7 @@ class ApiClient {
   }
 
   async reorderVideosInGroup(groupId: number, videoIds: number[]): Promise<{ message: string }> {
-    return this.request<{ message: string }>(`/videos/groups/${groupId}/reorder/`, {
+    return this.request<{ message: string }>(`/videos/groups/${groupId}/videos/order/`, {
       method: 'PATCH',
       body: { video_ids: videoIds },
     });


### PR DESCRIPTION
## Summary

- `PATCH /api/videos/groups/<id>/reorder/` を `PATCH /api/videos/groups/<id>/videos/order/` に変更
- フロントエンドの `reorderVideosInGroup` メソッドのエンドポイントを合わせて修正
- 旧URL (`/reorder/`) は 404 を返すことをテストで保証

## Test plan

- [x] バックエンド: `test_reorder_videos_url_is_resource_oriented` — 新URL `/videos/groups/<id>/videos/order/` が 200 を返す
- [x] バックエンド: `test_old_reorder_url_not_found` — 旧URL `/videos/groups/<id>/reorder/` が 404 を返す
- [x] バックエンド: 既存の `test_reorder_videos` が引き続き通過する
- [x] フロントエンド: `reorderVideosInGroup calls correct endpoint` が新URLを期待する

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)