### PR TITLE
refactor: POST /chat/ をリソース指向の POST /chat/messages/ に変更する

### DIFF
--- a/backend/app/presentation/chat/tests/test_views.py
+++ b/backend/app/presentation/chat/tests/test_views.py
@@ -64,7 +64,7 @@ class ChatViewTests(APITestCase):
             ],
         )
 
-        url = reverse("chat")
+        url = reverse("chat-messages")
         data = {
             "messages": [{"role": "user", "content": "Test question"}],
             "group_id": self.group.id,
@@ -87,7 +87,7 @@ class ChatViewTests(APITestCase):
             related_videos=None,
         )
 
-        url = reverse("chat")
+        url = reverse("chat-messages")
         data = {"messages": [{"role": "user", "content": "Test question"}]}
 
         response = self.client.post(url, data, format="json")
@@ -99,7 +99,7 @@ class ChatViewTests(APITestCase):
 
     def test_chat_empty_messages(self):
         """Test chat with empty messages"""
-        url = reverse("chat")
+        url = reverse("chat-messages")
         data = {"messages": []}
 
         response = self.client.post(url, data, format="json")
@@ -109,7 +109,7 @@ class ChatViewTests(APITestCase):
 
     def test_chat_missing_messages(self):
         """Test chat with missing messages"""
-        url = reverse("chat")
+        url = reverse("chat-messages")
         data = {}
 
         response = self.client.post(url, data, format="json")
@@ -119,7 +119,7 @@ class ChatViewTests(APITestCase):
     @patch("app.infrastructure.external.rag_gateway.RagChatGateway.generate_reply")
     def test_chat_group_not_found(self, mock_generate_reply):
         """Test chat with non-existent group"""
-        url = reverse("chat")
+        url = reverse("chat-messages")
         data = {
             "messages": [{"role": "user", "content": "Test question"}],
             "group_id": 99999,
@@ -136,7 +136,7 @@ class ChatViewTests(APITestCase):
             "OpenAI API key is not configured"
         )
 
-        url = reverse("chat")
+        url = reverse("chat-messages")
         data = {
             "messages": [{"role": "user", "content": "Test question"}],
             "group_id": self.group.id,
@@ -151,7 +151,7 @@ class ChatViewTests(APITestCase):
         """500 responses must not expose internal provider error details."""
         mock_generate_reply.side_effect = LLMProviderError("provider stack trace detail")
 
-        url = reverse("chat")
+        url = reverse("chat-messages")
         data = {
             "messages": [{"role": "user", "content": "Test question"}],
             "group_id": self.group.id,
@@ -181,7 +181,7 @@ class ChatViewTests(APITestCase):
 
         # Don't force authenticate - use share token instead
         self.client.force_authenticate(user=None)
-        url = reverse("chat")
+        url = reverse("chat-messages")
         url += f"?share_token={self.group.share_token}"
         data = {
             "messages": [{"role": "user", "content": "Test question"}],
@@ -198,7 +198,7 @@ class ChatViewTests(APITestCase):
 
     def test_chat_share_token_group_not_found(self):
         """Test chat with share token but group not found"""
-        url = reverse("chat")
+        url = reverse("chat-messages")
         url += "?share_token=invalid-token"
         data = {
             "messages": [{"role": "user", "content": "Test question"}],
@@ -211,7 +211,7 @@ class ChatViewTests(APITestCase):
 
     def test_chat_share_token_missing_group_id(self):
         """Test chat with share token but missing group_id"""
-        url = reverse("chat")
+        url = reverse("chat-messages")
         url += f"?share_token={self.group.share_token}"
         data = {"messages": [{"role": "user", "content": "Test question"}]}
 
@@ -235,7 +235,7 @@ class ChatViewTests(APITestCase):
             ],
         )
 
-        url = reverse("chat")
+        url = reverse("chat-messages")
         data = {
             "messages": [{"role": "user", "content": "q"}],
             "group_id": self.group.id,

--- a/backend/app/presentation/chat/urls.py
+++ b/backend/app/presentation/chat/urls.py
@@ -13,9 +13,9 @@ from .views import (
 
 urlpatterns = [
     path(
-        "",
+        "messages/",
         ChatView.as_view(send_message_use_case=chat_dependencies.get_send_message_use_case),
-        name="chat",
+        name="chat-messages",
     ),
     path(
         "scenes/",

--- a/backend/app/presentation/common/tests/test_throttles.py
+++ b/backend/app/presentation/common/tests/test_throttles.py
@@ -51,7 +51,7 @@ class ShareTokenIPThrottleTest(APITestCase):
             name="test group",
             share_token=secrets.token_urlsafe(32),
         )
-        self.url = f"/api/chat/?share_token={self.group.share_token}"
+        self.url = f"/api/chat/messages/?share_token={self.group.share_token}"
         self.payload = {
             "messages": [{"role": "user", "content": "hi"}],
             "group_id": self.group.id,
@@ -87,7 +87,7 @@ class ShareTokenGlobalThrottleTest(APITestCase):
             name="test group",
             share_token=secrets.token_urlsafe(32),
         )
-        self.url = f"/api/chat/?share_token={self.group.share_token}"
+        self.url = f"/api/chat/messages/?share_token={self.group.share_token}"
         self.payload = {
             "messages": [{"role": "user", "content": "hi"}],
             "group_id": self.group.id,
@@ -127,7 +127,7 @@ class AuthenticatedChatThrottleTest(APITestCase):
             username="chatuser", email="chat@example.com", password="pass1234"
         )
         self.client.force_authenticate(user=self.user)
-        self.url = "/api/chat/"
+        self.url = "/api/chat/messages/"
 
     def test_blocks_authenticated_user_after_limit(self):
         """Authenticated user is throttled after 2 requests/min."""

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -563,7 +563,7 @@ describe('ApiClient', () => {
         text: () => Promise.resolve(JSON.stringify({ role: 'assistant', content: 'hello' }))
       });
       await apiClient.chat({ messages: [] });
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/', expect.objectContaining({ method: 'POST' }));
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/messages/', expect.objectContaining({ method: 'POST' }));
     });
 
     it('chat with share token calls correct endpoint', async () => {
@@ -573,7 +573,7 @@ describe('ApiClient', () => {
         text: () => Promise.resolve(JSON.stringify({ role: 'assistant', content: 'hello' }))
       });
       await apiClient.chat({ messages: [], share_token: 'abc' });
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/?share_token=abc', expect.objectContaining({ method: 'POST' }));
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/messages/?share_token=abc', expect.objectContaining({ method: 'POST' }));
     });
 
     it('setChatFeedback calls correct endpoint', async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -551,7 +551,7 @@ class ApiClient {
 
   async chat(data: ChatRequest): Promise<ChatMessage> {
     const { share_token, ...bodyData } = data;
-    const endpoint = share_token ? `/chat/?share_token=${share_token}` : '/chat/';
+    const endpoint = share_token ? `/chat/messages/?share_token=${share_token}` : '/chat/messages/';
 
     return this.request<ChatMessage>(endpoint, {
       method: 'POST',


### PR DESCRIPTION
## Summary

- `POST /chat/` を `POST /chat/messages/` にリネームし、チャット関連エンドポイント全体でリソース指向URLを統一
- バックエンド: `urls.py` のパスと URL name を `messages/` / `chat-messages` に変更
- フロントエンド: `api.ts` の呼び出し先を `/chat/messages/` に変更

## Test plan

- [x] バックエンド: `ChatViewTests` 全11件パス（docker compose exec で確認）
- [x] フロントエンド: `ChatPanel.test.tsx` 全22件パス（ローカルで確認）

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)