### PR TITLE
refactor: タグ管理モーダルの削除確認から「確認」テキストを削除する

### DIFF
--- a/frontend/src/components/video/TagManagementModal.tsx
+++ b/frontend/src/components/video/TagManagementModal.tsx
@@ -61,9 +61,6 @@ export function TagManagementModal({ isOpen, onClose }: TagManagementModalProps)
 
                                     {deleteConfirmId === tag.id ? (
                                         <div className="flex items-center gap-2">
-                                            <span className="text-xs text-red-500 font-medium">
-                                                {t('common.actions.confirm', 'Confirm?')}
-                                            </span>
                                             <Button
                                                 variant="destructive"
                                                 size="sm"

--- a/frontend/src/components/video/__tests__/TagManagementModal.test.tsx
+++ b/frontend/src/components/video/__tests__/TagManagementModal.test.tsx
@@ -70,7 +70,7 @@ describe('TagManagementModal', () => {
         const deleteButton = screen.getByTestId('delete-tag-1')
         fireEvent.click(deleteButton)
 
-        expect(screen.getByText('Confirm?')).toBeInTheDocument()
+        expect(screen.queryByText('Confirm?')).not.toBeInTheDocument()
         expect(screen.getByTestId('confirm-delete-1')).toBeInTheDocument()
         expect(screen.getByTestId('cancel-delete-1')).toBeInTheDocument()
     })


### PR DESCRIPTION
## Summary

- タグ管理モーダルの削除確認UI から冗長な `確認` (`Confirm?`) テキストを削除
- 削除ボタンとキャンセルボタンのみで操作意図は十分に伝わるため

## Changes

- `TagManagementModal.tsx`: 削除確認状態で表示していた `<span className="text-xs text-red-500 font-medium">` 要素を削除
- `TagManagementModal.test.tsx`: 削除確認時に `Confirm?` テキストが表示されないことを検証するようテストを更新

## Test plan

- [x] `should show delete confirmation when trash icon is clicked` — `Confirm?` テキストが表示されず、削除・キャンセルボタンのみ表示されることを確認
- [x] 既存の全テスト（6件）が通過することを確認

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)