### PR TITLE
Stripe v15 webhook境界をDTO化し、to_dict依存を排除

### DIFF
--- a/backend/app/domain/billing/ports.py
+++ b/backend/app/domain/billing/ports.py
@@ -11,6 +11,18 @@ class SessionResult:
     url: str
 
 
+@dataclass
+class WebhookEvent:
+    """Domain representation of a Stripe webhook event.
+
+    Isolates the rest of the codebase from stripe's StripeObject type.
+    type: the Stripe event type string (e.g. "customer.subscription.created")
+    data_object: the event's data.object as a plain dict
+    """
+    type: str
+    data_object: dict
+
+
 class SubscriptionRepository(ABC):
     @abstractmethod
     def get_or_create(self, user_id: int) -> SubscriptionEntity: ...
@@ -68,7 +80,7 @@ class BillingGateway(ABC):
     def retrieve_subscription(self, subscription_id: str) -> dict: ...
 
     @abstractmethod
-    def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> dict: ...
+    def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> WebhookEvent: ...
 
     @abstractmethod
     def cancel_subscription(self, subscription_id: str) -> None: ...

--- a/backend/app/domain/billing/ports.py
+++ b/backend/app/domain/billing/ports.py
@@ -17,10 +17,22 @@ class WebhookEvent:
 
     Isolates the rest of the codebase from stripe's StripeObject type.
     type: the Stripe event type string (e.g. "customer.subscription.created")
