### PR TITLE
Cancel Stripe subscription on account deletion

### DIFF
--- a/backend/app/composition_root/auth.py
+++ b/backend/app/composition_root/auth.py
@@ -138,11 +138,26 @@ def get_delete_account_use_case() -> AccountDeletionUseCase:
 
 
 def get_delete_account_data_use_case() -> DeleteAccountDataUseCase:
+    import os
     from app.infrastructure.repositories.django_user_data_deletion_gateway import (
         DjangoUserDataDeletionGateway,
     )
 
-    return DeleteAccountDataUseCase(DjangoUserDataDeletionGateway())
+    billing_enabled = os.environ.get("BILLING_ENABLED", "false").lower() == "true"
+    if billing_enabled:
+        from app.infrastructure.billing.stripe_gateway import StripeBillingGateway
+        from app.infrastructure.repositories.django_subscription_repository import (
+            DjangoSubscriptionRepository,
+        )
+        return DeleteAccountDataUseCase(
+            user_data_deletion_gateway=DjangoUserDataDeletionGateway(),
+            subscription_repo=DjangoSubscriptionRepository(),
+            billing_gateway=StripeBillingGateway(),
+        )
+
+    return DeleteAccountDataUseCase(
+        user_data_deletion_gateway=DjangoUserDataDeletionGateway(),
+    )
 
 
 def get_list_api_keys_use_case() -> ListApiKeysUseCase:

--- a/backend/app/domain/billing/ports.py
+++ b/backend/app/domain/billing/ports.py
@@ -69,3 +69,6 @@ class BillingGateway(ABC):
 
     @abstractmethod
     def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> dict: ...
+
+    @abstractmethod
+    def cancel_subscription(self, subscription_id: str) -> None: ...

--- a/backend/app/infrastructure/billing/stripe_gateway.py
+++ b/backend/app/infrastructure/billing/stripe_gateway.py
@@ -74,3 +74,7 @@ class StripeBillingGateway(BillingGateway):
     def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> dict:
         stripe = self._get_stripe()
         return stripe.Webhook.construct_event(payload, sig_header, secret)
+
+    def cancel_subscription(self, subscription_id: str) -> None:
+        stripe = self._get_stripe()
+        stripe.Subscription.cancel(subscription_id)

--- a/backend/app/use_cases/auth/delete_account_data.py
+++ b/backend/app/use_cases/auth/delete_account_data.py
@@ -45,8 +45,5 @@ class DeleteAccountDataUseCase:
         entity = self._subscription_repo.get_by_user_id(user_id)
         if entity is None or not entity.stripe_subscription_id:
             return
-        try:
-            self._billing_gateway.cancel_subscription(entity.stripe_subscription_id)
-            logger.info("Stripe subscription %s cancelled for user %s", entity.stripe_subscription_id, user_id)
-        except Exception:
-            logger.warning("Failed to cancel Stripe subscription for user %s", user_id, exc_info=True)
+        self._billing_gateway.cancel_subscription(entity.stripe_subscription_id)
+        logger.info("Stripe subscription %s cancelled for user %s", entity.stripe_subscription_id, user_id)

--- a/backend/app/use_cases/auth/delete_account_data.py
+++ b/backend/app/use_cases/auth/delete_account_data.py
@@ -3,8 +3,10 @@ Use case: Delete all data associated with a user account (runs asynchronously).
 """
 
 import logging
+from typing import Optional
 
 from app.domain.auth.gateways import UserDataDeletionGateway
+from app.domain.billing.ports import BillingGateway, SubscriptionRepository
 
 logger = logging.getLogger(__name__)
 
@@ -12,18 +14,39 @@ logger = logging.getLogger(__name__)
 class DeleteAccountDataUseCase:
     """
     Orchestrates deletion of all user-owned data:
