### PR TITLE
fix: vector_store.pyのSQLクエリにホワイトリスト検証を追加しSQLインジェクションリスクを解消する

### DIFF
--- a/backend/app/infrastructure/external/tests/test_vector_store.py
+++ b/backend/app/infrastructure/external/tests/test_vector_store.py
@@ -9,6 +9,8 @@ from django.test import SimpleTestCase, override_settings
 
 from app.infrastructure.external.vector_store import (
     PGVectorManager,
+    _ALLOWED_TABLE_NAMES,
+    _get_safe_table_identifier,
     delete_all_vectors,
     delete_video_vectors,
     update_video_title_in_vectors,
@@ -140,6 +142,98 @@ class PGVectorManagerTests(SimpleTestCase):
             table_name=PGVectorManager.get_table_name(),
             metadata_columns=["user_id", "video_id"],
         )
+
+
+class SafeTableIdentifierTests(SimpleTestCase):
+    """Tests for _get_safe_table_identifier function (SQL injection prevention)"""
+
+    @override_settings(PGVECTOR_COLLECTION_NAME="videoq_scenes")
+    @patch("django.db.connection")
+    def test_allowed_table_name_returns_quoted_identifier(self, mock_connection):
+        mock_connection.ops.quote_name.return_value = '"videoq_scenes"'
+
+        result = _get_safe_table_identifier()
+
+        mock_connection.ops.quote_name.assert_called_once_with("videoq_scenes")
+        self.assertEqual(result, '"videoq_scenes"')
+
+    @override_settings(PGVECTOR_COLLECTION_NAME="malicious_table; DROP TABLE users; --")
+    def test_disallowed_table_name_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            _get_safe_table_identifier()
+
+    @override_settings(PGVECTOR_COLLECTION_NAME="unknown_table")
+    def test_unknown_table_name_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            _get_safe_table_identifier()
+
+    def test_allowed_table_names_is_frozenset(self):
+        self.assertIsInstance(_ALLOWED_TABLE_NAMES, frozenset)
+
+    def test_allowed_table_names_contains_default(self):
+        self.assertIn("videoq_scenes", _ALLOWED_TABLE_NAMES)
+
+    @override_settings(PGVECTOR_COLLECTION_NAME="videoq_scenes")
+    @patch("django.db.connection")
+    def test_update_video_title_uses_safe_table_identifier(self, mock_connection):
+        """Verify update_video_title_in_vectors does not use .format() with user input"""
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 1
+        mock_connection.cursor.return_value.__enter__ = MagicMock(
+            return_value=mock_cursor
+        )
+        mock_connection.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_connection.ops.quote_name.return_value = '"videoq_scenes"'
+
+        result = update_video_title_in_vectors(1, "Title")
+
+        self.assertEqual(result, 1)
+        # The table name must come from quote_name (validated path), not raw user input
+        mock_connection.ops.quote_name.assert_called_once_with("videoq_scenes")
+        call_args = mock_cursor.execute.call_args
+        sql = call_args[0][0]
+        # Parameterized args must be passed separately (not embedded in SQL)
+        params = call_args[0][1]
+        self.assertIn("Title", params)
+        self.assertNotIn("Title", sql)
+
+    @override_settings(PGVECTOR_COLLECTION_NAME="videoq_scenes")
+    @patch("django.db.connection")
+    def test_delete_all_vectors_uses_safe_table_identifier(self, mock_connection):
+        """Verify delete_all_vectors does not use .format() with unvalidated input"""
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 5
+        mock_connection.cursor.return_value.__enter__ = MagicMock(
+            return_value=mock_cursor
+        )
+        mock_connection.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_connection.ops.quote_name.return_value = '"videoq_scenes"'
+
+        result = delete_all_vectors()
+
+        self.assertEqual(result, 5)
+        # The table name must come through the validated quote_name path
+        mock_connection.ops.quote_name.assert_called_once_with("videoq_scenes")
+
+    @override_settings(PGVECTOR_COLLECTION_NAME="videoq_scenes")
+    @patch("app.infrastructure.external.vector_store.PGVectorManager.get_table_name")
+    @patch("django.db.connection")
+    def test_delete_all_vectors_calls_get_table_name_once(
+        self, mock_connection, mock_get_table_name
+    ):
+        """get_table_name() must be called exactly once to avoid redundant reads."""
+        mock_get_table_name.return_value = "videoq_scenes"
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 0
+        mock_connection.cursor.return_value.__enter__ = MagicMock(
+            return_value=mock_cursor
+        )
+        mock_connection.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_connection.ops.quote_name.return_value = '"videoq_scenes"'
+
+        delete_all_vectors()
+
+        mock_get_table_name.assert_called_once()
 
 
 class DeleteVideoVectorsTests(SimpleTestCase):

