### PR TITLE
refactor: POST /chat/search/ をリソース指向の GET /chat/scenes/ に変更する

### DIFF
--- a/backend/app/presentation/chat/tests/test_views.py
+++ b/backend/app/presentation/chat/tests/test_views.py
@@ -250,7 +250,7 @@ class ChatViewTests(APITestCase):
         self.assertEqual(related[0]["start_time"], "00:00:10")
 
 
-class ChatSearchViewTests(APITestCase):
+class ChatScenesViewTests(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user(
             username="searchuser",
@@ -286,13 +286,12 @@ class ChatSearchViewTests(APITestCase):
             )
         ]
 
-        response = self.client.post(
-            reverse("chat-search"),
+        response = self.client.get(
+            reverse("chat-scenes"),
             {
                 "query_text": "この部分の説明を探して",
                 "group_id": self.group.id,
             },
-            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -300,19 +299,17 @@ class ChatSearchViewTests(APITestCase):
         self.assertEqual(response.data["related_videos"][0]["video_id"], self.video.id)
 
     def test_search_related_scenes_rejects_empty_query(self):
-        response = self.client.post(
-            reverse("chat-search"),
+        response = self.client.get(
+            reverse("chat-scenes"),
             {"query_text": "", "group_id": self.group.id},
-            format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("error", response.data)
 
     def test_search_related_scenes_group_not_found(self):
-        response = self.client.post(
-            reverse("chat-search"),
+        response = self.client.get(
+            reverse("chat-scenes"),
             {"query_text": "q", "group_id": 99999},
-            format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -321,10 +318,9 @@ class ChatSearchViewTests(APITestCase):
         mock_search_related_videos.return_value = []
         self.client.force_authenticate(user=None)
 
-        response = self.client.post(
-            f"{reverse('chat-search')}?share_token={self.group.share_token}",
-            {"query_text": "q", "group_id": self.group.id},
-            format="json",
+        response = self.client.get(
+            reverse("chat-scenes"),
+            {"query_text": "q", "group_id": self.group.id, "share_token": self.group.share_token},
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -338,10 +334,9 @@ class ChatSearchViewTests(APITestCase):
             "provider retrieval detail"
         )
 
-        response = self.client.post(
-            reverse("chat-search"),
+        response = self.client.get(
+            reverse("chat-scenes"),
             {"query_text": "q", "group_id": self.group.id},
-            format="json",
         )
 
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/backend/app/presentation/chat/urls.py
+++ b/backend/app/presentation/chat/urls.py
@@ -18,11 +18,11 @@ urlpatterns = [
         name="chat",
     ),
     path(
-        "search/",
+        "scenes/",
         ChatSearchView.as_view(
             search_related_videos_use_case=chat_dependencies.get_search_related_videos_use_case
         ),
-        name="chat-search",
+        name="chat-scenes",
     ),
     path(
         "history/",

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -154,7 +154,11 @@ class ChatSearchView(DependencyResolverMixin, APIView):
     search_related_videos_use_case = None
 
     @extend_schema(
-        request=ChatSearchRequestSerializer,
+        parameters=[
+            OpenApiParameter("query_text", str, required=True),
+            OpenApiParameter("group_id", int, required=True),
+            OpenApiParameter("share_token", str, required=False),
+        ],
         responses={200: ChatSearchResponseSerializer},
         summary="Search related scenes",
         description=(
@@ -162,11 +166,11 @@ class ChatSearchView(DependencyResolverMixin, APIView):
             "No LLM answer generation is performed."
         ),
     )
-    def post(self, request):
+    def get(self, request):
         share_token = request.query_params.get("share_token")
         is_shared = share_token is not None
 
-        serializer = ChatSearchRequestSerializer(data=request.data)
+        serializer = ChatSearchRequestSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
 
         use_case = self.resolve_dependency(self.search_related_videos_use_case)

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -586,6 +586,32 @@ describe('ApiClient', () => {
       expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/feedback/', expect.objectContaining({ method: 'POST' }));
     });
 
+    it('searchScenes calls GET /chat/scenes/ with query params', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify({ query_text: 'test', related_videos: [] }))
+      });
+      await apiClient.searchScenes('test', 1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:8000/api/chat/scenes/?query_text=test&group_id=1',
+        expect.not.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('searchScenes with share_token appends share_token param', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify({ query_text: 'test', related_videos: [] }))
+      });
+      await apiClient.searchScenes('test', 1, 'mytoken');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:8000/api/chat/scenes/?query_text=test&group_id=1&share_token=mytoken',
+        expect.anything()
+      );
+    });
+
     it('getChatHistory calls correct endpoint', async () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -878,6 +878,12 @@ class ApiClient {
     });
   }
 
+  async searchScenes(queryText: string, groupId: number, shareToken?: string): Promise<{ query_text: string; related_videos?: RelatedVideo[] }> {
+    const params = new URLSearchParams({ query_text: queryText, group_id: String(groupId) });
+    if (shareToken) params.set('share_token', shareToken);
+    return this.request(`/chat/scenes/?${params.toString()}`);
+  }
+
   async getPopularScenes(groupId: number, shareToken?: string, limit?: number): Promise<PopularScene[]> {
     const params = new URLSearchParams({ group_id: String(groupId) });
     if (shareToken) {


### PR DESCRIPTION
## 概要

fixes #468

`POST /chat/search/` のURLに動詞 `search` が含まれておりRESTfulでなかったため、リソース指向の `GET /chat/scenes/` に変更する。

## 変更内容

### バックエンド

- **URL**: `POST /chat/search/` → `GET /chat/scenes/`
- **パラメータ渡し方**: リクエストボディ → クエリパラメータ（`?query_text=...&group_id=...`）
- **URL名**: `chat-search` → `chat-scenes`
- **OpenAPI スキーマ**: `request` → `parameters` に更新

### フロントエンド

- `ApiClient` に `searchScenes(queryText, groupId, shareToken?)` メソッドを追加

## テスト

- `ChatSearchViewTests` → `ChatScenesViewTests` にリネームし、GETクエリパラメータ形式に更新
- `api.test.ts` に `searchScenes` の2テストケースを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)