-    data_object: the event's data.object as a plain dict
+    data_object: the normalized subscription data used by the domain
     """
     type: str
-    data_object: dict
+    data_object: "SubscriptionEventData"
+
+
+@dataclass
+class SubscriptionEventData:
+    """Normalized subscription data extracted from a Stripe webhook."""
+
+    id: str
+    customer: str
+    status: str
+    cancel_at_period_end: bool
+    current_period_end: Optional[int]
+    price_id: Optional[str]
 
 
 class SubscriptionRepository(ABC):
@@ -75,9 +87,6 @@ class BillingGateway(ABC):
 
     @abstractmethod
     def create_billing_portal(self, customer_id: str, return_url: str) -> SessionResult: ...
-
-    @abstractmethod
-    def retrieve_subscription(self, subscription_id: str) -> dict: ...
 
     @abstractmethod
     def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> WebhookEvent: ...

--- a/backend/app/infrastructure/billing/stripe_gateway.py
+++ b/backend/app/infrastructure/billing/stripe_gateway.py
@@ -1,6 +1,6 @@
 import os
 
-from app.domain.billing.ports import BillingGateway, SessionResult
+from app.domain.billing.ports import BillingGateway, SessionResult, WebhookEvent
 
 
 class StripeBillingGateway(BillingGateway):
@@ -72,10 +72,13 @@ class StripeBillingGateway(BillingGateway):
         result = stripe.Subscription.retrieve(subscription_id)
         return result.to_dict()
 
-    def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> dict:
+    def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> WebhookEvent:
         stripe = self._get_stripe()
         event = stripe.Webhook.construct_event(payload, sig_header, secret)
-        return event.to_dict()
+        return WebhookEvent(
+            type=event.type,
+            data_object=event.data.object.to_dict(),
+        )
 
     def cancel_subscription(self, subscription_id: str) -> None:
         stripe = self._get_stripe()

--- a/backend/app/infrastructure/billing/stripe_gateway.py
+++ b/backend/app/infrastructure/billing/stripe_gateway.py
@@ -74,7 +74,8 @@ class StripeBillingGateway(BillingGateway):
 
     def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> dict:
         stripe = self._get_stripe()
-        return stripe.Webhook.construct_event(payload, sig_header, secret)
+        event = stripe.Webhook.construct_event(payload, sig_header, secret)
+        return event.to_dict()
 
     def cancel_subscription(self, subscription_id: str) -> None:
         stripe = self._get_stripe()

--- a/backend/app/infrastructure/billing/stripe_gateway.py
+++ b/backend/app/infrastructure/billing/stripe_gateway.py
@@ -52,10 +52,10 @@ class StripeBillingGateway(BillingGateway):
     def update_subscription(self, subscription_id: str, price_id: str) -> None:
         stripe = self._get_stripe()
         stripe_sub = stripe.Subscription.retrieve(subscription_id)
-        current_item = stripe_sub["items"]["data"][0]
+        current_item = stripe_sub.items.data[0]
         stripe.Subscription.modify(
             subscription_id,
-            items=[{"id": current_item["id"], "price": price_id}],
+            items=[{"id": current_item.id, "price": price_id}],
             proration_behavior="create_prorations",
         )
 
@@ -69,7 +69,8 @@ class StripeBillingGateway(BillingGateway):
 
     def retrieve_subscription(self, subscription_id: str) -> dict:
         stripe = self._get_stripe()
-        return stripe.Subscription.retrieve(subscription_id)
+        result = stripe.Subscription.retrieve(subscription_id)
+        return result.to_dict()
 
     def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> dict:
         stripe = self._get_stripe()

--- a/backend/app/infrastructure/billing/stripe_gateway.py
+++ b/backend/app/infrastructure/billing/stripe_gateway.py
@@ -1,6 +1,11 @@
 import os
 
-from app.domain.billing.ports import BillingGateway, SessionResult, WebhookEvent
+from app.domain.billing.ports import (
+    BillingGateway,
+    SessionResult,
+    SubscriptionEventData,
+    WebhookEvent,
+)
 
 
 class StripeBillingGateway(BillingGateway):
@@ -67,17 +72,22 @@ class StripeBillingGateway(BillingGateway):
         )
         return SessionResult(url=result.url)
 
-    def retrieve_subscription(self, subscription_id: str) -> dict:
-        stripe = self._get_stripe()
-        result = stripe.Subscription.retrieve(subscription_id)
-        return result.to_dict()
-
     def verify_webhook(self, payload: bytes, sig_header: str, secret: str) -> WebhookEvent:
         stripe = self._get_stripe()
         event = stripe.Webhook.construct_event(payload, sig_header, secret)
+        subscription = event.data.object
+        items = subscription.items.data if getattr(subscription, "items", None) else []
+        price_id = items[0].price.id if items else None
         return WebhookEvent(
             type=event.type,
-            data_object=event.data.object.to_dict(),
+            data_object=SubscriptionEventData(
+                id=getattr(subscription, "id", ""),
+                customer=getattr(subscription, "customer", ""),
+                status=getattr(subscription, "status", ""),
+                cancel_at_period_end=getattr(subscription, "cancel_at_period_end", False),
+                current_period_end=getattr(subscription, "current_period_end", None),
+                price_id=price_id,
+            ),
         )
 
     def cancel_subscription(self, subscription_id: str) -> None:

--- a/backend/app/infrastructure/billing/tests/test_stripe_gateway.py
+++ b/backend/app/infrastructure/billing/tests/test_stripe_gateway.py
@@ -1,0 +1,123 @@
+"""Unit tests for StripeBillingGateway — stripe-python v15 compatibility.
+
+stripe v15 dropped dict inheritance from StripeObject, so bracket-style
+access (obj["key"]) no longer works.  These tests enforce that the gateway
+uses attribute (dot) access only, by providing a stub StripeObject that
+intentionally raises TypeError on __getitem__.
+"""
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers — simulate v15 StripeObject (no dict inheritance)
+# ---------------------------------------------------------------------------
+
+class _V15StripeObject:
+    """Minimal stub that mimics stripe v15 StripeObject behaviour.
+
+    Attribute access works; subscript access raises TypeError, just like
+    the real v15 object would for code that still uses bracket notation.
+    to_dict() returns a plain dict (as the real v15 API provides).
+    """
+
+    def __init__(self, **attrs):
+        for k, v in attrs.items():
+            object.__setattr__(self, k, v)
+
+    def __getitem__(self, key):
+        raise TypeError(
+            f"StripeObject does not support item access in stripe v15. "
+            f"Use attribute access (obj.{key}) instead."
+        )
+
+    def to_dict(self):
+        return {k: v for k, v in self.__dict__.items()}
+
+
+def _make_subscription_obj(subscription_id="sub_test", item_id="si_test"):
+    """Build a v15-style Subscription object with nested items."""
+    item = _V15StripeObject(id=item_id)
+    items_list = _V15StripeObject(data=[item])
+    return _V15StripeObject(
+        id=subscription_id,
+        items=items_list,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: update_subscription
+# ---------------------------------------------------------------------------
+
+class UpdateSubscriptionV15Tests(TestCase):
+    """update_subscription must use dot-notation (not bracket access) on StripeObject."""
+
+    def _make_gateway(self):
+        from app.infrastructure.billing.stripe_gateway import StripeBillingGateway
+        gw = StripeBillingGateway.__new__(StripeBillingGateway)
+        gw._stripe = MagicMock()
+        return gw
+
+    def test_uses_dot_notation_to_access_items(self):
+        """Gateway must read current_item via .items.data[0], not ["items"]["data"][0]."""
+        gw = self._make_gateway()
+        stripe_sub = _make_subscription_obj(subscription_id="sub_abc", item_id="si_xyz")
+        gw._stripe.Subscription.retrieve.return_value = stripe_sub
+
+        # Should NOT raise TypeError (which would happen with bracket access)
+        gw.update_subscription("sub_abc", "price_new")
+
+        gw._stripe.Subscription.modify.assert_called_once_with(
+            "sub_abc",
+            items=[{"id": "si_xyz", "price": "price_new"}],
+            proration_behavior="create_prorations",
+        )
+
+    def test_item_id_from_dot_notation(self):
+        """The item id passed to modify must come from current_item.id, not current_item["id"]."""
+        gw = self._make_gateway()
+        stripe_sub = _make_subscription_obj(item_id="si_correct")
+        gw._stripe.Subscription.retrieve.return_value = stripe_sub
+
+        gw.update_subscription("sub_x", "price_y")
+
+        call_kwargs = gw._stripe.Subscription.modify.call_args
+        items_arg = call_kwargs[1]["items"]
+        self.assertEqual(items_arg[0]["id"], "si_correct")
+
+
+# ---------------------------------------------------------------------------
+# Tests: retrieve_subscription
+# ---------------------------------------------------------------------------
+
+class RetrieveSubscriptionV15Tests(TestCase):
+    """retrieve_subscription must return a plain dict, not a StripeObject."""
+
+    def _make_gateway(self):
+        from app.infrastructure.billing.stripe_gateway import StripeBillingGateway
+        gw = StripeBillingGateway.__new__(StripeBillingGateway)
+        gw._stripe = MagicMock()
+        return gw
+
+    def test_returns_plain_dict(self):
+        """retrieve_subscription must convert the StripeObject to a plain dict via to_dict()."""
+        gw = self._make_gateway()
+        stripe_obj = _V15StripeObject(id="sub_test", status="active")
+        gw._stripe.Subscription.retrieve.return_value = stripe_obj
+
+        result = gw.retrieve_subscription("sub_test")
+
+        self.assertIsInstance(result, dict,
+            "retrieve_subscription must return a plain dict, not a StripeObject")
+
+    def test_dict_contains_expected_fields(self):
+        """The returned dict must preserve id and status from the StripeObject."""
+        gw = self._make_gateway()
+        stripe_obj = _V15StripeObject(id="sub_test", status="active")
+        gw._stripe.Subscription.retrieve.return_value = stripe_obj
+
+        result = gw.retrieve_subscription("sub_test")
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["id"], "sub_test")
+        self.assertEqual(result["status"], "active")

--- a/backend/app/infrastructure/billing/tests/test_stripe_gateway.py
+++ b/backend/app/infrastructure/billing/tests/test_stripe_gateway.py
@@ -1,4 +1,4 @@
-"""Unit tests for StripeBillingGateway — stripe-python v15 compatibility.
+"""Unit tests for StripeBillingGateway stripe-python v15 compatibility.
 
 stripe v15 dropped dict inheritance from StripeObject, so bracket-style
 access (obj["key"]) no longer works.  These tests enforce that the gateway
@@ -18,7 +18,6 @@ class _V15StripeObject:
 
     Attribute access works; subscript access raises TypeError, just like
     the real v15 object would for code that still uses bracket notation.
-    to_dict() returns a plain dict (as the real v15 API provides).
     """
 
     def __init__(self, **attrs):