--- a/backend/app/infrastructure/external/vector_store.py
+++ b/backend/app/infrastructure/external/vector_store.py
@@ -12,6 +12,38 @@ from langchain_postgres import Column, PGEngine, PGVectorStore
 
 logger = logging.getLogger(__name__)
 
+# Static allowlist of permitted table names for raw SQL.
+# Prevents SQL injection even if PGVECTOR_COLLECTION_NAME is tampered with.
+_ALLOWED_TABLE_NAMES: frozenset[str] = frozenset({"videoq_scenes"})
+
+
+def _get_safe_table_identifier(table_name: str | None = None) -> str:
+    """
+    Return a safely-quoted table identifier for use in raw SQL.
+
+    Validates ``table_name`` (or the configured name when omitted) against
+    ``_ALLOWED_TABLE_NAMES`` before quoting, ensuring that neither env-var
+    tampering nor accidental user-input propagation can produce a malicious
+    table name.
+
+    Args:
+        table_name: Table name to validate. Defaults to
+            ``PGVectorManager.get_table_name()`` when ``None``.
+
+    Raises:
+        ValueError: If the table name is not in the allowlist.
+    """
+    from django.db import connection
+
+    if table_name is None:
+        table_name = PGVectorManager.get_table_name()
+    if table_name not in _ALLOWED_TABLE_NAMES:
+        raise ValueError(
+            f"Table name '{table_name}' is not in the allowed list. "
+            "Only statically-defined table names are permitted in raw SQL."
+        )
+    return connection.ops.quote_name(table_name)
+
 
 class PGVectorManager:
     """
@@ -132,7 +164,7 @@ def update_video_title_in_vectors(video_id: int, new_title: str) -> int:
     try:
         from django.db import connection
 
-        table = connection.ops.quote_name(PGVectorManager.get_table_name())
+        table = _get_safe_table_identifier()
 
         with connection.cursor() as cursor:
             cursor.execute(
@@ -144,7 +176,7 @@ def update_video_title_in_vectors(video_id: int, new_title: str) -> int:
                     to_jsonb(%s::text)
                 )
                 WHERE video_id = %s
-                """.format(table),
+                """.format(table),  # noqa: S608 – table is allowlist-validated above
                 [new_title, int(video_id)],
             )
             updated_count = cursor.rowcount
@@ -185,9 +217,9 @@ def delete_all_vectors() -> int:
         table_name = PGVectorManager.get_table_name()
         logger.info("Deleting all vectors from table: %s", table_name)
 
-        quoted_table = connection.ops.quote_name(table_name)
+        quoted_table = _get_safe_table_identifier(table_name)
         with connection.cursor() as cursor:
-            cursor.execute("DELETE FROM {}".format(quoted_table))
+            cursor.execute("DELETE FROM {}".format(quoted_table))  # noqa: S608 – table is allowlist-validated above
             deleted_count = cursor.rowcount
 
         if deleted_count > 0:


### PR DESCRIPTION
## 概要

`vector_store.py` の生SQLクエリでテーブル名に `.format()` を使用しており、将来的なSQLインジェクション脆弱性の温床になりうる問題を修正する。

## 変更内容

- `_ALLOWED_TABLE_NAMES`（`frozenset`）でテーブル名の静的ホワイトリストを定義
- `_get_safe_table_identifier()` を追加し、ホワイトリスト検証 → `quote_name()` エスケープの順で安全なテーブル識別子を返す
- `update_video_title_in_vectors` / `delete_all_vectors` で同関数を使用するよう変更
- 各呼び出し箇所に `# noqa: S608` コメントで安全性の根拠を明記

## リスク対応

| リスク | 対応 |
|---|---|
| `quote_name()` のDjango内部依存 | ホワイトリストが追加の防御層として機能 |
| `.format()` と `%s` の混在による見落とし | `_get_safe_table_identifier()` に集約し意図を明文化 |
| テーブル名へのユーザー入力混入 | ホワイトリスト外は `ValueError` で拒絶 |

## テスト

`SafeTableIdentifierTests` クラスを追加（7テスト）:

- [x] 許可テーブル名 → `quote_name()` 経由で返ること
- [x] SQLインジェクション文字列 → `ValueError`
- [x] 未知のテーブル名 → `ValueError`
- [x] `_ALLOWED_TABLE_NAMES` が `frozenset` であること
- [x] デフォルト値 `videoq_scenes` が含まれること
- [x] `update_video_title_in_vectors` でユーザー入力がSQL文字列に混入しないこと
- [x] `delete_all_vectors` で `get_table_name()` が1回だけ呼ばれること

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)