### PR TITLE
style: remove next video link from video group detail pages

### DIFF
--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   GraduationCap, List, Play, MessageSquare,
-  CheckCircle, Clock, AlertCircle, ArrowRight,
+  CheckCircle, Clock, AlertCircle,
 } from 'lucide-react';
 import { Link } from '@/lib/i18n';
 import { apiClient, type VideoInGroup } from '@/lib/api';
@@ -100,11 +100,6 @@ export default function SharePage() {
     return convertVideoInGroupToSelectedVideo(selected ?? group.videos[0]);
   }, [group, selectedVideoId]);
 
-  const nextVideo = (() => {
-    if (!group?.videos || !selectedVideo) return null;
-    const idx = group.videos.findIndex((v) => v.id === selectedVideo.id);
-    return idx >= 0 && idx < group.videos.length - 1 ? group.videos[idx + 1] : null;
-  })();
 
   const { videoRef, handleVideoCanPlay, handleVideoPlayFromTime } = useVideoPlayback({
     selectedVideo,
@@ -260,23 +255,6 @@ export default function SharePage() {
                 )}
               </div>
             </div>
-
-            {/* Next video link */}
-            {nextVideo && (
-              <div className="flex justify-center">
-                <button
-                  onClick={() => {
-                    handleVideoSelect(nextVideo.id);
-                    if (isMobile) setMobileTab('player');
-                  }}
-                  className="group flex items-center gap-2 text-[#00652c] font-bold text-sm hover:underline"
-                >
-                  {t('videos.groupDetail.nextVideo')}
-                  <span className="truncate max-w-[200px]">{nextVideo.title}</span>
-                  <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-                </button>
-              </div>
-            )}
           </section>
 
           {/* RIGHT: Chat */}

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -46,7 +46,7 @@ import { TagFilterPanel } from '@/components/video/TagFilterPanel';
 import {
   ArrowLeft, ChevronRight, Plus, GripVertical,
   CheckCircle, Clock, AlertCircle, Copy, Trash2,
-  Pencil, ArrowRight, List, Play, MessageSquare,
+  Pencil, List, Play, MessageSquare,
   Save, X, GraduationCap,
 } from 'lucide-react';
 
@@ -449,11 +449,6 @@ export default function VideoGroupDetailPage() {
     if (!exists) setSelectedVideo(convertVideoInGroupToSelectedVideo(videos[0]));
   }, [group?.videos, selectedVideo]);
 
-  const nextVideo = useMemo(() => {
-    if (!group?.videos || !selectedVideo) return null;
-    const idx = group.videos.findIndex((v) => v.id === selectedVideo.id);
-    return idx >= 0 && idx < group.videos.length - 1 ? group.videos[idx + 1] : null;
-  }, [group?.videos, selectedVideo]);
 
   const handleRemoveVideo = async (videoId: number) => {
     if (!confirm(t('videos.groupDetail.removeVideoConfirm')) || !groupId) return;
@@ -750,22 +745,6 @@ export default function VideoGroupDetailPage() {
                 )}
               </div>
             </div>
-
-            {/* Next video link */}
-            {nextVideo && (
-              <div className="flex justify-center">
-                <button
-                  onClick={() => {
-                    handleVideoSelect(nextVideo.id);
-                    if (isMobile) setMobileTab('player');
-                  }}
-                  className="group flex items-center gap-2 text-[#00652c] font-bold text-sm hover:underline"
-                >
-                  {t('videos.groupDetail.nextVideo')} <span className="truncate max-w-[200px]">{nextVideo.title}</span>
-                  <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-                </button>
-              </div>
-            )}
           </section>
 
           {/* RIGHT: Chat */}


### PR DESCRIPTION
## Summary
- `VideoGroupDetailPage` と `SharePage` の動画プレイヤー下部に表示されていた「次の動画」リンクを削除
- 未使用になった `nextVideo` 変数・`ArrowRight` インポート・`useMemo` インポートも合わせて削除

## Test plan
- [ ] `/ja/videos/groups/[id]` で動画プレイヤー下部に「次の動画」リンクが表示されないことを確認
- [ ] シェアページでも同様に非表示になっていることを確認
- [ ] フロントエンドのビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)