### PR TITLE
fix: APIキーのフォーマット検証を追加しタイミング攻撃リスクを解消する

### DIFF
--- a/backend/app/presentation/common/authentication.py
+++ b/backend/app/presentation/common/authentication.py
@@ -43,6 +43,9 @@ class APIKeyAuthentication(BaseAuthentication):
         if raw_key is None:
             return None
 
+        if not raw_key.startswith("vq_") or len(raw_key) < 12:
+            return None
+
         resolved = self.resolve_api_key_use_case_factory().execute(raw_key)
         if resolved is None:
             raise AuthenticationFailed(_("Invalid API key"))

--- a/backend/app/presentation/common/tests/test_authentication.py
+++ b/backend/app/presentation/common/tests/test_authentication.py
@@ -164,11 +164,27 @@ class APIKeyAuthenticationTests(APITestCase):
         self.assertEqual(auth_data["api_key_id"], self.api_key.pk)
 
     def test_authenticate_with_invalid_api_key(self):
-        """Test authentication failure with invalid API key."""
-        request = self.factory.get("/", HTTP_X_API_KEY="vq_invalid")
+        """Test authentication failure with valid-format key that does not exist in DB."""
+        request = self.factory.get("/", HTTP_X_API_KEY="vq_" + "x" * 32)
 
         with self.assertRaises(AuthenticationFailed):
             self.auth.authenticate(request)
+
+    def test_authenticate_returns_none_for_key_without_vq_prefix(self):
+        """Keys without vq_ prefix should return None without hitting the DB."""
+        request = self.factory.get("/", HTTP_X_API_KEY="sk_invalidkeyformat1234")
+
+        result = self.auth.authenticate(request)
+
+        self.assertIsNone(result)
+
+    def test_authenticate_returns_none_for_key_shorter_than_minimum(self):
+        """Keys shorter than 12 characters should return None without hitting the DB."""
+        request = self.factory.get("/", HTTP_X_API_KEY="vq_short")
+
+        result = self.auth.authenticate(request)
+
+        self.assertIsNone(result)
 
     def test_read_only_api_key_authenticates_without_scope_check(self):
         """Authentication layer should not apply read-only authorization rules."""


### PR DESCRIPTION
## 概要

closes #482

`ApiKeyAuthentication.authenticate()` にDB照合前のフォーマット検証を追加し、不正なAPIキーに対するタイミング攻撃リスクを解消する。

## 変更内容

- `vq_` プレフィックスチェックと最小長（12文字）チェックをDB照合前に追加
- フォーマット不正時は `AuthenticationFailed` ではなく `None` を返し、他の認証バックエンドへフォールスルーさせる

## テスト

- `test_authenticate_returns_none_for_key_without_vq_prefix` — `vq_` プレフィックスなし → `None`
- `test_authenticate_returns_none_for_key_shorter_than_minimum` — 12文字未満 → `None`
- `test_authenticate_with_invalid_api_key` — 有効フォーマットだがDB未登録 → `AuthenticationFailed`

## Test plan

- [x] `docker compose exec backend python manage.py test app.presentation.common.tests.test_authentication.APIKeyAuthenticationTests` が全パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)