### PR TITLE
fix: refreshToken の無限ループバグを修正する

### DIFF
--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -180,12 +180,23 @@ describe('ApiClient', () => {
       expect(result).toEqual(mockResponse);
       expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/tokens/', expect.objectContaining({
         method: 'PUT',
-        body: undefined,
         credentials: 'include',
         headers: expect.objectContaining({
           'X-CSRFToken': 'test-csrf-token',
         }),
       }));
+    });
+
+    it('refreshToken should throw immediately when refresh endpoint returns 401 without retrying', async () => {
+      document.cookie = 'csrftoken=test-csrf-token';
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+      });
+
+      await expect(apiClient.refreshToken()).rejects.toThrow();
+      // Must be called exactly once - no retry/recursion
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('getMe should return user info', async () => {
@@ -314,6 +325,29 @@ describe('ApiClient', () => {
       fetchMock.mockResolvedValueOnce({ ok: true });
 
       await expect(apiClient.getMe()).rejects.toThrow('Authentication failed');
+      expect(window.location.href).toBe('/login');
+    });
+
+    it('should not cause infinite loop when refreshToken gets 401 (original request → refresh 401 → auth error)', async () => {
+      // Original API call returns 401
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+      });
+
+      // Refresh token endpoint also returns 401 (expired/invalid session)
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+      });
+
+      // Mock logout call
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await expect(apiClient.getMe()).rejects.toThrow('Authentication failed');
+      // Should be called exactly 3 times: original request + refresh attempt + logout
+      // (NOT infinite calls)
+      expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(window.location.href).toBe('/login');
     });
   });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -512,11 +512,27 @@ class ApiClient {
     // No need to manage refresh tokens on frontend
     // Call backend refresh endpoint as needed
 
-    const response = await this.request<RefreshResponse>('/auth/tokens/', {
+    // Use executeRequest() directly to bypass retry logic.
+    // If the refresh endpoint itself returns 401, throw immediately to prevent
+    // an infinite loop where handle401Error would call refreshToken() again.
+    const url = this.buildUrl('/auth/tokens/');
+    const headers = this.buildHeaders();
+    const csrfToken = await this.ensureCsrfToken();
+    if (csrfToken) {
+      headers['X-CSRFToken'] = csrfToken;
+    }
+
+    const response = await this.executeRequest(url, {
       method: 'PUT',
+      headers,
+      credentials: 'include',
     });
 
-    return response;
+    if (response.status === 401) {
+      throw new Error('Token refresh failed: unauthorized');
+    }
+
+    return await this.parseJsonResponse<RefreshResponse>(response);
   }
 
   async getMe(): Promise<User> {


### PR DESCRIPTION
## 概要

`refreshToken()` が `request()` 経由で呼ばれていたため、リフレッシュエンドポイント (`PUT /api/auth/tokens/`) が 401 を返すと無限ループが発生していたバグを修正した。

## 原因

```
request() → executeRequest() → 401
  → handle401Error() → refreshToken()
    → request() → executeRequest() → 401
      → handle401Error() → refreshToken() → ...（無限ループ）
```

`handle401Error` はリトライカウントが 0 の場合に `refreshToken()` を呼び出す。`refreshToken()` が `request()` 経由だと、リフレッシュ自体が 401 を返した際に再び `handle401Error` が走り、カウンタがリセットされたまま再帰する。

## 修正内容

- `refreshToken()` を `request()` ではなく `executeRequest()` 直接呼び出しに変更
- 401 が返った場合は即座に例外をスロー（リトライなし）
- CSRF トークンの付与・`credentials: 'include'` は引き続き維持

## テスト

- `refreshToken should throw immediately when refresh endpoint returns 401 without retrying`：401 時に fetch が 1 回だけ呼ばれることを検証
- `should not cause infinite loop when refreshToken gets 401`：元リクエスト 401 → リフレッシュ 401 のシナリオで fetch 呼び出しが 3 回（元リクエスト + リフレッシュ + ログアウト）で終わることを検証

## Test plan
- [x] `npx vitest run` で全 450 テストが通過することを確認
- [x] セッションが期限切れの状態でページ操作し、nginx ログに 401 が大量出力されないことを確認

closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)