### PR TITLE
refactor: /auth/signup/ をリソース指向の /auth/users/ に変更する

### DIFF
--- a/backend/app/presentation/auth/tests/test_email_verification.py
+++ b/backend/app/presentation/auth/tests/test_email_verification.py
@@ -16,7 +16,7 @@ User = get_user_model()
 )
 class EmailVerificationTests(APITestCase):
     def test_signup_requires_email_verification(self):
-        url = reverse("signup")
+        url = reverse("auth-users")
         payload = {
             "username": "newuser",
             "email": "newuser@example.com",

--- a/backend/app/presentation/auth/tests/test_views.py
+++ b/backend/app/presentation/auth/tests/test_views.py
@@ -36,7 +36,7 @@ class UserSignupViewTests(APITestCase):
 
     def test_signup_success(self):
         """Test successful user signup"""
-        url = reverse("signup")
+        url = reverse("auth-users")
         data = {
             "username": "newuser",
             "email": "newuser@example.com",
@@ -56,7 +56,7 @@ class UserSignupViewTests(APITestCase):
             email="existing@example.com",
             password="SecurePass123",
         )
-        url = reverse("signup")
+        url = reverse("auth-users")
         data = {
             "username": "newuser",
             "email": "existing@example.com",
@@ -82,7 +82,7 @@ class UserSignupViewTests(APITestCase):
         )
         mock_resolve_dependency.return_value = use_case
 
-        url = reverse("signup")
+        url = reverse("auth-users")
         data = {
             "username": "newuser",
             "email": "newuser@example.com",

--- a/backend/app/presentation/auth/urls.py
+++ b/backend/app/presentation/auth/urls.py
@@ -95,8 +95,8 @@ urlpatterns = [
 if settings.ENABLE_SIGNUP:
     urlpatterns.append(
         path(
-            "signup/",
+            "users/",
             UserSignupView.as_view(signup_use_case=auth_dependencies.get_signup_use_case),
-            name="signup",
+            name="auth-users",
         )
     )

--- a/backend/app/presentation/common/tests/test_throttles.py
+++ b/backend/app/presentation/common/tests/test_throttles.py
@@ -246,7 +246,7 @@ class SignupThrottleTest(APITestCase):
 
     def setUp(self):
         cache.clear()
-        self.url = "/api/auth/signup/"
+        self.url = "/api/auth/users/"
 
     def test_blocks_after_limit(self):
         """Same IP is blocked after 2 signup attempts/min."""

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -134,7 +134,7 @@ describe('ApiClient', () => {
     it('signup should call signup endpoint', async () => {
       fetchMock.mockResolvedValueOnce({ ok: true, headers: new Headers() });
       await apiClient.signup({ username: 'u', email: 'e@e.com', password: 'p' });
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/signup/', expect.objectContaining({
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/users/', expect.objectContaining({
         method: 'POST',
       }));
     });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -467,7 +467,7 @@ class ApiClient {
   }
 
   async signup(data: SignupRequest): Promise<void> {
-    await this.request('/auth/signup/', {
+    await this.request('/auth/users/', {
       method: 'POST',
       body: data,
     });


### PR DESCRIPTION
## 概要

Issue #467 の対応。`POST /auth/signup/` のURLに動詞 `signup` が含まれており RESTful でなかったため、リソース指向の `POST /auth/users/` に変更する。

## 変更内容

- `backend/app/presentation/auth/urls.py`: パスを `signup/` → `users/`、URL名を `auth-signup` → `auth-users` に変更
- `backend/app/presentation/auth/tests/test_views.py`: `reverse("auth-signup")` → `reverse("auth-users")` に更新
- `frontend/src/lib/api.ts`: `signup()` メソッドのエンドポイントを `/auth/signup/` → `/auth/users/` に更新
- `frontend/src/lib/__tests__/api.test.ts`: テスト内のエンドポイント参照を更新

## テスト計画

- [x] `UserSignupViewTests` が `auth-users` URL名で正常に動作することを確認
- [x] フロントエンドのサインアップフローが `/auth/users/` を呼び出すことを確認

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)