### PR TITLE
style: remove unused i18n keys from old layout components

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -116,22 +116,14 @@
     }
   },
   "navigation": {
-    "brand": "VideoQ",
     "home": "Home",
     "videosNav": "Videos",
     "groupsNav": "Groups",
     "docs": "Developer Docs",
-    "videos": "Videos",
-    "videoGroups": "Chat groups",
     "settings": "Settings",
-    "logout": "Log out",
-    "welcome": "Welcome, {{username}}",
-    "openMenu": "Open menu"
+    "logout": "Log out"
   },
   "layout": {
-    "footer": {
-      "copyright": "© {{year}} VideoQ. Released under the MIT License."
-    },
     "authBranding": {
       "tagline": "Transform every video into the ultimate learning experience"
     },

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -116,22 +116,14 @@
     }
   },
   "navigation": {
-    "brand": "VideoQ",
     "home": "ホーム",
     "videosNav": "動画",
     "groupsNav": "グループ",
     "docs": "開発者Docs",
-    "videos": "動画一覧",
-    "videoGroups": "チャットグループ",
     "settings": "設定",
-    "logout": "ログアウト",
-    "welcome": "ようこそ、{{username}}さん",
-    "openMenu": "メニューを開く"
+    "logout": "ログアウト"
   },
   "layout": {
-    "footer": {
-      "copyright": "© {{year}} VideoQ. Released under the MIT License."
-    },
     "authBranding": {
       "tagline": "あらゆるビデオを、最高の学びの体験へ"
     },


### PR DESCRIPTION
## Summary

- `Header.tsx` / `Footer.tsx` 削除に伴い使われなくなった翻訳キーを en・ja 両ファイルから削除
- 削除したキー: `navigation.brand`, `navigation.videos`, `navigation.videoGroups`, `navigation.welcome`, `navigation.openMenu`, `layout.footer.copyright`

## Test plan

- [x] アプリを起動して各ナビゲーションリンク・ログアウトボタンが正常に表示されることを確認
- [x] 認証ページ（ログイン・サインアップ等）の表示が崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)