### PR TITLE
fix: /export/ エンドポイントを ?download=csv クエリパラメータに変更する

### DIFF
--- a/backend/app/presentation/chat/urls.py
+++ b/backend/app/presentation/chat/urls.py
@@ -5,7 +5,6 @@ from app.dependencies import chat as chat_dependencies
 from .views import (
     ChatAnalyticsView,
     ChatFeedbackView,
-    ChatHistoryExportView,
     ChatHistoryView,
     ChatSearchView,
     ChatView,
@@ -27,15 +26,11 @@ urlpatterns = [
     ),
     path(
         "history/",
-        ChatHistoryView.as_view(chat_history_use_case=chat_dependencies.get_chat_history_use_case),
-        name="chat-history",
-    ),
-    path(
-        "history/export/",
-        ChatHistoryExportView.as_view(
-            export_history_use_case=chat_dependencies.get_export_history_use_case
+        ChatHistoryView.as_view(
+            chat_history_use_case=chat_dependencies.get_chat_history_use_case,
+            export_history_use_case=chat_dependencies.get_export_history_use_case,
         ),
-        name="chat-history-export",
+        name="chat-history",
     ),
     path(
         "feedback/",

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -251,21 +251,59 @@ class ChatFeedbackView(DependencyResolverMixin, APIView):
 
 
 class ChatHistoryView(DependencyResolverMixin, APIView):
-    """Get conversation history for a group (owner only)."""
+    """Get conversation history for a group (owner only).
+
+    Supports ?format=csv to download history as a CSV file.
+    """
 
     authentication_classes = [APIKeyAuthentication, CookieJWTAuthentication]
     permission_classes = [IsAuthenticated, ApiKeyScopePermission]
     serializer_class = ChatLogSerializer
     chat_history_use_case = None
+    export_history_use_case = None
 
     @extend_schema(
-        parameters=[OpenApiParameter("group_id", int, required=False)],
-        responses={200: ChatLogSerializer(many=True)},
+        parameters=[
+            OpenApiParameter("group_id", int, required=False),
+            OpenApiParameter("format", str, required=False, description="Use 'csv' to download as CSV file."),
+        ],
+        responses={
+            200: OpenApiResponse(
+                response=OpenApiTypes.BINARY,
+                description="CSV export when format=csv, otherwise JSON chat log list.",
+            )
+        },
         summary="Get chat history",
-        description="Return chat history for a group. Empty list is returned when group_id is omitted.",
+        description=(
+            "Return chat history for a group. "
+            "Pass ?format=csv to download as a CSV file. "
+            "Empty list is returned when group_id is omitted."
+        ),
     )
     def get(self, request, *args, **kwargs):
         group_id = request.query_params.get("group_id")
+        fmt = request.query_params.get("format")
+
+        if fmt == "csv":
+            if not group_id:
+                return create_error_response(
+                    "Group ID not specified", status.HTTP_400_BAD_REQUEST
+                )
+            use_case = self.resolve_dependency(self.export_history_use_case)
+            try:
+                resolved_group_id, rows = use_case.execute(
+                    group_id=int(group_id), user_id=request.user.id
+                )
+            except ResourceNotFound as e:
+                return create_error_response(str(e), status.HTTP_404_NOT_FOUND)
+
+            http_response = HttpResponse(content_type="text/csv; charset=utf-8")
+            http_response["Content-Disposition"] = (
+                f'attachment; filename="chat_history_group_{resolved_group_id}.csv"'
+            )
+            write_chat_history_csv(csv.writer(http_response), rows)
+            return http_response
+
         if not group_id:
             return Response([])
 
@@ -279,46 +317,6 @@ class ChatHistoryView(DependencyResolverMixin, APIView):
         except ResourceNotFound as e:
             return create_error_response(str(e), status.HTTP_404_NOT_FOUND)
         return Response(ChatLogSerializer(logs, many=True).data)
-
-
-class ChatHistoryExportView(DependencyResolverMixin, APIView):
-    """Export group conversation history as CSV."""
-
-    authentication_classes = [APIKeyAuthentication, CookieJWTAuthentication]
-    permission_classes = [IsAuthenticated, ApiKeyScopePermission]
-    export_history_use_case = None
-
-    @extend_schema(
-        responses={
-            200: OpenApiResponse(
-                response=OpenApiTypes.BINARY,
-                description="CSV export of chat history.",
-            )
-        },
-        summary="Export chat history CSV",
-        description="Export group conversation history as a CSV file.",
-    )
-    def get(self, request):
-        group_id = request.query_params.get("group_id")
-        if not group_id:
-            return create_error_response(
-                "Group ID not specified", status.HTTP_400_BAD_REQUEST
-            )
-
-        use_case = self.resolve_dependency(self.export_history_use_case)
-        try:
-            resolved_group_id, rows = use_case.execute(
-                group_id=int(group_id), user_id=request.user.id
-            )
-        except ResourceNotFound as e:
-            return create_error_response(str(e), status.HTTP_404_NOT_FOUND)
-
-        response = HttpResponse(content_type="text/csv; charset=utf-8")
-        response["Content-Disposition"] = (
-            f'attachment; filename="chat_history_group_{resolved_group_id}.csv"'
-        )
-        write_chat_history_csv(csv.writer(response), rows)
-        return response
 
 
 class PopularScenesView(DependencyResolverMixin, APIView):

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -262,6 +262,15 @@ class ChatHistoryView(DependencyResolverMixin, APIView):
     chat_history_use_case = None
     export_history_use_case = None
 
+    def perform_content_negotiation(self, request, force=False):
+        # ?format=csv is a download hint, not a DRF renderer format.
+        # DRF 3.16+ calls this in initial() before the handler runs,
+        # so intercept here to avoid NotAcceptable when no CSV renderer exists.
+        if request.query_params.get("format") == "csv":
+            from rest_framework.renderers import JSONRenderer
+            return (JSONRenderer(), "application/json")
+        return super().perform_content_negotiation(request, force=force)
+
     @extend_schema(
         parameters=[
             OpenApiParameter("group_id", int, required=False),

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -253,7 +253,7 @@ class ChatFeedbackView(DependencyResolverMixin, APIView):
 class ChatHistoryView(DependencyResolverMixin, APIView):
     """Get conversation history for a group (owner only).
 
-    Supports ?format=csv to download history as a CSV file.
+    Pass ?download=csv to download history as a CSV file.
     """
 
     authentication_classes = [APIKeyAuthentication, CookieJWTAuthentication]
@@ -262,38 +262,28 @@ class ChatHistoryView(DependencyResolverMixin, APIView):
     chat_history_use_case = None
     export_history_use_case = None
 
-    def perform_content_negotiation(self, request, force=False):
-        # ?format=csv is a download hint, not a DRF renderer format.
-        # DRF 3.16+ calls this in initial() before the handler runs,
-        # so intercept here to avoid NotAcceptable when no CSV renderer exists.
-        if request.query_params.get("format") == "csv":
-            from rest_framework.renderers import JSONRenderer
-            return (JSONRenderer(), "application/json")
-        return super().perform_content_negotiation(request, force=force)
-
     @extend_schema(
         parameters=[
             OpenApiParameter("group_id", int, required=False),
-            OpenApiParameter("format", str, required=False, description="Use 'csv' to download as CSV file."),
+            OpenApiParameter("download", str, required=False, description="Pass 'csv' to download as a CSV file."),
         ],
         responses={
             200: OpenApiResponse(
                 response=OpenApiTypes.BINARY,
-                description="CSV export when format=csv, otherwise JSON chat log list.",
+                description="CSV file when download=csv, otherwise JSON chat log list.",
             )
         },
         summary="Get chat history",
         description=(
             "Return chat history for a group. "
-            "Pass ?format=csv to download as a CSV file. "
+            "Pass ?download=csv to download as a CSV file. "
             "Empty list is returned when group_id is omitted."
         ),
     )
     def get(self, request, *args, **kwargs):
         group_id = request.query_params.get("group_id")
-        fmt = request.query_params.get("format")
 
-        if fmt == "csv":
+        if request.query_params.get("download") == "csv":
             if not group_id:
                 return create_error_response(
                     "Group ID not specified", status.HTTP_400_BAD_REQUEST

--- a/backend/app/tests/test_chat_history_format_csv.py
+++ b/backend/app/tests/test_chat_history_format_csv.py
@@ -1,0 +1,147 @@
+"""TDD tests for GET /chat/history/?format=csv endpoint.
+
+Issue #459: /export/ エンドポイントをクエリパラメータに変更する
+- GET /api/chat/history/?format=csv&group_id=1 → CSV response
+- GET /api/chat/history/?group_id=1             → JSON response (unchanged)
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from django.test import RequestFactory
+from rest_framework.request import Request
+
+
+def _make_drf_request(params):
+    """Build a DRF Request with an authenticated user, bypassing auth middleware."""
+    django_request = RequestFactory().get("/chat/history/", params)
+    drf_request = Request(django_request)
+    user = MagicMock()
+    user.id = 1
+    user.is_authenticated = True
+    drf_request._user = user  # set private attr to skip authenticator pipeline
+    return drf_request
+
+
+def _make_export_use_case(group_id=42):
+    use_case = MagicMock()
+    use_case.execute.return_value = (group_id, iter([]))
+    return use_case
+
+
+def _make_history_use_case():
+    use_case = MagicMock()
+    use_case.execute.return_value = []
+    return use_case
+
+
+def _call_get(view_class, use_cases, params):
+    """Instantiate view, inject use cases, and call get() directly."""
+    instance = view_class()
+    for attr, val in use_cases.items():
+        setattr(instance, attr, val)
+    instance.kwargs = {}
+    return instance.get(_make_drf_request(params))
+
+
+class ChatHistoryFormatCsvTests(unittest.TestCase):
+    """ChatHistoryView handles ?format=csv to return CSV export."""
+
+    def test_format_csv_returns_200(self):
+        from app.presentation.chat.views import ChatHistoryView
+
+        response = _call_get(
+            ChatHistoryView,
+            {
+                "chat_history_use_case": _make_history_use_case(),
+                "export_history_use_case": _make_export_use_case(),
+            },
+            {"group_id": "42", "format": "csv"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_format_csv_content_type_is_text_csv(self):
+        from app.presentation.chat.views import ChatHistoryView
+
+        response = _call_get(
+            ChatHistoryView,
+            {
+                "chat_history_use_case": _make_history_use_case(),
+                "export_history_use_case": _make_export_use_case(),
+            },
+            {"group_id": "42", "format": "csv"},
+        )
+        self.assertIn("text/csv", response.get("Content-Type", ""))
+
+    def test_format_csv_content_disposition_contains_filename(self):
+        from app.presentation.chat.views import ChatHistoryView
+
+        response = _call_get(
+            ChatHistoryView,
+            {
+                "chat_history_use_case": _make_history_use_case(),
+                "export_history_use_case": _make_export_use_case(group_id=42),
+            },
+            {"group_id": "42", "format": "csv"},
+        )
+        self.assertIn("chat_history_group_42.csv", response.get("Content-Disposition", ""))
+
+    def test_format_csv_calls_export_use_case_not_history_use_case(self):
+        from app.presentation.chat.views import ChatHistoryView
+
+        history_uc = _make_history_use_case()
+        export_uc = _make_export_use_case()
+        _call_get(
+            ChatHistoryView,
+            {
+                "chat_history_use_case": history_uc,
+                "export_history_use_case": export_uc,
+            },
+            {"group_id": "42", "format": "csv"},
+        )
+        export_uc.execute.assert_called_once_with(group_id=42, user_id=1)
+        history_uc.execute.assert_not_called()
+
+    def test_no_format_param_returns_json(self):
+        from app.presentation.chat.views import ChatHistoryView
+
+        history_uc = _make_history_use_case()
+        response = _call_get(
+            ChatHistoryView,
+            {
+                "chat_history_use_case": history_uc,
+                "export_history_use_case": _make_export_use_case(),
+            },
+            {"group_id": "42"},
+        )
+        self.assertEqual(response.status_code, 200)
+        history_uc.execute.assert_called_once()
+
+    def test_format_csv_missing_group_id_returns_400(self):
+        from app.presentation.chat.views import ChatHistoryView
+
+        response = _call_get(
+            ChatHistoryView,
+            {
+                "chat_history_use_case": _make_history_use_case(),
+                "export_history_use_case": _make_export_use_case(),
+            },
+            {"format": "csv"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+class ChatHistoryExportViewRemovedTests(unittest.TestCase):
+    """ChatHistoryExportView must no longer exist in views module."""
+
+    def test_chat_history_export_view_not_exported(self):
+        import app.presentation.chat.views as views_module
+
+        self.assertFalse(
+            hasattr(views_module, "ChatHistoryExportView"),
+            "ChatHistoryExportView should be removed from views.py",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/app/tests/test_chat_history_format_csv.py
+++ b/backend/app/tests/test_chat_history_format_csv.py
@@ -131,6 +131,44 @@ class ChatHistoryFormatCsvTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
 
+class ChatHistoryFormatCsvDispatchTests(unittest.TestCase):
+    """Ensure ?format=csv works through DRF's full dispatch pipeline (not just get())."""
+
+    def _make_view_and_request(self, params):
+        from rest_framework.test import APIRequestFactory, force_authenticate
+        from app.presentation.chat.views import ChatHistoryView
+
+        export_uc = _make_export_use_case()
+        view = ChatHistoryView.as_view(
+            chat_history_use_case=_make_history_use_case(),
+            export_history_use_case=export_uc,
+        )
+        factory = APIRequestFactory()
+        req = factory.get("/chat/history/", params, HTTP_ACCEPT="application/json")
+        user = MagicMock()
+        user.id = 1
+        user.is_authenticated = True
+        force_authenticate(req, user=user)
+        return view, req, export_uc
+
+    def test_dispatch_format_csv_returns_200(self):
+        view, req, _ = self._make_view_and_request({"group_id": "1", "format": "csv"})
+        resp = view(req)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_dispatch_format_csv_content_type_is_text_csv(self):
+        view, req, _ = self._make_view_and_request({"group_id": "1", "format": "csv"})
+        resp = view(req)
+        self.assertIn("text/csv", resp.get("Content-Type", ""))
+
+    def test_dispatch_no_format_returns_json(self):
+        view, req, _ = self._make_view_and_request({"group_id": "1"})
+        resp = view(req)
+        self.assertEqual(resp.status_code, 200)
+        # DRF Response is lazy-rendered; check accepted_media_type set by finalize_response.
+        self.assertIn("application/json", getattr(resp, "accepted_media_type", ""))
+
+
 class ChatHistoryExportViewRemovedTests(unittest.TestCase):
     """ChatHistoryExportView must no longer exist in views module."""
 

--- a/backend/app/tests/test_chat_history_format_csv.py
+++ b/backend/app/tests/test_chat_history_format_csv.py
@@ -1,8 +1,8 @@
-"""TDD tests for GET /chat/history/?format=csv endpoint.
+"""TDD tests for GET /chat/history/?download=csv endpoint.
 
 Issue #459: /export/ エンドポイントをクエリパラメータに変更する
-- GET /api/chat/history/?format=csv&group_id=1 → CSV response
-- GET /api/chat/history/?group_id=1             → JSON response (unchanged)
+- GET /api/chat/history/?download=csv&group_id=1 → CSV response
+- GET /api/chat/history/?group_id=1              → JSON response (unchanged)
 """
 
 import unittest
@@ -44,10 +44,10 @@ def _call_get(view_class, use_cases, params):
     return instance.get(_make_drf_request(params))
 
 
-class ChatHistoryFormatCsvTests(unittest.TestCase):
-    """ChatHistoryView handles ?format=csv to return CSV export."""
+class ChatHistoryDownloadCsvTests(unittest.TestCase):
+    """ChatHistoryView handles ?download=csv to return CSV export."""
 
-    def test_format_csv_returns_200(self):
+    def test_download_csv_returns_200(self):
         from app.presentation.chat.views import ChatHistoryView
 
         response = _call_get(
@@ -56,11 +56,11 @@ class ChatHistoryFormatCsvTests(unittest.TestCase):
                 "chat_history_use_case": _make_history_use_case(),
                 "export_history_use_case": _make_export_use_case(),
             },
-            {"group_id": "42", "format": "csv"},
+            {"group_id": "42", "download": "csv"},
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_format_csv_content_type_is_text_csv(self):
+    def test_download_csv_content_type_is_text_csv(self):
         from app.presentation.chat.views import ChatHistoryView
 
         response = _call_get(
@@ -69,11 +69,11 @@ class ChatHistoryFormatCsvTests(unittest.TestCase):
                 "chat_history_use_case": _make_history_use_case(),
                 "export_history_use_case": _make_export_use_case(),
             },
-            {"group_id": "42", "format": "csv"},
+            {"group_id": "42", "download": "csv"},
         )
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
-    def test_format_csv_content_disposition_contains_filename(self):
+    def test_download_csv_content_disposition_contains_filename(self):
         from app.presentation.chat.views import ChatHistoryView
 
         response = _call_get(
@@ -82,11 +82,11 @@ class ChatHistoryFormatCsvTests(unittest.TestCase):
                 "chat_history_use_case": _make_history_use_case(),
                 "export_history_use_case": _make_export_use_case(group_id=42),
             },
-            {"group_id": "42", "format": "csv"},
+            {"group_id": "42", "download": "csv"},
         )
         self.assertIn("chat_history_group_42.csv", response.get("Content-Disposition", ""))
 
-    def test_format_csv_calls_export_use_case_not_history_use_case(self):
+    def test_download_csv_calls_export_use_case_not_history_use_case(self):
         from app.presentation.chat.views import ChatHistoryView
 
         history_uc = _make_history_use_case()
@@ -97,12 +97,12 @@ class ChatHistoryFormatCsvTests(unittest.TestCase):
                 "chat_history_use_case": history_uc,
                 "export_history_use_case": export_uc,
             },
-            {"group_id": "42", "format": "csv"},
+            {"group_id": "42", "download": "csv"},
         )
         export_uc.execute.assert_called_once_with(group_id=42, user_id=1)
         history_uc.execute.assert_not_called()
 
-    def test_no_format_param_returns_json(self):
+    def test_no_download_param_returns_json(self):
         from app.presentation.chat.views import ChatHistoryView
 
         history_uc = _make_history_use_case()
@@ -117,7 +117,7 @@ class ChatHistoryFormatCsvTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         history_uc.execute.assert_called_once()
 
-    def test_format_csv_missing_group_id_returns_400(self):
+    def test_download_csv_missing_group_id_returns_400(self):
         from app.presentation.chat.views import ChatHistoryView
 
         response = _call_get(
@@ -126,13 +126,13 @@ class ChatHistoryFormatCsvTests(unittest.TestCase):
                 "chat_history_use_case": _make_history_use_case(),
                 "export_history_use_case": _make_export_use_case(),
             },
-            {"format": "csv"},
+            {"download": "csv"},
         )
         self.assertEqual(response.status_code, 400)
 
 
-class ChatHistoryFormatCsvDispatchTests(unittest.TestCase):
-    """Ensure ?format=csv works through DRF's full dispatch pipeline (not just get())."""
+class ChatHistoryDownloadCsvDispatchTests(unittest.TestCase):
+    """Ensure ?download=csv works through DRF's full dispatch pipeline (not just get())."""
 
     def _make_view_and_request(self, params):
         from rest_framework.test import APIRequestFactory, force_authenticate
@@ -151,21 +151,20 @@ class ChatHistoryFormatCsvDispatchTests(unittest.TestCase):
         force_authenticate(req, user=user)
         return view, req, export_uc
 
-    def test_dispatch_format_csv_returns_200(self):
-        view, req, _ = self._make_view_and_request({"group_id": "1", "format": "csv"})
+    def test_dispatch_download_csv_returns_200(self):
+        view, req, _ = self._make_view_and_request({"group_id": "1", "download": "csv"})
         resp = view(req)
         self.assertEqual(resp.status_code, 200)
 
-    def test_dispatch_format_csv_content_type_is_text_csv(self):
-        view, req, _ = self._make_view_and_request({"group_id": "1", "format": "csv"})
+    def test_dispatch_download_csv_content_type_is_text_csv(self):
+        view, req, _ = self._make_view_and_request({"group_id": "1", "download": "csv"})
         resp = view(req)
         self.assertIn("text/csv", resp.get("Content-Type", ""))
 
-    def test_dispatch_no_format_returns_json(self):
+    def test_dispatch_no_download_returns_json(self):
         view, req, _ = self._make_view_and_request({"group_id": "1"})
         resp = view(req)
         self.assertEqual(resp.status_code, 200)
-        # DRF Response is lazy-rendered; check accepted_media_type set by finalize_response.
         self.assertIn("application/json", getattr(resp, "accepted_media_type", ""))
 
 

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -616,7 +616,7 @@ describe('ApiClient', () => {
 
       await apiClient.exportChatHistoryCsv(1);
 
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/history/export/?group_id=1', expect.anything());
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/history/?group_id=1&format=csv', expect.anything());
       expect(createElementSpy).toHaveBeenCalledWith('a');
       expect(appendChildSpy).toHaveBeenCalledWith(mockLink);
       expect(mockLink.click).toHaveBeenCalled();

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -616,7 +616,7 @@ describe('ApiClient', () => {
 
       await apiClient.exportChatHistoryCsv(1);
 
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/history/?group_id=1&format=csv', expect.anything());
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/history/?group_id=1&download=csv', expect.anything());
       expect(createElementSpy).toHaveBeenCalledWith('a');
       expect(appendChildSpy).toHaveBeenCalledWith(mockLink);
       expect(mockLink.click).toHaveBeenCalled();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -580,7 +580,7 @@ class ApiClient {
 
 
   async exportChatHistoryCsv(groupId: number): Promise<void> {
-    const url = this.buildUrl(`/chat/history/export/?group_id=${groupId}`);
+    const url = this.buildUrl(`/chat/history/?group_id=${groupId}&format=csv`);
 
     const doFetch = async (): Promise<Response> => {
       return fetch(url, {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -580,7 +580,7 @@ class ApiClient {
 
 
   async exportChatHistoryCsv(groupId: number): Promise<void> {
-    const url = this.buildUrl(`/chat/history/?group_id=${groupId}&format=csv`);
+    const url = this.buildUrl(`/chat/history/?group_id=${groupId}&download=csv`);
 
     const doFetch = async (): Promise<Response> => {
       return fetch(url, {


### PR DESCRIPTION
## 概要

Closes #459

`/export/` という動詞をURLから排除し、`?download=csv` クエリパラメータでCSVダウンロードを表現するよう変更しました。

## 変更内容

| 変更前 | 変更後 |
|--------|--------|
| `GET /api/chat/history/export/?group_id=N` | `GET /api/chat/history/?group_id=N&download=csv` |

## 実装の詳細

- `ChatHistoryView.get()` に `?download=csv` 対応を追加し、`ChatHistoryExportView` を削除
- `history/export/` URLルートを削除し、`history/` に `export_history_use_case` を統合
- フロントエンドの `exportChatHistoryCsv()` のURLを更新

### `?format=csv` ではなく `?download=csv` を採用した理由

`?format=csv` は DRF 3.16 の `URL_FORMAT_OVERRIDE` 機能と衝突し、CSVレンダラーが存在しないため 406 Not Acceptable が返される問題があります。`?download=csv` はこの衝突がなく、ダウンロード意図を明確に表現できます。

## テスト

- バックエンド: `test_chat_history_format_csv.py` を新規作成（10件）- dispatch パイプラインを通じた結合テストを含む
- フロントエンド: `api.test.ts` の期待URLを更新
- バックエンド全体: 764件 ✅
- フロントエンド全体: 446件 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)