### PR TITLE
style: ローディングスピナーをエレガントな薄リングデザインに刷新

### DIFF
--- a/frontend/src/components/common/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner.tsx
@@ -8,20 +8,21 @@ export function LoadingSpinner({ message }: LoadingSpinnerProps) {
       <div
         role="status"
         aria-live="polite"
-        className="flex flex-col items-center rounded-2xl border border-[#d9e6db] bg-white/80 px-6 py-5 shadow-[0_12px_32px_-8px_rgba(25,28,25,0.10)]"
+        className="flex flex-col items-center"
       >
-        <div className="relative mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-[#f2f4ef]">
-          <div className="absolute inset-1 rounded-full border border-[#dfe6df]" />
-          <div className="h-8 w-8 animate-spin rounded-full border-2 border-[#becabc] border-t-[#00652c]" />
-          <div className="absolute h-2 w-2 rounded-full bg-[#00652c]" />
+        <div className="relative w-24 h-24 flex items-center justify-center mb-4">
+          {/* Outer track */}
+          <div className="absolute inset-0 rounded-full border-[0.5px] border-[#bfc9bc]/30" />
+          {/* Slow-rotating thin ring */}
+          <div className="loading-ring absolute inset-0 rounded-full border-t-[1.5px] border-[#00652c]/60" />
+          {/* Pulsing center dot */}
+          <div className="flex flex-col items-center">
+            <div className="pulse-dot w-2.5 h-2.5 rounded-full bg-[#00652c] shadow-[0_0_16px_rgba(0,101,44,0.5)]" />
+          </div>
         </div>
-        {message ? (
-          <p className="text-sm font-medium text-[#3f493f]">{message}</p>
-        ) : (
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#6f7a6e]">
-            Loading
-          </p>
-        )}
+        <p className="text-[10px] font-bold tracking-[0.2em] text-[#3f493f] uppercase">
+          {message ?? 'Loading'}
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/components/common/__tests__/LoadingSpinner.test.tsx
+++ b/frontend/src/components/common/__tests__/LoadingSpinner.test.tsx
@@ -6,8 +6,8 @@ describe('LoadingSpinner', () => {
     const { container } = render(<LoadingSpinner />)
 
     expect(screen.getByRole('status')).toBeInTheDocument()
-    const spinner = container.querySelector('.animate-spin')
-    expect(spinner).toBeInTheDocument()
+    const spinnerRing = container.querySelector('.loading-ring')
+    expect(spinnerRing).toBeInTheDocument()
   })
 
   it('should display custom message', () => {

--- a/frontend/src/components/common/__tests__/LoadingState.test.tsx
+++ b/frontend/src/components/common/__tests__/LoadingState.test.tsx
@@ -11,8 +11,8 @@ describe('LoadingState', () => {
 
     // Check for spinner element
     expect(screen.getByRole('status')).toBeInTheDocument()
-    const spinner = container.querySelector('.animate-spin')
-    expect(spinner).toBeInTheDocument()
+    const spinnerRing = container.querySelector('.loading-ring')
+    expect(spinnerRing).toBeInTheDocument()
     expect(screen.queryByText('Content')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -120,3 +120,21 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes rotate-slow {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes subtle-pulse {
+  0%, 100% { opacity: 0.4; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.15); }
+}
+
+.loading-ring {
+  animation: rotate-slow 4s linear infinite;
+}
+
+.pulse-dot {
+  animation: subtle-pulse 3s ease-in-out infinite;
+}


### PR DESCRIPTION
## 概要

ローディングスピナーのデザインを VideoQ のデザイン参照に合わせて刷新。  
ボックス感の強いカード型スピナーを廃止し、「静かで上品なリズム」を体現するミニマルなデザインへ変更。

## 変更内容

### `frontend/src/components/common/LoadingSpinner.tsx`
- カード枠・ボーダー・背景色を削除してシンプルな構成に
- スピナーを薄リング（1.5px）＋外側トラック（0.5px）の二重円構造に変更
- 中央にグリーングロー付きパルスドット (`shadow-[0_0_16px_rgba(0,101,44,0.5)]`) を追加
- テキストを `tracking-[0.2em]` の広めレタースペーシング＋uppercase に統一

### `frontend/src/index.css`
- `rotate-slow`: 4秒でゆっくり1周するカスタムアニメーションを追加
- `subtle-pulse`: 3秒のフェード＋スケールパルスを追加
- `.loading-ring` / `.pulse-dot` クラスを定義

## Before / After

| 項目 | Before | After |
|------|--------|-------|
| 回転速度 | `animate-spin`（0.75s） | 4s ゆっくり |
| リング太さ | 2px、グレー地 + 緑 tip | 1.5px 薄リング |
| カード | ボーダー＋白背景 | 枠なし |
| 中央 | 固定ドット | パルス＋グロー |
| テキスト | 2種類の条件分岐スタイル | 統一 uppercase tracking |

## テスト方法

```bash
docker compose build frontend
docker compose up frontend
```

`LoadingSpinner` が表示される画面（動画一覧ロード中など）でアニメーションを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)