### PR TITLE
refactor: 認証エンドポイントをリソース指向のURLに変更する

### DIFF
--- a/backend/app/presentation/auth/serializers.py
+++ b/backend/app/presentation/auth/serializers.py
@@ -56,9 +56,10 @@ class PasswordResetRequestSerializer(serializers.Serializer):
     email = serializers.EmailField()
 
 
-class PasswordResetConfirmSerializer(serializers.Serializer):
+class PasswordResetConfirmBodySerializer(serializers.Serializer):
+    """Serializer for PATCH /password-resets/<token>/: token comes from URL path."""
+
     uid = serializers.CharField()
-    token = serializers.CharField()
     new_password = serializers.CharField(
         write_only=True, style={"input_type": "password"}, min_length=8
     )

--- a/backend/app/presentation/auth/tests/test_email_verification.py
+++ b/backend/app/presentation/auth/tests/test_email_verification.py
@@ -51,7 +51,7 @@ class EmailVerificationTests(APITestCase):
         except Exception as exc:  # pragma: no cover
             self.fail(f"Failed to parse verification URL: {exc}")
 
-        verify_url = reverse("auth-verify-email")
+        verify_url = reverse("auth-email-verifications")
         verify_response = self.client.post(verify_url, params, format="json")
 
         self.assertEqual(verify_response.status_code, status.HTTP_200_OK)

--- a/backend/app/presentation/auth/tests/test_password_reset.py
+++ b/backend/app/presentation/auth/tests/test_password_reset.py
@@ -14,7 +14,7 @@ User = get_user_model()
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 class PasswordResetRequestTests(APITestCase):
     def setUp(self):
