### PR TITLE
Reduce AI cost: Standard plan 7,000 AI answers, RAG k=4, max_tokens=1024

### DIFF
--- a/backend/app/domain/billing/entities.py
+++ b/backend/app/domain/billing/entities.py
@@ -14,7 +14,7 @@ class PlanType(str, Enum):
 PLAN_LIMITS: Dict[PlanType, Dict[str, Optional[int]]] = {
     PlanType.FREE: {"storage_gb": 1, "processing_minutes": 10, "ai_answers": 500},
     PlanType.LITE: {"storage_gb": 10, "processing_minutes": 120, "ai_answers": 3000},
-    PlanType.STANDARD: {"storage_gb": 50, "processing_minutes": 600, "ai_answers": 10000},
+    PlanType.STANDARD: {"storage_gb": 50, "processing_minutes": 600, "ai_answers": 7000},
     PlanType.ENTERPRISE: {"storage_gb": None, "processing_minutes": None, "ai_answers": None},  # set by admin
 }
 

--- a/backend/app/domain/billing/tests/test_entities.py
+++ b/backend/app/domain/billing/tests/test_entities.py
@@ -94,6 +94,14 @@ class AiAnswersLimitTests(TestCase):
         sub = _make_subscription(plan=PlanType.LITE)
         self.assertEqual(sub.get_ai_answers_limit(), 3000)
 
+    def test_ai_answers_standard_plan(self):
+        sub = _make_subscription(plan=PlanType.STANDARD)
+        self.assertEqual(sub.get_ai_answers_limit(), 7000)
+
+    def test_ai_answers_enterprise_no_custom_returns_none(self):
+        sub = _make_subscription(plan=PlanType.ENTERPRISE)
+        self.assertIsNone(sub.get_ai_answers_limit())
+
 
 class CanUseStorageTests(TestCase):
     def test_can_use_storage_within_limit(self):
@@ -135,6 +143,26 @@ class CanAnswerTests(TestCase):
     def test_can_answer_at_limit(self):
         sub = _make_subscription(plan=PlanType.FREE, used_ai_answers=500)
         self.assertFalse(sub.can_answer())
+
+    def test_can_answer_lite_within_limit(self):
+        sub = _make_subscription(plan=PlanType.LITE, used_ai_answers=2999)
+        self.assertTrue(sub.can_answer())
+
+    def test_can_answer_lite_at_limit(self):
+        sub = _make_subscription(plan=PlanType.LITE, used_ai_answers=3000)
+        self.assertFalse(sub.can_answer())
+
+    def test_can_answer_standard_within_limit(self):
+        sub = _make_subscription(plan=PlanType.STANDARD, used_ai_answers=6999)
+        self.assertTrue(sub.can_answer())
+
+    def test_can_answer_standard_at_limit(self):
+        sub = _make_subscription(plan=PlanType.STANDARD, used_ai_answers=7000)
+        self.assertFalse(sub.can_answer())
+
+    def test_can_answer_enterprise_unlimited(self):
+        sub = _make_subscription(plan=PlanType.ENTERPRISE, unlimited_ai_answers=True, used_ai_answers=999999)
+        self.assertTrue(sub.can_answer())
 
 class IsStripeActiveTests(TestCase):
     def test_free_plan_always_active(self):

--- a/backend/app/infrastructure/external/llm.py
+++ b/backend/app/infrastructure/external/llm.py
@@ -36,12 +36,13 @@ def get_langchain_llm(api_key: Optional[str] = None) -> BaseChatModel:
 
         model = getattr(settings, "LLM_MODEL", "gpt-4o-mini")
 
-        return ChatOpenAI(
+        llm = ChatOpenAI(
             model=model,
             api_key=SecretStr(resolved_key),
             temperature=temperature,
-            model_kwargs={"max_tokens": 1024},
         )
+        llm.max_tokens = 1024
+        return llm
 
     elif provider == "ollama":
         # Use Ollama LLM

--- a/backend/app/infrastructure/external/llm.py
+++ b/backend/app/infrastructure/external/llm.py
@@ -40,7 +40,7 @@ def get_langchain_llm(api_key: Optional[str] = None) -> BaseChatModel:
             model=model,
             api_key=SecretStr(resolved_key),
             temperature=temperature,
-            max_tokens=1024,
+            model_kwargs={"max_tokens": 1024},
         )
 
     elif provider == "ollama":

