### PR TITLE
fix: restore developer docs navigation

### DIFF
--- a/frontend/src/components/common/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner.tsx
@@ -5,9 +5,23 @@ interface LoadingSpinnerProps {
 export function LoadingSpinner({ message }: LoadingSpinnerProps) {
   return (
     <div className="flex justify-center items-center py-8">
-      <div className="text-center">
-        <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600"></div>
-        {message && <p className="text-gray-600 text-sm">{message}</p>}
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex flex-col items-center rounded-2xl border border-[#d9e6db] bg-white/80 px-6 py-5 shadow-[0_12px_32px_-8px_rgba(25,28,25,0.10)]"
+      >
+        <div className="relative mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-[#f2f4ef]">
+          <div className="absolute inset-1 rounded-full border border-[#dfe6df]" />
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-[#becabc] border-t-[#00652c]" />
+          <div className="absolute h-2 w-2 rounded-full bg-[#00652c]" />
+        </div>
+        {message ? (
+          <p className="text-sm font-medium text-[#3f493f]">{message}</p>
+        ) : (
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#6f7a6e]">
+            Loading
+          </p>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/common/__tests__/LoadingSpinner.test.tsx
+++ b/frontend/src/components/common/__tests__/LoadingSpinner.test.tsx
@@ -5,6 +5,7 @@ describe('LoadingSpinner', () => {
   it('should render spinner', () => {
     const { container } = render(<LoadingSpinner />)
 
+    expect(screen.getByRole('status')).toBeInTheDocument()
     const spinner = container.querySelector('.animate-spin')
     expect(spinner).toBeInTheDocument()
   })
@@ -16,9 +17,8 @@ describe('LoadingSpinner', () => {
   })
 
   it('should not display message when not provided', () => {
-    const { container } = render(<LoadingSpinner />)
+    render(<LoadingSpinner />)
 
-    const message = container.querySelector('p')
-    expect(message).not.toBeInTheDocument()
+    expect(screen.getByText('Loading')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/common/__tests__/LoadingState.test.tsx
+++ b/frontend/src/components/common/__tests__/LoadingState.test.tsx
@@ -10,6 +10,7 @@ describe('LoadingState', () => {
     )
 
     // Check for spinner element
+    expect(screen.getByRole('status')).toBeInTheDocument()
     const spinner = container.querySelector('.animate-spin')
     expect(spinner).toBeInTheDocument()
     expect(screen.queryByText('Content')).not.toBeInTheDocument()

--- a/frontend/src/components/layout/AppNav.tsx
+++ b/frontend/src/components/layout/AppNav.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api';
 import { APP_CONTAINER_CLASS } from '@/components/layout/layoutTokens';
 
-export type ActivePage = 'home' | 'videos' | 'groups' | 'settings';
+export type ActivePage = 'home' | 'videos' | 'groups' | 'docs' | 'settings';
 
 interface AppNavProps {
   activePage?: ActivePage;
@@ -37,6 +37,7 @@ export function AppNav({ activePage }: AppNavProps) {
     { href: '/', label: t('navigation.home'), key: 'home' },
     { href: '/videos', label: t('navigation.videosNav'), key: 'videos' },
     { href: '/videos/groups', label: t('navigation.groupsNav'), key: 'groups' },
+    { href: '/docs', label: t('navigation.docs'), key: 'docs' },
     { href: '/settings', label: t('navigation.settings'), key: 'settings' },
   ];
 

--- a/frontend/src/pages/DeveloperDocsPage.tsx
+++ b/frontend/src/pages/DeveloperDocsPage.tsx
@@ -29,12 +29,6 @@ export default function DeveloperDocsPage() {
       <AppPageHeader
         title={t('docs.home.title')}
         description={t('docs.home.subtitle')}
-        action={(
-          <div className="flex items-center gap-2 rounded-2xl border border-[#00652c]/15 bg-[#eff8f1] px-4 py-3 text-sm font-semibold text-[#00652c] shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
-            <FileCode2 className="w-4 h-4" />
-            API integration reference
-          </div>
-        )}
       />
 
       <section className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-8">

--- a/frontend/src/pages/DeveloperDocsPage.tsx
+++ b/frontend/src/pages/DeveloperDocsPage.tsx
@@ -25,7 +25,7 @@ export default function DeveloperDocsPage() {
   }));
 
   return (
-    <AppPageShell>
+    <AppPageShell activePage="docs">
       <AppPageHeader
         title={t('docs.home.title')}
         description={t('docs.home.subtitle')}

--- a/frontend/src/pages/DeveloperDocsSectionPage.tsx
+++ b/frontend/src/pages/DeveloperDocsSectionPage.tsx
@@ -30,7 +30,7 @@ export default function DeveloperDocsSectionPage() {
   const isOpenAi = section === 'openai';
 
   return (
-    <AppPageShell>
+    <AppPageShell activePage="docs">
       <nav className="flex items-center gap-2 text-sm font-medium text-[#6f7a6e] mb-6">
         <Link href="/docs" className="hover:text-[#00652c] transition-colors">
           ← {t('docs.backToHome')}


### PR DESCRIPTION
## Summary
- restore the Developer Docs entry point in the global navigation
- mark Developer Docs pages as the active docs section in the shared page shell
- remove the extra header badge from the docs landing page
- align the shared loading spinner with the current app visual language

## Testing
- npm run typecheck
- npm run build
- npm test -- --run src/components/video/__tests__/VideoNavBar.test.tsx src/pages/__tests__/HomePage.test.tsx
- npm test -- --run src/components/common/__tests__/LoadingSpinner.test.tsx src/components/common/__tests__/LoadingState.test.tsx