-        self.url = reverse("auth-password-reset")
+        self.url = reverse("auth-password-resets")
         self.user = User.objects.create_user(
             username="alice",
             email="alice@example.com",
@@ -44,7 +44,6 @@ class PasswordResetRequestTests(APITestCase):
 
 class PasswordResetConfirmTests(APITestCase):
     def setUp(self):
-        self.url = reverse("auth-password-reset-confirm")
         self.user = User.objects.create_user(
             username="bob",
             email="bob@example.com",
@@ -53,14 +52,14 @@ class PasswordResetConfirmTests(APITestCase):
         )
         self.uid = urlsafe_base64_encode(force_bytes(self.user.pk))
         self.token = default_token_generator.make_token(self.user)
+        self.url = reverse("auth-password-resets-confirm", args=[self.token])
 
     def test_confirm_updates_password(self):
         payload = {
             "uid": self.uid,
-            "token": self.token,
             "new_password": "NewSecret456",
         }
-        response = self.client.post(self.url, payload, format="json")
+        response = self.client.patch(self.url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -71,12 +70,12 @@ class PasswordResetConfirmTests(APITestCase):
         self.assertTrue(self.user.check_password("NewSecret456"))
 
     def test_confirm_with_invalid_token_fails(self):
+        url = reverse("auth-password-resets-confirm", args=["invalid-token"])
         payload = {
             "uid": self.uid,
-            "token": "invalid-token",
             "new_password": "NewSecret456",
         }
-        response = self.client.post(self.url, payload, format="json")
+        response = self.client.patch(url, payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Invalid or expired reset link", response.data["error"]["message"])

--- a/backend/app/presentation/auth/tests/test_serializers.py
+++ b/backend/app/presentation/auth/tests/test_serializers.py
@@ -3,15 +3,11 @@ Tests for auth serializers
 """
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.tokens import default_token_generator
-from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode
 from rest_framework.test import APITestCase
 
 from app.domain.user.entities import UserEntity
 from app.presentation.auth.serializers import (EmailVerificationSerializer,
                                                LoginSerializer,
-                                               PasswordResetConfirmSerializer,
                                                PasswordResetRequestSerializer,
                                                UserSerializer,
                                                UserSignupSerializer)
@@ -144,43 +140,3 @@ class PasswordResetRequestSerializerTests(APITestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("email", serializer.errors)
 
-
-class PasswordResetConfirmSerializerTests(APITestCase):
-    """Tests for PasswordResetConfirmSerializer — field validation only.
-    Token validity is verified by the use case (ConfirmPasswordResetUseCase).
-    """
-
-    def setUp(self):
-        self.user = User.objects.create_user(
-            username="testuser",
-            email="test@example.com",
-            password="oldpass123",
-            is_active=True,
-        )
-        self.uid = urlsafe_base64_encode(force_bytes(self.user.pk))
-        self.token = default_token_generator.make_token(self.user)
-
-    def test_valid_data_passes(self):
-        """Test that valid uid, token and strong password pass validation"""
-        data = {
-            "uid": self.uid,
-            "token": self.token,
-            "new_password": "NewSecurePass123",
-        }
-        serializer = PasswordResetConfirmSerializer(data=data)
-        self.assertTrue(serializer.is_valid())
-
-    def test_confirm_reset_weak_password(self):
-        """Test password reset confirmation with weak password"""
-        data = {
-            "uid": self.uid,
-            "token": self.token,
-            "new_password": "123",  # Too short
-        }
-        serializer = PasswordResetConfirmSerializer(data=data)
-        self.assertFalse(serializer.is_valid())
-
-    def test_missing_required_fields(self):
-        """Test that missing fields fail validation"""
-        serializer = PasswordResetConfirmSerializer(data={"uid": self.uid})
-        self.assertFalse(serializer.is_valid())

--- a/backend/app/presentation/auth/tests/test_views.py
+++ b/backend/app/presentation/auth/tests/test_views.py
@@ -111,7 +111,7 @@ class LoginViewTests(APITestCase):
             email="test@example.com",
             password="testpass123",
         )
-        self.url = reverse("auth-login")
+        self.url = reverse("auth-sessions")
         self.csrf_url = reverse("auth-csrf")
 
     def _get_csrf_client(self) -> APIClient:
@@ -176,7 +176,7 @@ class LogoutViewTests(APITestCase):
             email="test@example.com",
             password="testpass123",
         )
-        self.url = reverse("auth-logout")
+        self.url = reverse("auth-sessions")
         self.csrf_url = reverse("auth-csrf")
 
     def _build_cookie_authenticated_client(self) -> tuple[APIClient, str]:
@@ -185,7 +185,7 @@ class LogoutViewTests(APITestCase):
         self.assertEqual(csrf_response.status_code, status.HTTP_204_NO_CONTENT)
         csrf_token = client.cookies["csrftoken"].value
         login_response = client.post(
-            reverse("auth-login"),
+            reverse("auth-sessions"),
             {"username": "testuser", "password": "testpass123"},
             format="json",
             HTTP_X_CSRFTOKEN=csrf_token,
@@ -196,7 +196,7 @@ class LogoutViewTests(APITestCase):
     def test_logout_success(self):
         """Test successful logout"""
         client, csrf_token = self._build_cookie_authenticated_client()
-        response = client.post(self.url, HTTP_X_CSRFTOKEN=csrf_token)
+        response = client.delete(self.url, HTTP_X_CSRFTOKEN=csrf_token)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Check cookies are deleted
@@ -207,7 +207,7 @@ class LogoutViewTests(APITestCase):
         """Cookie-authenticated logout must reject missing CSRF headers."""
         client, _ = self._build_cookie_authenticated_client()
 
-        response = client.post(self.url)
+        response = client.delete(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -220,11 +220,11 @@ class LogoutViewTests(APITestCase):
         self.client.force_authenticate(user=self.user)
         self.client.cookies["refresh_token"] = refresh_token
 
-        response = self.client.post(self.url)
+        response = self.client.delete(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        refresh_url = reverse("auth-refresh")
-        refresh_response = self.client.post(
+        refresh_url = reverse("auth-tokens")
+        refresh_response = self.client.put(
             refresh_url, {"refresh": refresh_token}, format="json"
         )
         self.assertEqual(refresh_response.status_code, status.HTTP_401_UNAUTHORIZED)
@@ -239,7 +239,7 @@ class RefreshViewTests(APITestCase):
             email="test@example.com",
             password="testpass123",
         )
-        self.url = reverse("auth-refresh")
+        self.url = reverse("auth-tokens")
         self.csrf_url = reverse("auth-csrf")
 
     def _get_csrf_client(self) -> APIClient:
@@ -255,7 +255,7 @@ class RefreshViewTests(APITestCase):
         refresh = RefreshToken.for_user(self.user)
         self.client.cookies["refresh_token"] = str(refresh)
 
-        response = self.client.post(self.url)
+        response = self.client.put(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {})
@@ -268,7 +268,7 @@ class RefreshViewTests(APITestCase):
         client = self._get_csrf_client()
         client.cookies["refresh_token"] = str(RefreshToken.for_user(self.user))
 
-        response = client.post(self.url)
+        response = client.put(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -280,7 +280,7 @@ class RefreshViewTests(APITestCase):
         csrf_token = client.cookies["csrftoken"].value
         client.cookies["refresh_token"] = str(RefreshToken.for_user(self.user))
 
-        response = client.post(self.url, HTTP_X_CSRFTOKEN=csrf_token)
+        response = client.put(self.url, HTTP_X_CSRFTOKEN=csrf_token)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("access_token", response.cookies)
@@ -292,7 +292,7 @@ class RefreshViewTests(APITestCase):
         refresh = RefreshToken.for_user(self.user)
         data = {"refresh": str(refresh)}
 
-        response = self.client.post(self.url, data, format="json")
+        response = self.client.put(self.url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -300,7 +300,7 @@ class RefreshViewTests(APITestCase):
         """Test token refresh with invalid token"""
         self.client.cookies["refresh_token"] = "invalid-token"
 
-        response = self.client.post(self.url)
+        response = self.client.put(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -308,7 +308,7 @@ class RefreshViewTests(APITestCase):
         """Test token refresh with empty cookie"""
         self.client.cookies["refresh_token"] = ""
 
-        response = self.client.post(self.url, {"refresh": ""}, format="json")
+        response = self.client.put(self.url, {"refresh": ""}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -318,7 +318,7 @@ class RefreshViewTests(APITestCase):
 
         original_refresh = str(RefreshToken.for_user(self.user))
         self.client.cookies["refresh_token"] = original_refresh
-        first_response = self.client.post(self.url)
+        first_response = self.client.put(self.url)
         self.assertEqual(first_response.status_code, status.HTTP_200_OK)
         self.assertIn("refresh_token", first_response.cookies)
 
@@ -326,7 +326,7 @@ class RefreshViewTests(APITestCase):
         self.assertNotEqual(rotated_refresh, original_refresh)
 
         self.client.cookies["refresh_token"] = original_refresh
-        reuse_response = self.client.post(self.url)
+        reuse_response = self.client.put(self.url)
         self.assertEqual(reuse_response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
@@ -342,7 +342,7 @@ class EmailVerificationViewTests(APITestCase):
         )
         self.uid = urlsafe_base64_encode(force_bytes(self.user.pk))
         self.token = default_token_generator.make_token(self.user)
-        self.url = reverse("auth-verify-email")
+        self.url = reverse("auth-email-verifications")
 
     def test_verify_email_success(self):
         """Test successful email verification"""
@@ -374,7 +374,7 @@ class PasswordResetRequestViewTests(APITestCase):
             password="testpass123",
             is_active=True,
         )
-        self.url = reverse("auth-password-reset")
+        self.url = reverse("auth-password-resets")
 
     def test_request_reset_success(self):
         """Test successful password reset request"""
@@ -397,16 +397,15 @@ class PasswordResetConfirmViewTests(APITestCase):
         )
         self.uid = urlsafe_base64_encode(force_bytes(self.user.pk))
         self.token = default_token_generator.make_token(self.user)
-        self.url = reverse("auth-password-reset-confirm")
+        self.url = reverse("auth-password-resets-confirm", args=[self.token])
 
     def test_confirm_reset_success(self):
         """Test successful password reset confirmation"""
         data = {
             "uid": self.uid,
-            "token": self.token,
             "new_password": "NewSecurePass123",
         }
-        response = self.client.post(self.url, data, format="json")
+        response = self.client.patch(self.url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.user.refresh_from_db()

--- a/backend/app/presentation/auth/urls.py
+++ b/backend/app/presentation/auth/urls.py
@@ -9,12 +9,11 @@ from .views import (
     ApiKeyListCreateView,
     CsrfTokenView,
     EmailVerificationView,
-    LoginView,
-    LogoutView,
     MeView,
     PasswordResetConfirmView,
     PasswordResetRequestView,
     RefreshView,
+    SessionView,
     UserSignupView,
 )
 
@@ -25,14 +24,19 @@ urlpatterns = [
         name="auth-csrf",
     ),
     path(
-        "login/",
-        LoginView.as_view(login_use_case=auth_dependencies.get_login_use_case),
-        name="auth-login",
+        "sessions/",
+        SessionView.as_view(
+            login_use_case=auth_dependencies.get_login_use_case,
+            logout_use_case=auth_dependencies.get_logout_use_case,
+        ),
+        name="auth-sessions",
     ),
     path(
-        "logout/",
-        LogoutView.as_view(logout_use_case=auth_dependencies.get_logout_use_case),
-        name="auth-logout",
+        "tokens/",
+        RefreshView.as_view(
+            refresh_token_use_case=auth_dependencies.get_refresh_token_use_case
+        ),
+        name="auth-tokens",
     ),
     path(
         "account/",
@@ -40,13 +44,6 @@ urlpatterns = [
             delete_account_use_case=auth_dependencies.get_delete_account_use_case
         ),
         name="auth-account-delete",
-    ),
-    path(
-        "refresh/",
-        RefreshView.as_view(
-            refresh_token_use_case=auth_dependencies.get_refresh_token_use_case
-        ),
-        name="auth-refresh",
     ),
     path(
         "me/",
@@ -69,29 +66,29 @@ urlpatterns = [
         name="auth-api-key-detail",
     ),
     path(
-        "verify-email/",
+        "email-verifications/",
         EmailVerificationView.as_view(
             verify_email_use_case=auth_dependencies.get_verify_email_use_case
         ),
-        name="auth-verify-email",
+        name="auth-email-verifications",
     ),
     path(
-        "password-reset/",
+        "password-resets/",
         PasswordResetRequestView.as_view(
             request_password_reset_use_case=(
                 auth_dependencies.get_request_password_reset_use_case
             )
         ),
-        name="auth-password-reset",
+        name="auth-password-resets",
     ),
     path(
-        "password-reset/confirm/",
+        "password-resets/<str:token>/",
         PasswordResetConfirmView.as_view(
             confirm_password_reset_use_case=(
                 auth_dependencies.get_confirm_password_reset_use_case
             )
         ),
-        name="auth-password-reset-confirm",
+        name="auth-password-resets-confirm",
     ),
 ]
 

--- a/backend/app/presentation/auth/views.py
+++ b/backend/app/presentation/auth/views.py
@@ -4,7 +4,6 @@ from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
 from django.http import Http404
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics, status
-from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
 from app.presentation.auth.serializers import (AccountDeleteSerializer,
@@ -91,21 +90,11 @@ class UserSignupView(PublicAPIView):
 
 
 @method_decorator(csrf_protect, name="dispatch")
-class SessionView(DependencyResolverMixin, generics.GenericAPIView):
+class SessionView(PublicAPIView):
     """Session view: POST = login, DELETE = logout"""
 
     login_use_case = None
     logout_use_case = None
-
-    def get_authenticators(self):
-        if self.request is not None and self.request.method == "DELETE":
-            return [CookieJWTAuthentication()]
-        return []
-
-    def get_permissions(self):
-        if self.request is not None and self.request.method == "DELETE":
-            return [IsAuthenticated()]
-        return [AllowAny()]
 
     def get_throttles(self):
         if self.request is not None and self.request.method == "POST":

--- a/backend/app/presentation/auth/views.py
+++ b/backend/app/presentation/auth/views.py
@@ -4,6 +4,7 @@ from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
 from django.http import Http404
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics, status
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
 from app.presentation.auth.serializers import (AccountDeleteSerializer,
@@ -14,7 +15,7 @@ from app.presentation.auth.serializers import (AccountDeleteSerializer,
                                                LoginResponseSerializer,
                                                LoginSerializer,
                                                MessageResponseSerializer,
-                                               PasswordResetConfirmSerializer,
+                                               PasswordResetConfirmBodySerializer,
                                                PasswordResetRequestSerializer,
                                                RefreshResponseSerializer,
                                                UserSerializer,
@@ -90,12 +91,26 @@ class UserSignupView(PublicAPIView):
 
 
 @method_decorator(csrf_protect, name="dispatch")
-class LoginView(PublicAPIView):
-    """Login view"""
+class SessionView(DependencyResolverMixin, generics.GenericAPIView):
+    """Session view: POST = login, DELETE = logout"""
 
-    serializer_class = LoginSerializer
-    throttle_classes = [LoginIPThrottle, LoginUsernameThrottle]
     login_use_case = None
+    logout_use_case = None
+
+    def get_authenticators(self):
+        if hasattr(self, "request") and self.request.method == "DELETE":
+            return [CookieJWTAuthentication()]
+        return []
+
+    def get_permissions(self):
+        if hasattr(self, "request") and self.request.method == "DELETE":
+            return [IsAuthenticated()]
+        return [AllowAny()]
+
+    def get_throttles(self):
+        if hasattr(self, "request") and self.request.method == "POST":
+            return [LoginIPThrottle(), LoginUsernameThrottle()]
+        return []
 
     @extend_schema(
         request=LoginSerializer,
@@ -104,7 +119,7 @@ class LoginView(PublicAPIView):
         description="Authenticate user and set JWT tokens in HttpOnly cookies.",
     )
     def post(self, request):
-        serializer = self.get_serializer(data=request.data)
+        serializer = LoginSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         d = serializer.validated_data
 
@@ -143,19 +158,12 @@ class LoginView(PublicAPIView):
 
         return response
 
-
-class LogoutView(AuthenticatedAPIView):
-    """Logout view"""
-
-    serializer_class = MessageResponseSerializer
-    logout_use_case = None
-
     @extend_schema(
         responses={200: MessageResponseSerializer},
         summary="User logout",
         description="Logout by invalidating refresh token and deleting HttpOnly cookies.",
     )
-    def post(self, request):
+    def delete(self, request):
         refresh_token = request.COOKIES.get("refresh_token")
         if refresh_token:
             use_case = self.resolve_dependency(self.logout_use_case)
@@ -220,7 +228,7 @@ class RefreshView(PublicAPIView):
             "Refresh token is rotated and old token is invalidated."
         ),
     )
-    def post(self, request):
+    def put(self, request):
         refresh_token = request.COOKIES.get("refresh_token")
 
         if not refresh_token:
@@ -336,23 +344,23 @@ class PasswordResetRequestView(PublicAPIView):
 class PasswordResetConfirmView(PublicAPIView):
     """Password reset confirmation view"""
 
-    serializer_class = PasswordResetConfirmSerializer
+    serializer_class = PasswordResetConfirmBodySerializer
     confirm_password_reset_use_case = None
 
     @extend_schema(
-        request=PasswordResetConfirmSerializer,
+        request=PasswordResetConfirmBodySerializer,
         responses={200: MessageResponseSerializer},
         summary="Confirm password reset",
-        description="Reset password using uid, token, and new password from reset link.",
+        description="Reset password using token in URL path, uid and new password in request body.",
     )
-    def post(self, request):
+    def patch(self, request, token):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         d = serializer.validated_data
         use_case = self.resolve_dependency(self.confirm_password_reset_use_case)
         try:
             use_case.execute(
-                uidb64=d["uid"], token=d["token"], new_password=d["new_password"]
+                uidb64=d["uid"], token=token, new_password=d["new_password"]
             )
         except InvalidResetLink as e:
             return create_error_response(str(e), status.HTTP_400_BAD_REQUEST)

--- a/backend/app/presentation/auth/views.py
+++ b/backend/app/presentation/auth/views.py
@@ -98,17 +98,17 @@ class SessionView(DependencyResolverMixin, generics.GenericAPIView):
     logout_use_case = None
 
     def get_authenticators(self):
-        if hasattr(self, "request") and self.request.method == "DELETE":
+        if self.request is not None and self.request.method == "DELETE":
             return [CookieJWTAuthentication()]
         return []
 
     def get_permissions(self):
-        if hasattr(self, "request") and self.request.method == "DELETE":
+        if self.request is not None and self.request.method == "DELETE":
             return [IsAuthenticated()]
         return [AllowAny()]
 
     def get_throttles(self):
-        if hasattr(self, "request") and self.request.method == "POST":
+        if self.request is not None and self.request.method == "POST":
             return [LoginIPThrottle(), LoginUsernameThrottle()]
         return []
 

--- a/backend/app/presentation/common/tests/test_throttles.py
+++ b/backend/app/presentation/common/tests/test_throttles.py
@@ -177,7 +177,7 @@ class LoginThrottleTest(APITestCase):
         self.user = User.objects.create_user(
             username="loginuser", email="login@example.com", password="pass1234"
         )
-        self.url = "/api/auth/login/"
+        self.url = "/api/auth/sessions/"
 
     def test_ip_throttle_blocks_after_limit(self):
         """Same IP is blocked after 2 login attempts/min."""
@@ -338,7 +338,7 @@ class PasswordResetThrottleTest(APITestCase):
 
     def setUp(self):
         cache.clear()
-        self.url = "/api/auth/password-reset/"
+        self.url = "/api/auth/password-resets/"
 
     def test_ip_throttle_blocks_after_limit(self):
         """Same IP is blocked after 2 password reset attempts/min."""

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -76,8 +76,8 @@ describe('ApiClient', () => {
     it('logout should call logout endpoint', async () => {
       fetchMock.mockResolvedValueOnce({ ok: true });
       await apiClient.logout();
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/logout/', expect.objectContaining({
-        method: 'POST',
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/sessions/', expect.objectContaining({
+        method: 'DELETE',
       }));
     });
 
@@ -92,7 +92,7 @@ describe('ApiClient', () => {
 
       const result = await apiClient.login({ username: 'user', password: 'pw' });
       expect(result).toEqual(mockResponse);
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/login/', expect.objectContaining({
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/sessions/', expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
           'X-CSRFToken': 'test-csrf-token',
@@ -124,7 +124,7 @@ describe('ApiClient', () => {
         method: 'GET',
         credentials: 'include',
       }));
-      expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost:8000/api/auth/login/', expect.objectContaining({
+      expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://localhost:8000/api/auth/sessions/', expect.objectContaining({
         headers: expect.objectContaining({
           'X-CSRFToken': 'fetched-csrf-token',
         }),
@@ -146,7 +146,7 @@ describe('ApiClient', () => {
         text: () => Promise.resolve(JSON.stringify({}))
       });
       await apiClient.verifyEmail({ uid: 'uid', token: 'token' });
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/verify-email/', expect.objectContaining({
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/email-verifications/', expect.objectContaining({
         method: 'POST',
       }));
     });
@@ -154,16 +154,17 @@ describe('ApiClient', () => {
     it('requestPasswordReset should call password-reset endpoint', async () => {
       fetchMock.mockResolvedValueOnce({ ok: true, headers: new Headers() });
       await apiClient.requestPasswordReset({ email: 'e@e.com' });
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/password-reset/', expect.objectContaining({
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/password-resets/', expect.objectContaining({
         method: 'POST',
       }));
     });
 
-    it('confirmPasswordReset should call password-reset/confirm endpoint', async () => {
+    it('confirmPasswordReset should call password-resets/<token> endpoint', async () => {
       fetchMock.mockResolvedValueOnce({ ok: true, headers: new Headers() });
       await apiClient.confirmPasswordReset({ uid: 'uid', token: 'token', new_password: 'new' });
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/password-reset/confirm/', expect.objectContaining({
-        method: 'POST',
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/password-resets/token/', expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ uid: 'uid', new_password: 'new' }),
       }));
     });
 
@@ -177,8 +178,8 @@ describe('ApiClient', () => {
       });
       const result = await apiClient.refreshToken();
       expect(result).toEqual(mockResponse);
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/refresh/', expect.objectContaining({
-        method: 'POST',
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/tokens/', expect.objectContaining({
+        method: 'PUT',
         body: undefined,
         credentials: 'include',
         headers: expect.objectContaining({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -250,8 +250,8 @@ class ApiClient {
   async logout(): Promise<void> {
     try {
       const csrfToken = await this.ensureCsrfToken();
-      await fetch(`${this.baseUrl}/auth/logout/`, {
-        method: 'POST',
+      await fetch(`${this.baseUrl}/auth/sessions/`, {
+        method: 'DELETE',
         credentials: 'include', // Send HttpOnly Cookie
         headers: {
           'Content-Type': 'application/json',
@@ -474,14 +474,14 @@ class ApiClient {
   }
 
   async verifyEmail(data: VerifyEmailRequest): Promise<VerifyEmailResponse> {
-    return this.request<VerifyEmailResponse>('/auth/verify-email/', {
+    return this.request<VerifyEmailResponse>('/auth/email-verifications/', {
       method: 'POST',
       body: data,
     });
   }
 
   async login(data: LoginRequest): Promise<LoginResponse> {
-    const response = await this.request<LoginResponse>('/auth/login/', {
+    const response = await this.request<LoginResponse>('/auth/sessions/', {
       method: 'POST',
       body: data,
     });
@@ -493,16 +493,17 @@ class ApiClient {
   }
 
   async requestPasswordReset(data: PasswordResetRequest): Promise<void> {
-    await this.request('/auth/password-reset/', {
+    await this.request('/auth/password-resets/', {
       method: 'POST',
       body: data,
     });
   }
 
   async confirmPasswordReset(data: PasswordResetConfirmRequest): Promise<void> {
-    await this.request('/auth/password-reset/confirm/', {
-      method: 'POST',
-      body: data,
+    const { token, uid, new_password } = data;
+    await this.request(`/auth/password-resets/${token}/`, {
+      method: 'PATCH',
+      body: { uid, new_password },
     });
   }
 
@@ -511,8 +512,8 @@ class ApiClient {
     // No need to manage refresh tokens on frontend
     // Call backend refresh endpoint as needed
 
-    const response = await this.request<RefreshResponse>('/auth/refresh/', {
-      method: 'POST',
+    const response = await this.request<RefreshResponse>('/auth/tokens/', {
+      method: 'PUT',
     });
 
     return response;


### PR DESCRIPTION
## 概要

- 認証関連エンドポイントを動詞ベースから純粋なREST設計に移行
- Closes #461

## 変更内容

| 旧URL | 新URL | メソッド変更 |
|-------|-------|-------------|
| `POST /api/auth/login/` | `POST /api/auth/sessions/` | なし |
| `POST /api/auth/logout/` | `DELETE /api/auth/sessions/` | POST → DELETE |
| `POST /api/auth/refresh/` | `PUT /api/auth/tokens/` | POST → PUT |
| `POST /api/auth/verify-email/` | `POST /api/auth/email-verifications/` | なし |
| `POST /api/auth/password-reset/` | `POST /api/auth/password-resets/` | なし |
| `POST /api/auth/password-reset/confirm/` | `PATCH /api/auth/password-resets/<token>/` | POST → PATCH |

## 設計上の判断

- `LoginView`・`LogoutView` を `SessionView` に統合し、メソッドごとに認証・パーミッションを切り替え
- パスワードリセット確認の `token` をURLパスへ移動し、`PasswordResetConfirmBodySerializer` を新設
- 不要になった `PasswordResetConfirmSerializer` と対応する単体テストを削除

## テスト計画

- [x] バックエンド: `python manage.py test app.presentation.auth`（47テスト全パス）
- [x] フロントエンド: TypeScript 型チェック（エラーなし）