--- a/backend/app/infrastructure/external/llm.py
+++ b/backend/app/infrastructure/external/llm.py
@@ -40,6 +40,7 @@ def get_langchain_llm(api_key: Optional[str] = None) -> BaseChatModel:
             model=model,
             api_key=SecretStr(resolved_key),
             temperature=temperature,
+            max_tokens=1024,
         )
 
     elif provider == "ollama":

--- a/backend/app/infrastructure/external/rag_service.py
+++ b/backend/app/infrastructure/external/rag_service.py
@@ -121,7 +121,7 @@ class RagChatService:
         vector_store = self._create_vector_store()
         return vector_store.as_retriever(
             search_kwargs={
-                "k": 6,
+                "k": 4,
                 "filter": {
                     "user_id": self.user.id,
                     "video_id": {"$in": group_video_ids},

--- a/backend/app/use_cases/billing/tests/test_check_limits.py
+++ b/backend/app/use_cases/billing/tests/test_check_limits.py
@@ -70,7 +70,6 @@ class CheckStorageLimitTests(TestCase):
     def test_storage_within_limit_does_not_raise(self):
         entity = _make_subscription(plan=PlanType.FREE, used_storage_bytes=0)
         use_case = CheckStorageLimitUseCase(_StubSubscriptionRepo(entity))
-        # Should not raise
         use_case.execute(user_id=1, additional_bytes=100)
 
     def test_storage_exceeded_raises(self):
@@ -79,6 +78,33 @@ class CheckStorageLimitTests(TestCase):
         use_case = CheckStorageLimitUseCase(_StubSubscriptionRepo(entity))
         with self.assertRaises(StorageLimitExceeded):
             use_case.execute(user_id=1, additional_bytes=1)
+
+    def test_storage_lite_within_limit_does_not_raise(self):
+        entity = _make_subscription(plan=PlanType.LITE, used_storage_bytes=0)
+        use_case = CheckStorageLimitUseCase(_StubSubscriptionRepo(entity))
+        use_case.execute(user_id=1, additional_bytes=10 * 1024 ** 3)
+
+    def test_storage_lite_exceeded_raises(self):
+        entity = _make_subscription(plan=PlanType.LITE, used_storage_bytes=10 * 1024 ** 3)
+        use_case = CheckStorageLimitUseCase(_StubSubscriptionRepo(entity))
+        with self.assertRaises(StorageLimitExceeded):
+            use_case.execute(user_id=1, additional_bytes=1)
+
+    def test_storage_standard_within_limit_does_not_raise(self):
+        entity = _make_subscription(plan=PlanType.STANDARD, used_storage_bytes=0)
+        use_case = CheckStorageLimitUseCase(_StubSubscriptionRepo(entity))
+        use_case.execute(user_id=1, additional_bytes=50 * 1024 ** 3)
+
+    def test_storage_standard_exceeded_raises(self):
+        entity = _make_subscription(plan=PlanType.STANDARD, used_storage_bytes=50 * 1024 ** 3)
+        use_case = CheckStorageLimitUseCase(_StubSubscriptionRepo(entity))
+        with self.assertRaises(StorageLimitExceeded):
+            use_case.execute(user_id=1, additional_bytes=1)
+
+    def test_storage_enterprise_unlimited_does_not_raise(self):
+        entity = _make_subscription(plan=PlanType.ENTERPRISE, used_storage_bytes=100 * 1024 ** 3)
+        use_case = CheckStorageLimitUseCase(_StubSubscriptionRepo(entity))
+        use_case.execute(user_id=1, additional_bytes=100 * 1024 ** 3)
 
 
 class CheckProcessingLimitTests(TestCase):
@@ -96,6 +122,36 @@ class CheckProcessingLimitTests(TestCase):
         with self.assertRaises(ProcessingLimitExceeded):
             use_case.execute(user_id=1, additional_seconds=1)
 
+    def test_processing_lite_within_limit_does_not_raise(self):
+        entity = _make_subscription(plan=PlanType.LITE, used_processing_seconds=0)
+        use_case = CheckProcessingLimitUseCase(_StubSubscriptionRepo(entity))
+        use_case.execute(user_id=1, additional_seconds=120 * 60)
+
+    def test_processing_lite_exceeded_raises(self):
+        entity = _make_subscription(plan=PlanType.LITE, used_processing_seconds=120 * 60)
+        use_case = CheckProcessingLimitUseCase(_StubSubscriptionRepo(entity))
+        with self.assertRaises(ProcessingLimitExceeded):
+            use_case.execute(user_id=1, additional_seconds=1)
+
+    def test_processing_standard_within_limit_does_not_raise(self):
+        entity = _make_subscription(plan=PlanType.STANDARD, used_processing_seconds=0)
+        use_case = CheckProcessingLimitUseCase(_StubSubscriptionRepo(entity))
+        use_case.execute(user_id=1, additional_seconds=600 * 60)
+
+    def test_processing_standard_exceeded_raises(self):
+        entity = _make_subscription(plan=PlanType.STANDARD, used_processing_seconds=600 * 60)
+        use_case = CheckProcessingLimitUseCase(_StubSubscriptionRepo(entity))
+        with self.assertRaises(ProcessingLimitExceeded):
+            use_case.execute(user_id=1, additional_seconds=1)
+
+    def test_processing_enterprise_unlimited_does_not_raise(self):
+        entity = _make_subscription(
+            plan=PlanType.ENTERPRISE, unlimited_processing_minutes=True,
+            used_processing_seconds=9999 * 60
+        )
+        use_case = CheckProcessingLimitUseCase(_StubSubscriptionRepo(entity))
+        use_case.execute(user_id=1, additional_seconds=9999 * 60)
+
 
 class CheckAiAnswersLimitTests(TestCase):
     def test_ai_answers_within_limit_does_not_raise(self):
@@ -108,3 +164,32 @@ class CheckAiAnswersLimitTests(TestCase):
         use_case = CheckAiAnswersLimitUseCase(_StubSubscriptionRepo(entity))
         with self.assertRaises(AiAnswersLimitExceeded):
             use_case.execute(user_id=1)
+
+    def test_ai_answers_lite_within_limit_does_not_raise(self):
+        entity = _make_subscription(plan=PlanType.LITE, used_ai_answers=2999)
+        use_case = CheckAiAnswersLimitUseCase(_StubSubscriptionRepo(entity))
+        use_case.execute(user_id=1)
+
+    def test_ai_answers_lite_exceeded_raises(self):
+        entity = _make_subscription(plan=PlanType.LITE, used_ai_answers=3000)
+        use_case = CheckAiAnswersLimitUseCase(_StubSubscriptionRepo(entity))
+        with self.assertRaises(AiAnswersLimitExceeded):
+            use_case.execute(user_id=1)
+
+    def test_ai_answers_standard_within_limit_does_not_raise(self):
+        entity = _make_subscription(plan=PlanType.STANDARD, used_ai_answers=6999)
+        use_case = CheckAiAnswersLimitUseCase(_StubSubscriptionRepo(entity))
+        use_case.execute(user_id=1)
+
+    def test_ai_answers_standard_at_limit_raises(self):
+        entity = _make_subscription(plan=PlanType.STANDARD, used_ai_answers=7000)
+        use_case = CheckAiAnswersLimitUseCase(_StubSubscriptionRepo(entity))
+        with self.assertRaises(AiAnswersLimitExceeded):
+            use_case.execute(user_id=1)
+
+    def test_ai_answers_enterprise_unlimited_does_not_raise(self):
+        entity = _make_subscription(
+            plan=PlanType.ENTERPRISE, unlimited_ai_answers=True, used_ai_answers=999999
+        )
+        use_case = CheckAiAnswersLimitUseCase(_StubSubscriptionRepo(entity))
+        use_case.execute(user_id=1)


### PR DESCRIPTION
## Summary

- Standard プランの AI 回答上限を 10,000 → 7,000 に引き下げ（価格据え置き）
- RAG 検索の取得チャンク数を k=6 → k=4 に削減（入力トークン削減）
- ChatOpenAI に `max_tokens=1024` を設定し、回答長を制御

## Changes

| ファイル | 変更内容 |
|---|---|
| `domain/billing/entities.py` | `PLAN_LIMITS[STANDARD]["ai_answers"]` 10000 → 7000 |
| `infrastructure/external/rag_service.py` | retriever `k=6` → `k=4` |
| `infrastructure/external/llm.py` | `ChatOpenAI(max_tokens=1024)` 追加 |

## Test plan

- [x] `docker compose run --rm backend python manage.py test app.domain.billing`
- [x] `docker compose run --rm backend python manage.py test app.use_cases.billing`
- [x] チャット応答が正常に返ることを手動確認
- [ ] Standard プランのユーザーが 7,000 回到達後に制限されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)