-    1. Delete all videos (including files)
-    2. Delete chat history
-    3. Delete video groups
-    4. Delete tags
+    1. Cancel Stripe subscription if active
+    2. Delete all videos (including files)
+    3. Delete chat history
+    4. Delete video groups
+    5. Delete tags
     """
 
-    def __init__(self, user_data_deletion_gateway: UserDataDeletionGateway):
+    def __init__(
+        self,
+        user_data_deletion_gateway: UserDataDeletionGateway,
+        subscription_repo: Optional[SubscriptionRepository] = None,
+        billing_gateway: Optional[BillingGateway] = None,
+    ):
         self.gateway = user_data_deletion_gateway
+        self._subscription_repo = subscription_repo
+        self._billing_gateway = billing_gateway
 
     def execute(self, user_id: int) -> None:
+        self._cancel_subscription_if_active(user_id)
         self.gateway.delete_all_videos_for_user(user_id)
         self.gateway.delete_chat_history_for_user(user_id)
         self.gateway.delete_video_groups_for_user(user_id)
         self.gateway.delete_tags_for_user(user_id)
         logger.info("Account data deleted for user %s", user_id)
+
+    def _cancel_subscription_if_active(self, user_id: int) -> None:
+        if self._subscription_repo is None or self._billing_gateway is None:
+            return
+        entity = self._subscription_repo.get_by_user_id(user_id)
+        if entity is None or not entity.stripe_subscription_id:
+            return
+        try:
+            self._billing_gateway.cancel_subscription(entity.stripe_subscription_id)
+            logger.info("Stripe subscription %s cancelled for user %s", entity.stripe_subscription_id, user_id)
+        except Exception:
+            logger.warning("Failed to cancel Stripe subscription for user %s", user_id, exc_info=True)

--- a/backend/app/use_cases/auth/tests/test_delete_account_data.py
+++ b/backend/app/use_cases/auth/tests/test_delete_account_data.py
@@ -1,0 +1,175 @@
+"""Unit tests for DeleteAccountDataUseCase — subscription cancellation on account deletion."""
+
+from typing import Optional
+from unittest import TestCase
+from unittest.mock import MagicMock, call
+
+from app.domain.billing.entities import PlanType, SubscriptionEntity
+from app.domain.billing.ports import BillingGateway, SubscriptionRepository
+from app.domain.auth.gateways import UserDataDeletionGateway
+from app.use_cases.auth.delete_account_data import DeleteAccountDataUseCase
+
+
+def _make_subscription(**kwargs) -> SubscriptionEntity:
+    defaults = {
+        "user_id": 1,
+        "plan": PlanType.LITE,
+        "stripe_customer_id": "cus_test",
+        "stripe_subscription_id": "sub_test",
+        "stripe_status": "active",
+        "current_period_end": None,
+        "cancel_at_period_end": False,
+        "used_storage_bytes": 0,
+        "used_processing_seconds": 0,
+        "used_ai_answers": 0,
+        "usage_period_start": None,
+        "custom_storage_gb": None,
+        "custom_processing_minutes": None,
+        "custom_ai_answers": None,
+        "unlimited_processing_minutes": False,
+        "unlimited_ai_answers": False,
+    }
+    defaults.update(kwargs)
+    return SubscriptionEntity(**defaults)  # type: ignore[arg-type]
+
+
+class _StubSubscriptionRepo(SubscriptionRepository):
+    def __init__(self, entity: Optional[SubscriptionEntity]):
+        self._entity = entity
+
+    def get_or_create(self, user_id: int) -> SubscriptionEntity:
+        return self._entity
+
+    def get_by_user_id(self, user_id: int) -> Optional[SubscriptionEntity]:
+        return self._entity
+
+    def get_by_stripe_customer_id(self, customer_id: str) -> Optional[SubscriptionEntity]:
+        return self._entity
+
+    def save(self, entity: SubscriptionEntity) -> SubscriptionEntity:
+        return entity
+
+    def create_stripe_customer(self, user_id: int, customer_id: str) -> SubscriptionEntity:
+        return self._entity
+
+    def reset_monthly_usage(self, user_id: int, period_start) -> None:
+        pass
+
+    def maybe_reset_monthly_usage(self, user_id: int) -> None:
+        pass
+
+
+class _StubBillingGateway(BillingGateway):
+    def __init__(self):
+        self.cancelled: list[str] = []
+
+    def get_or_create_customer(self, user_id, email, username) -> str:
+        return "cus_test"
+
+    def create_checkout_session(self, customer_id, price_id, success_url, cancel_url, user_id, plan):
+        return MagicMock(url="https://checkout.test")
+
+    def update_subscription(self, subscription_id, price_id) -> None:
+        pass
+
+    def create_billing_portal(self, customer_id, return_url):
+        return MagicMock(url="https://portal.test")
+
+    def retrieve_subscription(self, subscription_id) -> dict:
+        return {}
+
+    def verify_webhook(self, payload, sig_header, secret) -> dict:
+        return {}
+
+    def cancel_subscription(self, subscription_id: str) -> None:
+        self.cancelled.append(subscription_id)
+
+
+def _make_deletion_gateway() -> UserDataDeletionGateway:
+    gw = MagicMock(spec=UserDataDeletionGateway)
+    return gw
+
+
+class CancelSubscriptionOnDeleteTests(TestCase):
+    def test_cancels_stripe_subscription_when_active(self):
+        """アクティブなサブスクリプションがある場合、アカウント削除時にStripeをキャンセルする"""
+        entity = _make_subscription(stripe_subscription_id="sub_abc")
+        billing_gw = _StubBillingGateway()
+        use_case = DeleteAccountDataUseCase(
+            user_data_deletion_gateway=_make_deletion_gateway(),
+            subscription_repo=_StubSubscriptionRepo(entity),
+            billing_gateway=billing_gw,
+        )
+
+        use_case.execute(user_id=1)
+
+        self.assertEqual(billing_gw.cancelled, ["sub_abc"])
+
+    def test_skips_cancel_when_no_subscription_id(self):
+        """stripe_subscription_idがNullの場合はキャンセルしない（Freeプラン等）"""
+        entity = _make_subscription(plan=PlanType.FREE, stripe_subscription_id=None)
+        billing_gw = _StubBillingGateway()
+        use_case = DeleteAccountDataUseCase(
+            user_data_deletion_gateway=_make_deletion_gateway(),
+            subscription_repo=_StubSubscriptionRepo(entity),
+            billing_gateway=billing_gw,
+        )
+
+        use_case.execute(user_id=1)
+
+        self.assertEqual(billing_gw.cancelled, [])
+
+    def test_skips_cancel_when_no_subscription_record(self):
+        """サブスクリプションレコード自体がない場合はキャンセルしない"""
+        billing_gw = _StubBillingGateway()
+        use_case = DeleteAccountDataUseCase(
+            user_data_deletion_gateway=_make_deletion_gateway(),
+            subscription_repo=_StubSubscriptionRepo(None),
+            billing_gateway=billing_gw,
+        )
+
+        use_case.execute(user_id=1)
+
+        self.assertEqual(billing_gw.cancelled, [])
+
+    def test_skips_cancel_when_billing_not_configured(self):
+        """billing_gateway/subscription_repoがNoneの場合（billing無効環境）はキャンセルしない"""
+        use_case = DeleteAccountDataUseCase(
+            user_data_deletion_gateway=_make_deletion_gateway(),
+        )
+
+        use_case.execute(user_id=1)  # エラーなく完了すること
+
+    def test_continues_data_deletion_even_if_stripe_cancel_fails(self):
+        """Stripeキャンセルが失敗してもデータ削除は続行される"""
+        entity = _make_subscription(stripe_subscription_id="sub_fail")
+        billing_gw = MagicMock(spec=BillingGateway)
+        billing_gw.cancel_subscription.side_effect = Exception("Stripe error")
+
+        deletion_gw = _make_deletion_gateway()
+        use_case = DeleteAccountDataUseCase(
+            user_data_deletion_gateway=deletion_gw,
+            subscription_repo=_StubSubscriptionRepo(entity),
+            billing_gateway=billing_gw,
+        )
+
+        use_case.execute(user_id=1)  # エラーで中断しないこと
+
+        deletion_gw.delete_all_videos_for_user.assert_called_once_with(1)
+        deletion_gw.delete_chat_history_for_user.assert_called_once_with(1)
+        deletion_gw.delete_video_groups_for_user.assert_called_once_with(1)
+        deletion_gw.delete_tags_for_user.assert_called_once_with(1)
+
+    def test_all_data_deletion_methods_called(self):
+        """サブスクリプションなしでも全データ削除メソッドが呼ばれる"""
+        deletion_gw = _make_deletion_gateway()
+        use_case = DeleteAccountDataUseCase(
+            user_data_deletion_gateway=deletion_gw,
+        )
+
+        use_case.execute(user_id=42)
+
+        deletion_gw.delete_all_videos_for_user.assert_called_once_with(42)
+        deletion_gw.delete_chat_history_for_user.assert_called_once_with(42)
+        deletion_gw.delete_video_groups_for_user.assert_called_once_with(42)
+        deletion_gw.delete_tags_for_user.assert_called_once_with(42)

--- a/backend/app/use_cases/auth/tests/test_delete_account_data.py
+++ b/backend/app/use_cases/auth/tests/test_delete_account_data.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from unittest import TestCase
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 from app.domain.billing.entities import PlanType, SubscriptionEntity
 from app.domain.billing.ports import BillingGateway, SubscriptionRepository

--- a/backend/app/use_cases/auth/tests/test_delete_account_data.py
+++ b/backend/app/use_cases/auth/tests/test_delete_account_data.py
@@ -140,8 +140,8 @@ class CancelSubscriptionOnDeleteTests(TestCase):
 
         use_case.execute(user_id=1)  # エラーなく完了すること
 
-    def test_continues_data_deletion_even_if_stripe_cancel_fails(self):
-        """Stripeキャンセルが失敗してもデータ削除は続行される"""
+    def test_blocks_deletion_if_stripe_cancel_fails(self):
+        """Stripeキャンセルが失敗した場合、アカウント削除をブロックする（課金継続を防ぐ）"""
         entity = _make_subscription(stripe_subscription_id="sub_fail")
         billing_gw = MagicMock(spec=BillingGateway)
         billing_gw.cancel_subscription.side_effect = Exception("Stripe error")
@@ -153,12 +153,11 @@ class CancelSubscriptionOnDeleteTests(TestCase):
             billing_gateway=billing_gw,
         )
 
-        use_case.execute(user_id=1)  # エラーで中断しないこと
+        with self.assertRaises(Exception):
+            use_case.execute(user_id=1)
 
-        deletion_gw.delete_all_videos_for_user.assert_called_once_with(1)
-        deletion_gw.delete_chat_history_for_user.assert_called_once_with(1)
-        deletion_gw.delete_video_groups_for_user.assert_called_once_with(1)
-        deletion_gw.delete_tags_for_user.assert_called_once_with(1)
+        deletion_gw.delete_all_videos_for_user.assert_not_called()
+        deletion_gw.delete_chat_history_for_user.assert_not_called()
 
     def test_all_data_deletion_methods_called(self):
         """サブスクリプションなしでも全データ削除メソッドが呼ばれる"""

--- a/backend/app/use_cases/auth/tests/test_delete_account_data.py
+++ b/backend/app/use_cases/auth/tests/test_delete_account_data.py
@@ -38,6 +38,7 @@ class _StubSubscriptionRepo(SubscriptionRepository):
         self._entity = entity
 
     def get_or_create(self, user_id: int) -> SubscriptionEntity:
+        assert self._entity is not None
         return self._entity
 
     def get_by_user_id(self, user_id: int) -> Optional[SubscriptionEntity]:
@@ -50,6 +51,7 @@ class _StubSubscriptionRepo(SubscriptionRepository):
         return entity
 
     def create_stripe_customer(self, user_id: int, customer_id: str) -> SubscriptionEntity:
+        assert self._entity is not None
         return self._entity
 
     def reset_monthly_usage(self, user_id: int, period_start) -> None:

--- a/backend/app/use_cases/billing/tests/test_create_checkout_session.py
+++ b/backend/app/use_cases/billing/tests/test_create_checkout_session.py
@@ -93,6 +93,9 @@ class _StubBillingGateway(BillingGateway):
     def verify_webhook(self, payload, sig_header, secret) -> dict:
         return {}
 
+    def cancel_subscription(self, subscription_id: str) -> None:
+        pass
+
 
 class _StubUserRepo:
     def get_by_id(self, user_id: int):

--- a/backend/app/use_cases/billing/tests/test_handle_webhook.py
+++ b/backend/app/use_cases/billing/tests/test_handle_webhook.py
@@ -84,6 +84,9 @@ class _StubBillingGateway(BillingGateway):
     def verify_webhook(self, payload, sig_header, secret) -> dict:
         return self._event
 
+    def cancel_subscription(self, subscription_id: str) -> None:
+        pass
+
 
 PRICE_MAP = {"price_lite_001": "lite", "price_standard_001": "standard"}
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,4 +24,4 @@ redis>=7.0.0
 scikit-learn>=1.7.2
 uvicorn-worker>=0.4.0
 uvicorn>=0.38.0
-stripe>=14.4.1
+stripe==14.4.1


### PR DESCRIPTION
## Summary

- アカウント削除時にStripeのサブスクリプションを自動キャンセルする処理を追加
- `BillingGateway` ポートに `cancel_subscription()` を追加し、`StripeBillingGateway` で実装
- `DeleteAccountDataUseCase` に `subscription_repo` と `billing_gateway` を注入し、データ削除前にサブスクリプションをキャンセル
- Stripeキャンセルが失敗した場合はアカウント削除をブロックする（課金継続を防ぐ）
- `stripe==14.4.1` にピン留めしてDockerとLambda環境のバージョンを統一

## 動作仕様

| ケース | 動作 |
|---|---|
| アクティブなサブスクリプションあり | Stripeキャンセル → データ削除 |
| Stripeキャンセルが失敗 | 例外を raise してアカウント削除をブロック（課金継続防止） |
| Freeプラン / subscription_id なし | キャンセルスキップ → データ削除 |
| `BILLING_ENABLED=false` 環境 | キャンセルスキップ → データ削除 |

## Test plan

- [x] `test_cancels_stripe_subscription_when_active` — アクティブなサブスクリプションがキャンセルされる
- [x] `test_blocks_deletion_if_stripe_cancel_fails` — Stripeエラー時はアカウント削除をブロックし、データ削除も実行しない
- [x] `test_skips_cancel_when_no_subscription_id` — Freeプランはスキップ
- [x] `test_skips_cancel_when_no_subscription_record` — サブスクリプションレコードなしはスキップ
- [x] `test_skips_cancel_when_billing_not_configured` — billing無効環境はスキップ
- [x] `test_all_data_deletion_methods_called` — 全データ削除メソッドが呼ばれる
- [x] 既存910テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)