### PR TITLE
fix: get_shared_groupエンドポイント（AllowAny）にShareTokenIPThrottleを適用する

### DIFF
--- a/backend/app/presentation/common/tests/test_throttles.py
+++ b/backend/app/presentation/common/tests/test_throttles.py
@@ -37,6 +37,38 @@ _TEST_THROTTLE_RATES = {
 
 @override_settings(CACHES=_TEST_CACHES, ENABLE_SIGNUP=True)
 @patch.dict(SimpleRateThrottle.THROTTLE_RATES, _TEST_THROTTLE_RATES)
+class GetSharedGroupThrottleTest(APITestCase):
+    """Tests for ShareTokenIPThrottle applied to get_shared_group (path-param share_token)."""
+
+    def setUp(self):
+        cache.clear()
+        self.user = User.objects.create_user(
+            username="groupowner", email="groupowner@example.com", password="pass1234"
+        )
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="shared group",
+            share_token=secrets.token_urlsafe(32),
+        )
+        self.url = f"/api/videos/groups/share/{self.group.share_token}/"
+
+    def test_allows_requests_within_limit(self):
+        """Requests within the rate limit should succeed (not 429)."""
+        for _ in range(2):
+            resp = self.client.get(self.url)
+            self.assertNotEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_blocks_after_limit(self):
+        """Third request from same IP should be throttled."""
+        for _ in range(2):
+            self.client.get(self.url)
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(resp.json()["error"]["code"], "LIMIT_EXCEEDED")
+
+
+@override_settings(CACHES=_TEST_CACHES, ENABLE_SIGNUP=True)
+@patch.dict(SimpleRateThrottle.THROTTLE_RATES, _TEST_THROTTLE_RATES)
 class ShareTokenIPThrottleTest(APITestCase):
     """Tests for ShareTokenIPThrottle (per-IP limit on share_token chat)."""
 

--- a/backend/app/presentation/common/throttles.py
+++ b/backend/app/presentation/common/throttles.py
@@ -22,7 +22,9 @@ class ShareTokenIPThrottle(SimpleRateThrottle):
     scope = "chat_share_token_ip"
 
     def get_cache_key(self, request, view):
-        share_token = request.query_params.get("share_token")
+        share_token = request.query_params.get("share_token") or (
+            view.kwargs.get("share_token") if hasattr(view, "kwargs") else None
+        )
         if not share_token:
             return None
         return self.cache_format % {

--- a/backend/app/presentation/video/views.py
+++ b/backend/app/presentation/video/views.py
@@ -7,12 +7,13 @@ import logging
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import generics, status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from app.presentation.common.responses import create_error_response
+from app.presentation.common.throttles import ShareTokenIPThrottle
 from app.use_cases.video.dto import (
     CreateGroupInput,
     CreateTagInput,
@@ -551,6 +552,7 @@ class CreateShareLinkView(DependencyResolverMixin, AuthenticatedViewMixin, APIVi
 )
 @api_view(["GET"])
 @permission_classes([AllowAny])
+@throttle_classes([ShareTokenIPThrottle])
 def get_shared_group(
     request,
     share_token,


### PR DESCRIPTION
## 概要

- `get_shared_group` エンドポイント（`AllowAny`）にスロットリングが未適用で、share_token のブルートフォース攻撃や DoS 攻撃のリスクがあった
- `ShareTokenIPThrottle` を適用し、他の共有エンドポイント（チャット等）と一貫したレート制限を実装した

## 変更内容

- **`video/views.py`**: `get_shared_group` に `@throttle_classes([ShareTokenIPThrottle])` を追加
- **`throttles.py`**: `ShareTokenIPThrottle.get_cache_key` をURLパス引数（`view.kwargs`）にも対応させた（既存実装はクエリパラメータのみ参照していたため、パス引数を使う本エンドポイントではスロットリングが無効になる問題があった）
- **`test_throttles.py`**: `GetSharedGroupThrottleTest` を追加（TDD）

## テスト計画

- [x] `test_allows_requests_within_limit`: 制限内のリクエストが 429 にならないことを確認
- [x] `test_blocks_after_limit`: 3回目のリクエストが 429（LIMIT_EXCEEDED）になることを確認
- [x] 既存の throttle・video view テスト 75件すべてパス

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)