@@ -30,10 +29,6 @@ class _V15StripeObject:
             f"StripeObject does not support item access in stripe v15. "
             f"Use attribute access (obj.{key}) instead."
         )
-
-    def to_dict(self):
-        return {k: v for k, v in self.__dict__.items()}
-
 
 def _make_subscription_obj(subscription_id="sub_test", item_id="si_test"):
     """Build a v15-style Subscription object with nested items."""
@@ -87,43 +82,6 @@ class UpdateSubscriptionV15Tests(TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Tests: retrieve_subscription
-# ---------------------------------------------------------------------------
-
-class RetrieveSubscriptionV15Tests(TestCase):
-    """retrieve_subscription must return a plain dict, not a StripeObject."""
-
-    def _make_gateway(self):
-        from app.infrastructure.billing.stripe_gateway import StripeBillingGateway
-        gw = StripeBillingGateway.__new__(StripeBillingGateway)
-        gw._stripe = MagicMock()
-        return gw
-
-    def test_returns_plain_dict(self):
-        """retrieve_subscription must convert the StripeObject to a plain dict via to_dict()."""
-        gw = self._make_gateway()
-        stripe_obj = _V15StripeObject(id="sub_test", status="active")
-        gw._stripe.Subscription.retrieve.return_value = stripe_obj
-
-        result = gw.retrieve_subscription("sub_test")
-
-        self.assertIsInstance(result, dict,
-            "retrieve_subscription must return a plain dict, not a StripeObject")
-
-    def test_dict_contains_expected_fields(self):
-        """The returned dict must preserve id and status from the StripeObject."""
-        gw = self._make_gateway()
-        stripe_obj = _V15StripeObject(id="sub_test", status="active")
-        gw._stripe.Subscription.retrieve.return_value = stripe_obj
-
-        result = gw.retrieve_subscription("sub_test")
-
-        self.assertIsInstance(result, dict)
-        self.assertEqual(result["id"], "sub_test")
-        self.assertEqual(result["status"], "active")
-
-
-# ---------------------------------------------------------------------------
 # Tests: verify_webhook
 # ---------------------------------------------------------------------------
 
@@ -162,15 +120,40 @@ class VerifyWebhookV15Tests(TestCase):
 
         self.assertEqual(result.type, "customer.subscription.updated")
 
-    def test_data_object_is_plain_dict(self):
-        """WebhookEvent.data_object must be a plain dict for use-case access."""
+    def test_data_object_is_subscription_event_data(self):
+        """WebhookEvent.data_object must be a typed DTO built via dot notation."""
         gw = self._make_gateway()
-        event_obj = self._make_event_obj("customer.subscription.deleted",
-                                         id="sub_3", customer="cus_test")
+        price = _V15StripeObject(id="price_lite_001")
+        item = _V15StripeObject(price=price)
+        items = _V15StripeObject(data=[item])
+        event_obj = self._make_event_obj(
+            "customer.subscription.deleted",
+            id="sub_3",
+            customer="cus_test",
+            status="canceled",
+            cancel_at_period_end=False,
+            current_period_end=None,
+            items=items,
+        )
         gw._stripe.Webhook.construct_event.return_value = event_obj
 
         result = gw.verify_webhook(b"payload", "sig", "whsec_test")
 
-        self.assertIsInstance(result.data_object, dict)
-        self.assertEqual(result.data_object["id"], "sub_3")
-        self.assertEqual(result.data_object["customer"], "cus_test")
+        self.assertEqual(result.data_object.id, "sub_3")
+        self.assertEqual(result.data_object.customer, "cus_test")
+        self.assertEqual(result.data_object.status, "canceled")
+        self.assertEqual(result.data_object.price_id, "price_lite_001")
+
+    def test_price_id_is_none_when_items_are_empty(self):
+        gw = self._make_gateway()
+        event_obj = self._make_event_obj(
+            "customer.subscription.deleted",
+            id="sub_4",
+            customer="cus_test",
+            items=_V15StripeObject(data=[]),
+        )
+        gw._stripe.Webhook.construct_event.return_value = event_obj
+
+        result = gw.verify_webhook(b"payload", "sig", "whsec_test")
+
+        self.assertIsNone(result.data_object.price_id)

--- a/backend/app/infrastructure/billing/tests/test_stripe_gateway.py
+++ b/backend/app/infrastructure/billing/tests/test_stripe_gateway.py
@@ -128,7 +128,7 @@ class RetrieveSubscriptionV15Tests(TestCase):
 # ---------------------------------------------------------------------------
 
 class VerifyWebhookV15Tests(TestCase):
-    """verify_webhook must return a plain dict so callers can use .get()."""
+    """verify_webhook must return a WebhookEvent domain DTO, not a raw StripeObject."""
 
     def _make_gateway(self):
         from app.infrastructure.billing.stripe_gateway import StripeBillingGateway
@@ -136,24 +136,41 @@ class VerifyWebhookV15Tests(TestCase):
         gw._stripe = MagicMock()
         return gw
 
-    def test_returns_plain_dict(self):
-        """verify_webhook must convert the Event StripeObject to a plain dict."""
+    def _make_event_obj(self, event_type, **sub_attrs):
+        data_obj = _V15StripeObject(**sub_attrs)
+        data = _V15StripeObject(object=data_obj)
+        return _V15StripeObject(type=event_type, data=data)
+
+    def test_returns_webhook_event_dto(self):
+        """verify_webhook must return a WebhookEvent, not a raw StripeObject or dict."""
+        from app.domain.billing.ports import WebhookEvent
         gw = self._make_gateway()
-        event_obj = _V15StripeObject(type="customer.subscription.created")
+        event_obj = self._make_event_obj("customer.subscription.created", id="sub_1")
         gw._stripe.Webhook.construct_event.return_value = event_obj
 
         result = gw.verify_webhook(b"payload", "sig", "whsec_test")
 
-        self.assertIsInstance(result, dict,
-            "verify_webhook must return a plain dict, not a StripeObject")
+        self.assertIsInstance(result, WebhookEvent)
 
-    def test_dict_allows_get_access(self):
-        """Callers must be able to call .get('type') on the returned value."""
+    def test_event_type_extracted_via_dot_notation(self):
+        """WebhookEvent.type must come from event.type (dot notation), not event['type']."""
         gw = self._make_gateway()
-        event_obj = _V15StripeObject(type="customer.subscription.updated")
+        event_obj = self._make_event_obj("customer.subscription.updated", id="sub_2")
         gw._stripe.Webhook.construct_event.return_value = event_obj
 
         result = gw.verify_webhook(b"payload", "sig", "whsec_test")
 
-        # This is how handle_webhook.py reads the event — must not raise AttributeError
-        self.assertEqual(result.get("type"), "customer.subscription.updated")
+        self.assertEqual(result.type, "customer.subscription.updated")
+
+    def test_data_object_is_plain_dict(self):
+        """WebhookEvent.data_object must be a plain dict for use-case access."""
+        gw = self._make_gateway()
+        event_obj = self._make_event_obj("customer.subscription.deleted",
+                                         id="sub_3", customer="cus_test")
+        gw._stripe.Webhook.construct_event.return_value = event_obj
+
+        result = gw.verify_webhook(b"payload", "sig", "whsec_test")
+
+        self.assertIsInstance(result.data_object, dict)
+        self.assertEqual(result.data_object["id"], "sub_3")
+        self.assertEqual(result.data_object["customer"], "cus_test")

--- a/backend/app/infrastructure/billing/tests/test_stripe_gateway.py
+++ b/backend/app/infrastructure/billing/tests/test_stripe_gateway.py
@@ -121,3 +121,39 @@ class RetrieveSubscriptionV15Tests(TestCase):
         self.assertIsInstance(result, dict)
         self.assertEqual(result["id"], "sub_test")
         self.assertEqual(result["status"], "active")
+
+
+# ---------------------------------------------------------------------------
+# Tests: verify_webhook
+# ---------------------------------------------------------------------------
+
+class VerifyWebhookV15Tests(TestCase):
+    """verify_webhook must return a plain dict so callers can use .get()."""
+
+    def _make_gateway(self):
+        from app.infrastructure.billing.stripe_gateway import StripeBillingGateway
+        gw = StripeBillingGateway.__new__(StripeBillingGateway)
+        gw._stripe = MagicMock()
+        return gw
+
+    def test_returns_plain_dict(self):
+        """verify_webhook must convert the Event StripeObject to a plain dict."""
+        gw = self._make_gateway()
+        event_obj = _V15StripeObject(type="customer.subscription.created")
+        gw._stripe.Webhook.construct_event.return_value = event_obj
+
+        result = gw.verify_webhook(b"payload", "sig", "whsec_test")
+
+        self.assertIsInstance(result, dict,
+            "verify_webhook must return a plain dict, not a StripeObject")
+
+    def test_dict_allows_get_access(self):
+        """Callers must be able to call .get('type') on the returned value."""
+        gw = self._make_gateway()
+        event_obj = _V15StripeObject(type="customer.subscription.updated")
+        gw._stripe.Webhook.construct_event.return_value = event_obj
+
+        result = gw.verify_webhook(b"payload", "sig", "whsec_test")
+
+        # This is how handle_webhook.py reads the event — must not raise AttributeError
+        self.assertEqual(result.get("type"), "customer.subscription.updated")

--- a/backend/app/use_cases/auth/tests/test_delete_account_data.py
+++ b/backend/app/use_cases/auth/tests/test_delete_account_data.py
@@ -5,7 +5,12 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from app.domain.billing.entities import PlanType, SubscriptionEntity
-from app.domain.billing.ports import BillingGateway, SubscriptionRepository, WebhookEvent
+from app.domain.billing.ports import (
+    BillingGateway,
+    SubscriptionEventData,
+    SubscriptionRepository,
+    WebhookEvent,
+)
 from app.domain.auth.gateways import UserDataDeletionGateway
 from app.use_cases.auth.delete_account_data import DeleteAccountDataUseCase
 
@@ -77,11 +82,18 @@ class _StubBillingGateway(BillingGateway):
     def create_billing_portal(self, customer_id, return_url):
         return MagicMock(url="https://portal.test")
 
-    def retrieve_subscription(self, subscription_id) -> dict:
-        return {}
-
     def verify_webhook(self, payload, sig_header, secret) -> WebhookEvent:
-        return WebhookEvent(type="", data_object={})
+        return WebhookEvent(
+            type="",
+            data_object=SubscriptionEventData(
+                id="",
+                customer="",
+                status="",
+                cancel_at_period_end=False,
+                current_period_end=None,
+                price_id=None,
+            ),
+        )
 
     def cancel_subscription(self, subscription_id: str) -> None:
         self.cancelled.append(subscription_id)

--- a/backend/app/use_cases/auth/tests/test_delete_account_data.py
+++ b/backend/app/use_cases/auth/tests/test_delete_account_data.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from app.domain.billing.entities import PlanType, SubscriptionEntity
-from app.domain.billing.ports import BillingGateway, SubscriptionRepository
+from app.domain.billing.ports import BillingGateway, SubscriptionRepository, WebhookEvent
 from app.domain.auth.gateways import UserDataDeletionGateway
 from app.use_cases.auth.delete_account_data import DeleteAccountDataUseCase
 
@@ -80,8 +80,8 @@ class _StubBillingGateway(BillingGateway):
     def retrieve_subscription(self, subscription_id) -> dict:
         return {}
 
-    def verify_webhook(self, payload, sig_header, secret) -> dict:
-        return {}
+    def verify_webhook(self, payload, sig_header, secret) -> WebhookEvent:
+        return WebhookEvent(type="", data_object={})
 
     def cancel_subscription(self, subscription_id: str) -> None:
         self.cancelled.append(subscription_id)

--- a/backend/app/use_cases/billing/handle_webhook.py
+++ b/backend/app/use_cases/billing/handle_webhook.py
@@ -1,5 +1,5 @@
 from app.domain.billing.entities import PlanType
-from app.domain.billing.ports import BillingGateway, SubscriptionRepository
+from app.domain.billing.ports import BillingGateway, SubscriptionRepository, WebhookEvent
 
 
 class HandleWebhookUseCase:
@@ -23,17 +23,14 @@ class HandleWebhookUseCase:
         )
         self._handle_event(event)
 
