### PR TITLE
feat: モバイルレイアウト改善 — チャットをプレイヤー直下に表示 & ブレークポイントを1024pxに統一

### DIFF
--- a/frontend/src/hooks/useMobileTab.ts
+++ b/frontend/src/hooks/useMobileTab.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-type MobileTab = 'videos' | 'player' | 'chat';
+type MobileTab = 'videos' | 'player';
 
 interface UseMobileTabReturn {
   mobileTab: MobileTab;

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -158,7 +158,7 @@ export default function SharePage() {
               <GraduationCap className="text-[#00652c] w-6 h-6" />
               <span>VideoQ</span>
             </Link>
-            <div className="hidden md:flex items-center gap-1 text-sm text-[#6f7a6e] font-medium min-w-0">
+            <div className="hidden lg:flex items-center gap-1 text-sm text-[#6f7a6e] font-medium min-w-0">
               <span className="text-[#00652c] font-bold border-b-2 border-[#00652c] truncate max-w-[200px]">
                 {group.name}
               </span>
@@ -174,7 +174,7 @@ export default function SharePage() {
       </header>
 
       {/* ── Main ────────────────────────────────────────────────────────── */}
-      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 md:pb-0 md:h-[calc(100dvh-4rem)] md:overflow-hidden">
+      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-0 lg:h-[calc(100dvh-4rem)] lg:overflow-hidden">
         {group.description && (
           <div className="shrink-0 rounded-2xl border border-stone-200/70 bg-white/80 px-4 py-3 text-sm text-[#4f5a4f] shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
             {group.description}
@@ -182,10 +182,10 @@ export default function SharePage() {
         )}
 
         {/* 3-column grid */}
-        <div className="flex flex-col md:grid md:grid-cols-4 gap-6 md:flex-1 md:min-h-0 md:items-stretch">
+        <div className="flex flex-col lg:grid lg:grid-cols-4 gap-6 lg:flex-1 lg:min-h-0 lg:items-stretch">
 
           {/* LEFT: Video list */}
-          <aside className={`md:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden md:flex'}`}>
+          <aside className={`lg:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
             <div className="bg-white rounded-xl flex flex-col h-full overflow-hidden shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
               <div className="p-4 border-b border-stone-100 flex items-center justify-between shrink-0">
                 <h2 className="font-extrabold text-[#191c19]">{t('videos.groupDetail.videoListTitle')}</h2>
@@ -216,8 +216,8 @@ export default function SharePage() {
           </aside>
 
           {/* CENTER: Video player */}
-          <section className={`md:col-span-2 flex flex-col gap-3 md:min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden md:flex'}`}>
-            <div className="bg-white rounded-xl flex flex-col md:flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
+          <section className={`lg:col-span-2 flex flex-col gap-3 lg:min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden lg:flex'}`}>
+            <div className="bg-white rounded-xl flex flex-col lg:flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
               <div className="p-4 border-b border-stone-100 shrink-0 flex items-center justify-between gap-3 min-w-0">
                 <h1 className="font-extrabold text-[#191c19] text-lg truncate flex-1 min-w-0">
                   {selectedVideo ? selectedVideo.title : t('videos.shared.playerPlaceholder')}
@@ -233,7 +233,7 @@ export default function SharePage() {
                   </div>
                 )}
               </div>
-              <div className="aspect-video md:aspect-auto md:flex-1 bg-[#1a1c1c] flex items-center justify-center md:min-h-0">
+              <div className="aspect-video lg:aspect-auto lg:flex-1 bg-[#1a1c1c] flex items-center justify-center lg:min-h-0">
                 {selectedVideo ? (
                   selectedVideo.file ? (
                     <video
@@ -255,7 +255,7 @@ export default function SharePage() {
               </div>
             </div>
             {/* Chat below player on mobile */}
-            <div className="md:hidden">
+            <div className="lg:hidden">
               <ChatPanel
                 groupId={group.id}
                 onVideoPlay={handleVideoPlayFromTime}
@@ -266,7 +266,7 @@ export default function SharePage() {
           </section>
 
           {/* RIGHT: Chat (desktop only) */}
-          <aside className="hidden md:flex md:col-span-1 flex-col min-h-0">
+          <aside className="hidden lg:flex lg:col-span-1 flex-col min-h-0">
             <ChatPanel
               groupId={group.id}
               onVideoPlay={handleVideoPlayFromTime}
@@ -279,7 +279,7 @@ export default function SharePage() {
       </main>
 
       {/* ── Mobile bottom nav ───────────────────────────────────────────── */}
-      <nav className="fixed bottom-0 left-0 w-full z-50 md:hidden flex justify-around items-center h-16 bg-white border-t border-stone-100 shadow-[0_-4px_20px_rgba(28,25,23,0.06)] rounded-t-2xl px-4">
+      <nav className="fixed bottom-0 left-0 w-full z-50 lg:hidden flex justify-around items-center h-16 bg-white border-t border-stone-100 shadow-[0_-4px_20px_rgba(28,25,23,0.06)] rounded-t-2xl px-4">
         {(['videos', 'player'] as MobileTab[]).map((tab) => {
           const Icon = mobileTabIcon[tab];
           const isActive = mobileTab === tab;

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
-  GraduationCap, List, Play, MessageSquare,
+  GraduationCap, List, Play,
   CheckCircle, Clock, AlertCircle,
 } from 'lucide-react';
 import { Link } from '@/lib/i18n';
@@ -16,7 +16,7 @@ import { useMobileTab } from '@/hooks/useMobileTab';
 import { useSharedGroupQuery } from '@/hooks/useSharePageData';
 import { useI18nNavigate } from '@/lib/i18n';
 
-type MobileTab = 'videos' | 'player' | 'chat';
+type MobileTab = 'videos' | 'player';
 
 // ── Status badge ──────────────────────────────────────────────────────────────
 
@@ -107,11 +107,10 @@ export default function SharePage() {
     onMobileSwitch: () => setMobileTab('player'),
   });
 
-  const mobileTabIcon: Record<MobileTab, typeof List> = { videos: List, player: Play, chat: MessageSquare };
+  const mobileTabIcon: Record<MobileTab, typeof List> = { videos: List, player: Play };
   const mobileTabLabel: Record<MobileTab, string> = {
     videos: t('videos.shared.tabs.videos'),
     player: t('videos.shared.tabs.player'),
-    chat: t('videos.shared.tabs.chat'),
   };
 
   // ── Loading ────────────────────────────────────────────────────────────────
@@ -175,7 +174,7 @@ export default function SharePage() {
       </header>
 
       {/* ── Main ────────────────────────────────────────────────────────── */}
-      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full h-[calc(100dvh-8rem)] overflow-hidden md:h-[calc(100dvh-4rem)]">
+      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 md:pb-0 md:h-[calc(100dvh-4rem)] md:overflow-hidden">
         {group.description && (
           <div className="shrink-0 rounded-2xl border border-stone-200/70 bg-white/80 px-4 py-3 text-sm text-[#4f5a4f] shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
             {group.description}
@@ -183,7 +182,7 @@ export default function SharePage() {
         )}
 
         {/* 3-column grid */}
-        <div className="flex flex-col md:grid md:grid-cols-4 gap-6 flex-1 min-h-0 md:items-stretch">
+        <div className="flex flex-col md:grid md:grid-cols-4 gap-6 md:flex-1 md:min-h-0 md:items-stretch">
 
           {/* LEFT: Video list */}
           <aside className={`md:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden md:flex'}`}>
@@ -217,8 +216,8 @@ export default function SharePage() {
           </aside>
 
           {/* CENTER: Video player */}
-          <section className={`md:col-span-2 flex flex-col gap-3 min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden md:flex'}`}>
-            <div className="bg-white rounded-xl flex flex-col flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
+          <section className={`md:col-span-2 flex flex-col gap-3 md:min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden md:flex'}`}>
+            <div className="bg-white rounded-xl flex flex-col md:flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
               <div className="p-4 border-b border-stone-100 shrink-0 flex items-center justify-between gap-3 min-w-0">
                 <h1 className="font-extrabold text-[#191c19] text-lg truncate flex-1 min-w-0">
                   {selectedVideo ? selectedVideo.title : t('videos.shared.playerPlaceholder')}
@@ -234,7 +233,7 @@ export default function SharePage() {
                   </div>
                 )}
               </div>
-              <div className="flex-1 bg-[#1a1c1c] flex items-center justify-center min-h-0">
+              <div className="aspect-video md:aspect-auto md:flex-1 bg-[#1a1c1c] flex items-center justify-center md:min-h-0">
                 {selectedVideo ? (
                   selectedVideo.file ? (
                     <video
@@ -255,10 +254,19 @@ export default function SharePage() {
                 )}
               </div>
             </div>
+            {/* Chat below player on mobile */}
+            <div className="md:hidden">
+              <ChatPanel
+                groupId={group.id}
+                onVideoPlay={handleVideoPlayFromTime}
+                shareToken={shareToken}
+                className="h-[480px] shadow-[0_4px_20px_rgba(28,25,23,0.04)]"
+              />
+            </div>
           </section>
 
-          {/* RIGHT: Chat */}
-          <aside className={`md:col-span-1 flex flex-col min-h-0 ${mobileTab === 'chat' ? 'flex' : 'hidden md:flex'}`}>
+          {/* RIGHT: Chat (desktop only) */}
+          <aside className="hidden md:flex md:col-span-1 flex-col min-h-0">
             <ChatPanel
               groupId={group.id}
               onVideoPlay={handleVideoPlayFromTime}
@@ -272,7 +280,7 @@ export default function SharePage() {
 
       {/* ── Mobile bottom nav ───────────────────────────────────────────── */}
       <nav className="fixed bottom-0 left-0 w-full z-50 md:hidden flex justify-around items-center h-16 bg-white border-t border-stone-100 shadow-[0_-4px_20px_rgba(28,25,23,0.06)] rounded-t-2xl px-4">
-        {(['videos', 'player', 'chat'] as MobileTab[]).map((tab) => {
+        {(['videos', 'player'] as MobileTab[]).map((tab) => {
           const Icon = mobileTabIcon[tab];
           const isActive = mobileTab === tab;
           return (

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -46,14 +46,14 @@ import { TagFilterPanel } from '@/components/video/TagFilterPanel';
 import {
   ArrowLeft, ChevronRight, Plus, GripVertical,
   CheckCircle, Clock, AlertCircle, Copy, Trash2,
-  Pencil, List, Play, MessageSquare,
+  Pencil, List, Play,
   Save, X, GraduationCap,
 } from 'lucide-react';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const MOBILE_SENSORS: SensorDescriptor<any>[] = [];
 
-type MobileTab = 'videos' | 'player' | 'chat';
+type MobileTab = 'videos' | 'player';
 
 const ORDERING_OPTIONS = [
   'uploaded_at_desc',
@@ -530,11 +530,10 @@ export default function VideoGroupDetailPage() {
     );
   }
 
-  const mobileTabIcon: Record<MobileTab, typeof List> = { videos: List, player: Play, chat: MessageSquare };
+  const mobileTabIcon: Record<MobileTab, typeof List> = { videos: List, player: Play };
   const mobileTabLabel: Record<MobileTab, string> = {
     videos: t('videos.groupDetail.mobileTabs.videos'),
     player: t('videos.groupDetail.mobileTabs.player'),
-    chat: t('videos.groupDetail.mobileTabs.chat'),
   };
 
   return (
@@ -648,7 +647,7 @@ export default function VideoGroupDetailPage() {
       </Dialog>
 
       {/* ── Main ─────────────────────────────────────────────────────────── */}
-      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full h-[calc(100dvh-8rem)] overflow-hidden md:h-[calc(100dvh-4rem)]">
+      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 md:pb-0 md:h-[calc(100dvh-4rem)] md:overflow-hidden">
         {/* Share link panel */}
         <ShareLinkPanel
           shareLink={shareLink}
@@ -660,7 +659,7 @@ export default function VideoGroupDetailPage() {
         />
 
         {/* 3-column grid */}
-        <div className="flex flex-col md:grid md:grid-cols-4 gap-6 flex-1 min-h-0 md:items-stretch">
+        <div className="flex flex-col md:grid md:grid-cols-4 gap-6 md:flex-1 md:min-h-0 md:items-stretch">
 
           {/* LEFT: Video list */}
           <aside className={`md:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden md:flex'}`}>
@@ -711,8 +710,8 @@ export default function VideoGroupDetailPage() {
           </aside>
 
           {/* CENTER: Video player */}
-          <section className={`md:col-span-2 flex flex-col gap-3 min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden md:flex'}`}>
-            <div className="bg-white rounded-xl flex flex-col flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
+          <section className={`md:col-span-2 flex flex-col gap-3 md:min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden md:flex'}`}>
+            <div className="bg-white rounded-xl flex flex-col md:flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
               <div className="p-4 border-b border-stone-100 shrink-0 flex items-center justify-between gap-3 min-w-0">
                 <h1 className="font-extrabold text-[#191c19] text-lg truncate flex-1 min-w-0">
                   {selectedVideo ? selectedVideo.title : t('videos.groupDetail.playerPlaceholder')}
@@ -724,7 +723,7 @@ export default function VideoGroupDetailPage() {
                   {groupId && <DashboardButton groupId={groupId} size="sm" />}
                 </div>
               </div>
-              <div className="flex-1 bg-[#1a1c1c] flex items-center justify-center min-h-0">
+              <div className="aspect-video md:aspect-auto md:flex-1 bg-[#1a1c1c] flex items-center justify-center md:min-h-0">
                 {selectedVideo ? (
                   selectedVideo.file ? (
                     <video
@@ -745,10 +744,18 @@ export default function VideoGroupDetailPage() {
                 )}
               </div>
             </div>
+            {/* Chat below player on mobile */}
+            <div className="md:hidden">
+              <ChatPanel
+                groupId={groupId ?? undefined}
+                onVideoPlay={handleVideoPlayFromTime}
+                className="h-[480px] shadow-[0_4px_20px_rgba(28,25,23,0.04)]"
+              />
+            </div>
           </section>
 
-          {/* RIGHT: Chat */}
-          <aside className={`md:col-span-1 flex flex-col min-h-0 ${mobileTab === 'chat' ? 'flex' : 'hidden md:flex'}`}>
+          {/* RIGHT: Chat (desktop only) */}
+          <aside className="hidden md:flex md:col-span-1 flex-col min-h-0">
             <ChatPanel
               groupId={groupId ?? undefined}
               onVideoPlay={handleVideoPlayFromTime}
@@ -760,7 +767,7 @@ export default function VideoGroupDetailPage() {
 
       {/* ── Mobile bottom nav ─────────────────────────────────────────────── */}
       <nav className="fixed bottom-0 left-0 w-full z-50 md:hidden flex justify-around items-center h-16 bg-white border-t border-stone-100 shadow-[0_-4px_20px_rgba(28,25,23,0.06)] rounded-t-2xl px-4">
-        {(['videos', 'player', 'chat'] as MobileTab[]).map((tab) => {
+        {(['videos', 'player'] as MobileTab[]).map((tab) => {
           const Icon = mobileTabIcon[tab];
           const isActive = mobileTab === tab;
           return (

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -549,7 +549,7 @@ export default function VideoGroupDetailPage() {
             <GraduationCap className="text-[#00652c] w-6 h-6" />
             <span>VideoQ</span>
           </Link>
-          <div className="hidden md:flex items-center gap-1 text-sm text-[#6f7a6e] font-medium min-w-0">
+          <div className="hidden lg:flex items-center gap-1 text-sm text-[#6f7a6e] font-medium min-w-0">
             <Link href="/videos/groups" className="text-stone-400 hover:text-[#00652c] transition-colors shrink-0">
               {t('videos.groupDetail.breadcrumbGroups')}
             </Link>
@@ -647,7 +647,7 @@ export default function VideoGroupDetailPage() {
       </Dialog>
 
       {/* ── Main ─────────────────────────────────────────────────────────── */}
-      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 md:pb-0 md:h-[calc(100dvh-4rem)] md:overflow-hidden">
+      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-0 lg:h-[calc(100dvh-4rem)] lg:overflow-hidden">
         {/* Share link panel */}
         <ShareLinkPanel
           shareLink={shareLink}
@@ -659,16 +659,16 @@ export default function VideoGroupDetailPage() {
         />
 
         {/* 3-column grid */}
-        <div className="flex flex-col md:grid md:grid-cols-4 gap-6 md:flex-1 md:min-h-0 md:items-stretch">
+        <div className="flex flex-col lg:grid lg:grid-cols-4 gap-6 lg:flex-1 lg:min-h-0 lg:items-stretch">
 
           {/* LEFT: Video list */}
-          <aside className={`md:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden md:flex'}`}>
+          <aside className={`lg:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
             <div className="bg-white rounded-xl flex flex-col h-full overflow-hidden shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
               <div className="p-4 border-b border-stone-100 flex items-center justify-between gap-2 shrink-0">
                 <h2 className="font-extrabold text-[#191c19]">{t('videos.groupDetail.videoListTitle')}</h2>
                 <div className="flex items-center gap-2 shrink-0">
                   {group.videos && group.videos.length > 0 && groupId && (
-                    <div className="md:hidden">
+                    <div className="lg:hidden">
                       <ShortsButton groupId={groupId} videos={group.videos} size="sm" />
                     </div>
                   )}
@@ -710,8 +710,8 @@ export default function VideoGroupDetailPage() {
           </aside>
 
           {/* CENTER: Video player */}
-          <section className={`md:col-span-2 flex flex-col gap-3 md:min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden md:flex'}`}>
-            <div className="bg-white rounded-xl flex flex-col md:flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
+          <section className={`lg:col-span-2 flex flex-col gap-3 lg:min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden lg:flex'}`}>
+            <div className="bg-white rounded-xl flex flex-col lg:flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
               <div className="p-4 border-b border-stone-100 shrink-0 flex items-center justify-between gap-3 min-w-0">
                 <h1 className="font-extrabold text-[#191c19] text-lg truncate flex-1 min-w-0">
                   {selectedVideo ? selectedVideo.title : t('videos.groupDetail.playerPlaceholder')}
@@ -723,7 +723,7 @@ export default function VideoGroupDetailPage() {
                   {groupId && <DashboardButton groupId={groupId} size="sm" />}
                 </div>
               </div>
-              <div className="aspect-video md:aspect-auto md:flex-1 bg-[#1a1c1c] flex items-center justify-center md:min-h-0">
+              <div className="aspect-video lg:aspect-auto lg:flex-1 bg-[#1a1c1c] flex items-center justify-center lg:min-h-0">
                 {selectedVideo ? (
                   selectedVideo.file ? (
                     <video
@@ -745,7 +745,7 @@ export default function VideoGroupDetailPage() {
               </div>
             </div>
             {/* Chat below player on mobile */}
-            <div className="md:hidden">
+            <div className="lg:hidden">
               <ChatPanel
                 groupId={groupId ?? undefined}
                 onVideoPlay={handleVideoPlayFromTime}
@@ -755,7 +755,7 @@ export default function VideoGroupDetailPage() {
           </section>
 
           {/* RIGHT: Chat (desktop only) */}
-          <aside className="hidden md:flex md:col-span-1 flex-col min-h-0">
+          <aside className="hidden lg:flex lg:col-span-1 flex-col min-h-0">
             <ChatPanel
               groupId={groupId ?? undefined}
               onVideoPlay={handleVideoPlayFromTime}
@@ -766,7 +766,7 @@ export default function VideoGroupDetailPage() {
       </main>
 
       {/* ── Mobile bottom nav ─────────────────────────────────────────────── */}
-      <nav className="fixed bottom-0 left-0 w-full z-50 md:hidden flex justify-around items-center h-16 bg-white border-t border-stone-100 shadow-[0_-4px_20px_rgba(28,25,23,0.06)] rounded-t-2xl px-4">
+      <nav className="fixed bottom-0 left-0 w-full z-50 lg:hidden flex justify-around items-center h-16 bg-white border-t border-stone-100 shadow-[0_-4px_20px_rgba(28,25,23,0.06)] rounded-t-2xl px-4">
         {(['videos', 'player'] as MobileTab[]).map((tab) => {
           const Icon = mobileTabIcon[tab];
           const isActive = mobileTab === tab;

--- a/frontend/src/pages/__tests__/SharePage.test.tsx
+++ b/frontend/src/pages/__tests__/SharePage.test.tsx
@@ -68,7 +68,7 @@ describe('SharePage', () => {
     render(<SharePage />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('chat-panel')).toBeInTheDocument()
+      expect(screen.getAllByTestId('chat-panel').length).toBeGreaterThan(0)
     })
   })
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -133,7 +133,7 @@ describe('VideoGroupDetailPage', () => {
     render(<VideoGroupDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByTestId('chat-panel')).toBeInTheDocument()
+      expect(screen.getAllByTestId('chat-panel').length).toBeGreaterThan(0)
     })
   })
 


### PR DESCRIPTION
## Summary

- **チャット専用タブを廃止**: モバイルのボトムナビを3タブ(動画/プレイヤー/チャット)から2タブ(動画/プレイヤー)に削減
- **プレイヤー直下にチャットを表示**: playerタブでビデオ(16:9固定)の下にChatPanelを縦積み表示 — YouTubeのモバイルUIに準拠
- **ブレークポイントを統一**: CSS `md:`(768px) を `lg:`(1024px) に変更し、JSの`isMobile`判定(1024px)と一致させた。768〜1024pxの幅で誤って3カラムデスクトップレイアウトが表示されていた問題を修正

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `frontend/src/hooks/useMobileTab.ts` | `MobileTab` 型から `'chat'` を削除 |
| `frontend/src/pages/VideoGroupDetailPage.tsx` | チャット統合・ブレークポイント修正 |
| `frontend/src/pages/SharePage.tsx` | 同上(共有ページも同様に対応) |

## Test plan

- [x] モバイル幅(< 1024px)でプレイヤータブを開き、動画の下にチャットが表示されることを確認
- [x] デスクトップ幅(≥ 1024px)で3カラムレイアウトが維持されることを確認
- [x] SharePage でも同様の動作を確認
- [x] ボトムナビに「動画」「プレイヤー」の2タブのみ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)