### PR TITLE
refactor: PUT エンドポイントを partial=False の全体更新として正しく実装する

### DIFF
--- a/backend/app/presentation/video/serializers.py
+++ b/backend/app/presentation/video/serializers.py
@@ -333,6 +333,27 @@ class TagUpdateSerializer(serializers.Serializer):
     color = serializers.CharField(required=False)
 
 
+class VideoFullUpdateSerializer(serializers.Serializer):
+    """Serializer for full video update (PUT). title is required."""
+
+    title = serializers.CharField(max_length=255)
+    description = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class VideoGroupFullUpdateSerializer(serializers.Serializer):
+    """Serializer for full video group update (PUT). name is required."""
+
+    name = serializers.CharField(max_length=255)
+    description = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class TagFullUpdateSerializer(serializers.Serializer):
+    """Serializer for full tag update (PUT). name and color are required."""
+
+    name = serializers.CharField(max_length=50, trim_whitespace=False)
+    color = serializers.CharField()
+
+
 class AddTagsToVideoRequestSerializer(serializers.Serializer):
     tag_ids = serializers.ListField(
         child=serializers.IntegerField(),

--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -584,6 +584,154 @@ class TagViewTests(APITestCase):
         )
 
 
+class VideoPutViewTests(APITestCase):
+    """Tests for VideoDetailView PUT (full update)"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Original Title",
+            description="Original Description",
+            status="completed",
+        )
+
+    def test_put_video_requires_title(self):
+        """PUT without title should return 400 (full update requires all fields)"""
+        url = reverse("video-detail", kwargs={"pk": self.video.pk})
+        response = self.client.put(url, {"description": "New Desc"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_put_video_updates_all_fields(self):
+        """PUT with all required fields should return 200 and update the video"""
+        url = reverse("video-detail", kwargs={"pk": self.video.pk})
+        response = self.client.put(
+            url,
+            {"title": "New Title", "description": "New Desc"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["title"], "New Title")
+        self.assertEqual(response.data["description"], "New Desc")
+        self.video.refresh_from_db()
+        self.assertEqual(self.video.title, "New Title")
+        self.assertEqual(self.video.description, "New Desc")
+
+    def test_put_video_is_not_partial(self):
+        """PUT should not behave the same as PATCH (partial update)"""
+        url = reverse("video-detail", kwargs={"pk": self.video.pk})
+        # PATCH accepts partial data; PUT must reject missing required fields
+        patch_response = self.client.patch(url, {"description": "Patched"}, format="json")
+        put_response = self.client.put(url, {"description": "Put Only"}, format="json")
+        self.assertEqual(patch_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(put_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class VideoGroupPutViewTests(APITestCase):
+    """Tests for VideoGroupDetailView PUT (full update)"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="group@example.com",
+            password="testpass123",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="Original Name",
+            description="Original Description",
+        )
+
+    def test_put_group_requires_name(self):
+        """PUT without name should return 400 (full update requires all fields)"""
+        url = reverse("video-group-detail", kwargs={"pk": self.group.pk})
+        response = self.client.put(url, {"description": "New Desc"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_put_group_updates_all_fields(self):
+        """PUT with all required fields should return 200 and update the group"""
+        url = reverse("video-group-detail", kwargs={"pk": self.group.pk})
+        response = self.client.put(
+            url,
+            {"name": "New Name", "description": "New Desc"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "New Name")
+        self.assertEqual(response.data["description"], "New Desc")
+        self.group.refresh_from_db()
+        self.assertEqual(self.group.name, "New Name")
+        self.assertEqual(self.group.description, "New Desc")
+
+    def test_put_group_is_not_partial(self):
+        """PUT should not behave the same as PATCH (partial update)"""
+        url = reverse("video-group-detail", kwargs={"pk": self.group.pk})
+        patch_response = self.client.patch(url, {"description": "Patched"}, format="json")
+        put_response = self.client.put(url, {"description": "Put Only"}, format="json")
+        self.assertEqual(patch_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(put_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TagPutViewTests(APITestCase):
+    """Tests for TagDetailView PUT (full update)"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="tag@example.com",
+            password="testpass123",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.tag = Tag.objects.create(
+            user=self.user,
+            name="Original Tag",
+            color="#111111",
+        )
+
+    def test_put_tag_requires_name(self):
+        """PUT without name should return 400"""
+        url = reverse("tag-detail", kwargs={"pk": self.tag.pk})
+        response = self.client.put(url, {"color": "#222222"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_put_tag_requires_color(self):
+        """PUT without color should return 400"""
+        url = reverse("tag-detail", kwargs={"pk": self.tag.pk})
+        response = self.client.put(url, {"name": "New Tag"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_put_tag_updates_all_fields(self):
+        """PUT with all required fields should return 200 and update the tag"""
+        url = reverse("tag-detail", kwargs={"pk": self.tag.pk})
+        response = self.client.put(
+            url,
+            {"name": "New Tag", "color": "#222222"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "New Tag")
+        self.tag.refresh_from_db()
+        self.assertEqual(self.tag.name, "New Tag")
+        self.assertEqual(self.tag.color, "#222222")
+
+    def test_put_tag_is_not_partial(self):
+        """PUT should not behave the same as PATCH (partial update)"""
+        url = reverse("tag-detail", kwargs={"pk": self.tag.pk})
+        patch_response = self.client.patch(url, {"name": "Patched"}, format="json")
+        put_response = self.client.put(url, {"name": "Put Only"}, format="json")
+        self.assertEqual(patch_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(put_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
 class ShareLinkTests(APITestCase):
     """Tests for share link functionality"""
 

--- a/backend/app/presentation/video/views.py
+++ b/backend/app/presentation/video/views.py
@@ -43,12 +43,15 @@ from .serializers import (
     ShareLinkResponseSerializer,
     TagCreateSerializer,
     TagDetailSerializer,
+    TagFullUpdateSerializer,
     TagListSerializer,
     TagUpdateSerializer,
     VideoActionMessageResponseSerializer,
     VideoCreateSerializer,
+    VideoFullUpdateSerializer,
     VideoGroupCreateSerializer,
     VideoGroupDetailSerializer,
+    VideoGroupFullUpdateSerializer,
     VideoGroupListSerializer,
     VideoGroupUpdateSerializer,
     VideoListSerializer,
@@ -202,8 +205,33 @@ class VideoDetailView(DependencyResolverMixin, AuthenticatedViewMixin, APIView):
         ctx = {"request": request}
         return Response(VideoSerializer(updated, context=ctx).data)
 
+    @extend_schema(
+        request=VideoFullUpdateSerializer,
+        responses={200: VideoSerializer},
+        summary="Full update video",
+        description="Replace all video fields. title is required.",
+    )
     def put(self, request, pk):
-        return self.patch(request, pk)
+        video = self._get_video(pk, request.user.id)
+        if video is None:
+            return create_error_response("Video not found", status.HTTP_404_NOT_FOUND)
+
+        serializer = VideoFullUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        use_case = self.resolve_dependency(self.update_video_use_case)
+        try:
+            data = serializer.validated_data
+            input_dto = UpdateVideoInput(
+                title=data["title"],
+                description=data.get("description", ""),
+            )
+            updated = use_case.execute(pk, request.user.id, input_dto)
+        except ResourceNotFound:
+            return create_error_response("Video not found", status.HTTP_404_NOT_FOUND)
+
+        ctx = {"request": request}
+        return Response(VideoSerializer(updated, context=ctx).data)
 
     def delete(self, request, pk):
         use_case = self.resolve_dependency(self.delete_video_use_case)
@@ -303,8 +331,29 @@ class VideoGroupDetailView(DependencyResolverMixin, AuthenticatedViewMixin, APIV
         ctx = {"request": request}
         return Response(VideoGroupDetailSerializer(group, context=ctx).data)
 
+    @extend_schema(
+        request=VideoGroupFullUpdateSerializer,
+        responses={200: VideoGroupDetailSerializer},
+        summary="Full update video group",
+        description="Replace all video group fields. name is required.",
+    )
     def put(self, request, pk):
-        return self.patch(request, pk)
+        serializer = VideoGroupFullUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        use_case = self.resolve_dependency(self.update_group_use_case)
+        try:
+            data = serializer.validated_data
+            input_dto = UpdateGroupInput(
+                name=data["name"],
+                description=data.get("description", ""),
+            )
+            group = use_case.execute(pk, request.user.id, input_dto)
+        except ResourceNotFound:
+            return create_error_response("Group not found", status.HTTP_404_NOT_FOUND)
+
+        ctx = {"request": request}
+        return Response(VideoGroupDetailSerializer(group, context=ctx).data)
 
     def delete(self, request, pk):
         use_case = self.resolve_dependency(self.delete_group_use_case)
@@ -609,8 +658,31 @@ class TagDetailView(DependencyResolverMixin, AuthenticatedViewMixin, APIView):
         ctx = {"request": request}
         return Response(TagDetailSerializer(tag, context=ctx).data)
 
+    @extend_schema(
+        request=TagFullUpdateSerializer,
+        responses={200: TagDetailSerializer},
+        summary="Full update tag",
+        description="Replace all tag fields. name and color are required.",
+    )
     def put(self, request, pk):
-        return self.patch(request, pk)
+        serializer = TagFullUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        use_case = self.resolve_dependency(self.update_tag_use_case)
+        try:
+            data = serializer.validated_data
+            input_dto = UpdateTagInput(
+                name=data["name"],
+                color=data["color"],
+            )
+            tag = use_case.execute(pk, request.user.id, input_dto)
+        except InvalidTagInput as e:
+            return create_error_response(str(e), status.HTTP_400_BAD_REQUEST)
+        except ResourceNotFound:
+            return create_error_response("Tag not found", status.HTTP_404_NOT_FOUND)
+
+        ctx = {"request": request}
+        return Response(TagDetailSerializer(tag, context=ctx).data)
 
     def delete(self, request, pk):
         use_case = self.resolve_dependency(self.delete_tag_use_case)


### PR DESCRIPTION
## 関連Issue
closes #471

## 概要
`/videos/<pk>/`、`/groups/<pk>/`、`/tags/<pk>/` の `PUT` が `self.patch()` に丸投げしており、実質 `PATCH`（部分更新）と同じ動作になっていた問題を修正。

## 変更内容

### `serializers.py`
PUT 専用シリアライザを追加。必須フィールドに `required=False` を付けず、欠損時は 400 を返すよう定義。

| シリアライザ | 必須フィールド |
|---|---|
| `VideoFullUpdateSerializer` | `title` |
| `VideoGroupFullUpdateSerializer` | `name` |
| `TagFullUpdateSerializer` | `name`, `color` |

### `views.py`
3 つのビューで `put()` を独立実装。

- `VideoDetailView.put` — `VideoFullUpdateSerializer(partial=False)` で検証
- `VideoGroupDetailView.put` — `VideoGroupFullUpdateSerializer(partial=False)` で検証
- `TagDetailView.put` — `TagFullUpdateSerializer(partial=False)` で検証

## テスト計画 (TDD)
- [x] 失敗テスト先行追加 (RED) — PUT に必須フィールドなし → 400 を期待
- [x] 実装後に全テストが GREEN になることを確認
- [x] 既存の PATCH テストが壊れていないことを確認（59 テスト全 OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)