-    def _handle_event(self, event: dict) -> None:
-        event_type = event.get("type", "")
-        data_object = event.get("data", {}).get("object", {})
-
-        if event_type in (
+    def _handle_event(self, event: WebhookEvent) -> None:
+        if event.type in (
             "customer.subscription.created",
             "customer.subscription.updated",
         ):
-            self._sync_subscription(data_object)
-        elif event_type == "customer.subscription.deleted":
-            self._revert_to_free(data_object)
+            self._sync_subscription(event.data_object)
+        elif event.type == "customer.subscription.deleted":
+            self._revert_to_free(event.data_object)
 
     def _sync_subscription(self, subscription_data: dict) -> None:
         customer_id = subscription_data.get("customer")

--- a/backend/app/use_cases/billing/handle_webhook.py
+++ b/backend/app/use_cases/billing/handle_webhook.py
@@ -1,5 +1,10 @@
 from app.domain.billing.entities import PlanType
-from app.domain.billing.ports import BillingGateway, SubscriptionRepository, WebhookEvent
+from app.domain.billing.ports import (
+    BillingGateway,
+    SubscriptionEventData,
+    SubscriptionRepository,
+    WebhookEvent,
+)
 
 
 class HandleWebhookUseCase:
@@ -32,8 +37,8 @@ class HandleWebhookUseCase:
         elif event.type == "customer.subscription.deleted":
             self._revert_to_free(event.data_object)
 
-    def _sync_subscription(self, subscription_data: dict) -> None:
-        customer_id = subscription_data.get("customer")
+    def _sync_subscription(self, subscription_data: SubscriptionEventData) -> None:
+        customer_id = subscription_data.customer
         if not customer_id:
             return
 
@@ -41,25 +46,21 @@ class HandleWebhookUseCase:
         if entity is None:
             return
 
-        subscription_id = subscription_data.get("id", "")
-        status = subscription_data.get("status", "")
-        cancel_at_period_end = subscription_data.get("cancel_at_period_end", False)
+        subscription_id = subscription_data.id
+        status = subscription_data.status
+        cancel_at_period_end = subscription_data.cancel_at_period_end
 
-        # Get plan from price ID
-        items = subscription_data.get("items", {}).get("data", [])
         plan_type = entity.plan  # keep existing if not found
-        if items:
-            price_id = items[0].get("price", {}).get("id", "")
-            plan_name = self._price_map.get(price_id)
+        if subscription_data.price_id:
+            plan_name = self._price_map.get(subscription_data.price_id)
             if plan_name:
                 try:
                     plan_type = PlanType(plan_name)
                 except ValueError:
                     pass
 
-        # Get period end
         current_period_end = None
-        raw_end = subscription_data.get("current_period_end")
+        raw_end = subscription_data.current_period_end
         if raw_end:
             from datetime import datetime, timezone
             current_period_end = datetime.fromtimestamp(raw_end, tz=timezone.utc)
@@ -71,8 +72,8 @@ class HandleWebhookUseCase:
         entity.current_period_end = current_period_end
         self._subscription_repo.save(entity)
 
-    def _revert_to_free(self, subscription_data: dict) -> None:
-        customer_id = subscription_data.get("customer")
+    def _revert_to_free(self, subscription_data: SubscriptionEventData) -> None:
+        customer_id = subscription_data.customer
         if not customer_id:
             return
 

--- a/backend/app/use_cases/billing/tests/test_create_checkout_session.py
+++ b/backend/app/use_cases/billing/tests/test_create_checkout_session.py
@@ -5,7 +5,12 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from app.domain.billing.entities import PlanType, SubscriptionEntity
-from app.domain.billing.ports import BillingGateway, SubscriptionRepository, WebhookEvent
+from app.domain.billing.ports import (
+    BillingGateway,
+    SubscriptionEventData,
+    SubscriptionRepository,
+    WebhookEvent,
+)
 from app.use_cases.billing.create_checkout_session import CreateCheckoutSessionUseCase
 from app.use_cases.billing.exceptions import (
     BillingNotEnabled,
@@ -87,11 +92,18 @@ class _StubBillingGateway(BillingGateway):
         portal.url = "https://portal.test"
         return portal
 
-    def retrieve_subscription(self, subscription_id) -> dict:
-        return {}
-
     def verify_webhook(self, payload, sig_header, secret) -> WebhookEvent:
-        return WebhookEvent(type="", data_object={})
+        return WebhookEvent(
+            type="",
+            data_object=SubscriptionEventData(
+                id="",
+                customer="",
+                status="",
+                cancel_at_period_end=False,
+                current_period_end=None,
+                price_id=None,
+            ),
+        )
 
     def cancel_subscription(self, subscription_id: str) -> None:
         pass

--- a/backend/app/use_cases/billing/tests/test_create_checkout_session.py
+++ b/backend/app/use_cases/billing/tests/test_create_checkout_session.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from app.domain.billing.entities import PlanType, SubscriptionEntity
-from app.domain.billing.ports import BillingGateway, SubscriptionRepository
+from app.domain.billing.ports import BillingGateway, SubscriptionRepository, WebhookEvent
 from app.use_cases.billing.create_checkout_session import CreateCheckoutSessionUseCase
 from app.use_cases.billing.exceptions import (
     BillingNotEnabled,
@@ -90,8 +90,8 @@ class _StubBillingGateway(BillingGateway):
     def retrieve_subscription(self, subscription_id) -> dict:
         return {}
 
-    def verify_webhook(self, payload, sig_header, secret) -> dict:
-        return {}
+    def verify_webhook(self, payload, sig_header, secret) -> WebhookEvent:
+        return WebhookEvent(type="", data_object={})
 
     def cancel_subscription(self, subscription_id: str) -> None:
         pass

--- a/backend/app/use_cases/billing/tests/test_handle_webhook.py
+++ b/backend/app/use_cases/billing/tests/test_handle_webhook.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from app.domain.billing.entities import PlanType, SubscriptionEntity
-from app.domain.billing.ports import BillingGateway, SubscriptionRepository
+from app.domain.billing.ports import BillingGateway, SubscriptionRepository, WebhookEvent
 from app.use_cases.billing.handle_webhook import HandleWebhookUseCase
 
 
@@ -81,8 +81,11 @@ class _StubBillingGateway(BillingGateway):
     def retrieve_subscription(self, subscription_id) -> dict:
         return {}
 
-    def verify_webhook(self, payload, sig_header, secret) -> dict:
-        return self._event
+    def verify_webhook(self, payload, sig_header, secret) -> WebhookEvent:
+        return WebhookEvent(
+            type=self._event.get("type", ""),
+            data_object=self._event.get("data", {}).get("object", {}),
+        )
 
     def cancel_subscription(self, subscription_id: str) -> None:
         pass

--- a/backend/app/use_cases/billing/tests/test_handle_webhook.py
+++ b/backend/app/use_cases/billing/tests/test_handle_webhook.py
@@ -93,17 +93,27 @@ class _StubBillingGateway(BillingGateway):
 PRICE_MAP = {"price_lite_001": "lite", "price_standard_001": "standard"}
 
 
-def _make_event(event_type: str, **kwargs) -> WebhookEvent:
-    defaults = {
-        "id": "",
-        "customer": "",
-        "status": "",
-        "cancel_at_period_end": False,
-        "current_period_end": None,
-        "price_id": None,
-    }
-    defaults.update(kwargs)
-    return WebhookEvent(type=event_type, data_object=SubscriptionEventData(**defaults))
+def _make_event(
+    event_type: str,
+    *,
+    id: str = "",
+    customer: str = "",
+    status: str = "",
+    cancel_at_period_end: bool = False,
+    current_period_end: Optional[int] = None,
+    price_id: Optional[str] = None,
+) -> WebhookEvent:
+    return WebhookEvent(
+        type=event_type,
+        data_object=SubscriptionEventData(
+            id=id,
+            customer=customer,
+            status=status,
+            cancel_at_period_end=cancel_at_period_end,
+            current_period_end=current_period_end,
+            price_id=price_id,
+        ),
+    )
 
 
 def _make_use_case(entity: SubscriptionEntity, event: WebhookEvent) -> HandleWebhookUseCase:

--- a/backend/app/use_cases/billing/tests/test_handle_webhook.py
+++ b/backend/app/use_cases/billing/tests/test_handle_webhook.py
@@ -5,7 +5,12 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from app.domain.billing.entities import PlanType, SubscriptionEntity
-from app.domain.billing.ports import BillingGateway, SubscriptionRepository, WebhookEvent
+from app.domain.billing.ports import (
+    BillingGateway,
+    SubscriptionEventData,
+    SubscriptionRepository,
+    WebhookEvent,
+)
 from app.use_cases.billing.handle_webhook import HandleWebhookUseCase
 
 
@@ -63,7 +68,7 @@ class _StubSubscriptionRepo(SubscriptionRepository):
 
 
 class _StubBillingGateway(BillingGateway):
-    def __init__(self, event: dict):
+    def __init__(self, event: WebhookEvent):
         self._event = event
 
     def get_or_create_customer(self, user_id, email, username) -> str:
@@ -78,14 +83,8 @@ class _StubBillingGateway(BillingGateway):
     def create_billing_portal(self, customer_id, return_url):
         return MagicMock(url="https://portal.test")
 
-    def retrieve_subscription(self, subscription_id) -> dict:
-        return {}
-
     def verify_webhook(self, payload, sig_header, secret) -> WebhookEvent:
-        return WebhookEvent(
-            type=self._event.get("type", ""),
-            data_object=self._event.get("data", {}).get("object", {}),
-        )
+        return self._event
 
     def cancel_subscription(self, subscription_id: str) -> None:
         pass
@@ -94,7 +93,20 @@ class _StubBillingGateway(BillingGateway):
 PRICE_MAP = {"price_lite_001": "lite", "price_standard_001": "standard"}
 
 
-def _make_use_case(entity: SubscriptionEntity, event: dict) -> HandleWebhookUseCase:
+def _make_event(event_type: str, **kwargs) -> WebhookEvent:
+    defaults = {
+        "id": "",
+        "customer": "",
+        "status": "",
+        "cancel_at_period_end": False,
+        "current_period_end": None,
+        "price_id": None,
+    }
+    defaults.update(kwargs)
+    return WebhookEvent(type=event_type, data_object=SubscriptionEventData(**defaults))
+
+
+def _make_use_case(entity: SubscriptionEntity, event: WebhookEvent) -> HandleWebhookUseCase:
     return HandleWebhookUseCase(
         subscription_repo=_StubSubscriptionRepo(entity),
         billing_gateway=_StubBillingGateway(event),
@@ -106,21 +118,15 @@ def _make_use_case(entity: SubscriptionEntity, event: dict) -> HandleWebhookUseC
 class SubscriptionCreatedTests(TestCase):
     def test_subscription_created_syncs_plan_and_status(self):
         entity = _make_subscription(plan=PlanType.FREE)
-        event = {
-            "type": "customer.subscription.created",
-            "data": {
-                "object": {
-                    "id": "sub_new",
-                    "customer": "cus_test",
-                    "status": "active",
-                    "cancel_at_period_end": False,
-                    "current_period_end": 1893456000,
-                    "items": {
-                        "data": [{"price": {"id": "price_lite_001"}}]
-                    },
-                }
-            },
-        }
+        event = _make_event(
+            "customer.subscription.created",
+            id="sub_new",
+            customer="cus_test",
+            status="active",
+            cancel_at_period_end=False,
+            current_period_end=1893456000,
+            price_id="price_lite_001",
+        )
         repo = _StubSubscriptionRepo(entity)
         use_case = HandleWebhookUseCase(
             subscription_repo=repo,
@@ -143,21 +149,15 @@ class SubscriptionUpdatedTests(TestCase):
             stripe_subscription_id="sub_existing",
             stripe_status="active",
         )
-        event = {
-            "type": "customer.subscription.updated",
-            "data": {
-                "object": {
-                    "id": "sub_existing",
-                    "customer": "cus_test",
-                    "status": "active",
-                    "cancel_at_period_end": True,
-                    "current_period_end": 1893456000,
-                    "items": {
-                        "data": [{"price": {"id": "price_standard_001"}}]
-                    },
-                }
-            },
-        }
+        event = _make_event(
+            "customer.subscription.updated",
+            id="sub_existing",
+            customer="cus_test",
+            status="active",
+            cancel_at_period_end=True,
+            current_period_end=1893456000,
+            price_id="price_standard_001",
+        )
         repo = _StubSubscriptionRepo(entity)
         use_case = HandleWebhookUseCase(
             subscription_repo=repo,
@@ -179,18 +179,13 @@ class SubscriptionDeletedTests(TestCase):
             stripe_subscription_id="sub_existing",
             stripe_status="active",
         )
-        event = {
-            "type": "customer.subscription.deleted",
-            "data": {
-                "object": {
-                    "id": "sub_existing",
-                    "customer": "cus_test",
-                    "status": "canceled",
-                    "cancel_at_period_end": False,
-                    "items": {"data": []},
-                }
-            },
-        }
+        event = _make_event(
+            "customer.subscription.deleted",
+            id="sub_existing",
+            customer="cus_test",
+            status="canceled",
+            cancel_at_period_end=False,
+        )
         repo = _StubSubscriptionRepo(entity)
         use_case = HandleWebhookUseCase(
             subscription_repo=repo,
@@ -209,10 +204,7 @@ class SubscriptionDeletedTests(TestCase):
 class UnknownEventTests(TestCase):
     def test_unknown_event_is_ignored(self):
         entity = _make_subscription(plan=PlanType.FREE)
-        event = {
-            "type": "payment_intent.succeeded",
-            "data": {"object": {"customer": "cus_test"}},
-        }
+        event = _make_event("payment_intent.succeeded", customer="cus_test")
         repo = _StubSubscriptionRepo(entity)
         use_case = HandleWebhookUseCase(
             subscription_repo=repo,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,4 +24,4 @@ redis>=7.0.0
 scikit-learn>=1.7.2
 uvicorn-worker>=0.4.0
 uvicorn>=0.38.0
-stripe==14.4.1
+stripe>=15.0.0


### PR DESCRIPTION
## 概要
Stripe Python v15 対応の一環として、billing webhook の境界を整理しました。

これまで webhook 処理では `StripeObject` を `to_dict()` で変換して use case に渡していましたが、この PR では Stripe 固有の型を gateway 内に閉じ込め、ドメイン側には意味のある DTO を渡すように変更しています。

## 変更内容
- `stripe-python` を v15 系前提で扱うよう整理
- `BillingGateway.verify_webhook()` の戻り値を `WebhookEvent` + `SubscriptionEventData` に統一
- `stripe.Webhook.construct_event()` の戻り値は dot notation で明示的に読み取り
- `event.data.object.to_dict()` 依存を削除
- `HandleWebhookUseCase` を `dict.get()` ベースから属性アクセスベースへ変更
- 未使用だった `BillingGateway.retrieve_subscription()` を削除
- Stripe v15 互換を担保する unit test を追加・更新
- `StripeObject` の `[]` アクセスを禁止する stub で検証
- `deleted` イベントで `items` が空でも `price_id=None` で扱えることを確認

## 設計意図
- Stripe v15 の `StripeObject` をアプリケーション内部へ漏らさない
- webhook 境界で payload を正規化し、use case を Stripe SDK の仕様変更から切り離す
- `dict` の暗黙契約ではなく、型付き DTO で扱うことで保守性を上げる

## 影響範囲
- billing webhook 処理
- billing 関連のテストダブル
- Stripe gateway の unit test

## 確認したこと
- `backend/app` 内の Stripe 利用箇所を横断確認し、Stripe 関連の実装は billing gateway に集約されていることを確認
- StripeObject の `[]` アクセスや `to_dict()` 依存の残件がないことを確認

## テスト
実行済み:
```bash
python -m unittest discover -s app/use_cases/billing/tests -p 'test_*.py'
python -m unittest app.infrastructure.billing.tests.test_stripe_gateway
python -m unittest app.use_cases.auth.tests.test_delete_account_data
```

未実行:
- `app.presentation.billing.tests.test_views`
- この環境では `django` が入っていないため未実行