### PR TITLE
Fix Lost Update in usage recording via atomic F() expressions (#511)

### DIFF
--- a/backend/app/domain/billing/ports.py
+++ b/backend/app/domain/billing/ports.py
@@ -66,6 +66,34 @@ class SubscriptionRepository(ABC):
         """
         ...
 
+    @abstractmethod
+    def increment_storage_bytes(self, user_id: int, bytes_delta: int) -> None:
+        """Atomically update used_storage_bytes by bytes_delta.
+
+        Result is clamped to >= 0 to prevent negative storage values.
+        Must use a database-level atomic operation (e.g. F() expression) to
+        avoid lost updates under concurrent requests.
+        """
+        ...
+
+    @abstractmethod
+    def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
+        """Atomically increment used_processing_seconds by seconds.
+
+        Must use a database-level atomic operation (e.g. F() expression) to
+        avoid lost updates under concurrent requests.
+        """
+        ...
+
+    @abstractmethod
+    def increment_ai_answers(self, user_id: int) -> None:
+        """Atomically increment used_ai_answers by 1.
+
+        Must use a database-level atomic operation (e.g. F() expression) to
+        avoid lost updates under concurrent requests.
+        """
+        ...
+
 
 class BillingGateway(ABC):
     @abstractmethod

--- a/backend/app/infrastructure/billing/tests/test_subscription_repository.py
+++ b/backend/app/infrastructure/billing/tests/test_subscription_repository.py
@@ -1,0 +1,87 @@
+"""Integration tests for DjangoSubscriptionRepository atomic update methods.
+
+These tests exercise the actual DB layer to verify that increment_* methods
+perform atomic writes via F() expressions, preventing Lost Update anomalies.
+"""
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.infrastructure.repositories.django_subscription_repository import (
+    DjangoSubscriptionRepository,
+)
+from app.infrastructure.models.subscription import Subscription
+
+User = get_user_model()
+
+
+def _create_user(username="testuser"):
+    return User.objects.create_user(username=username, password="pw")
+
+
+class IncrementStorageBytesTests(TestCase):
+    def setUp(self):
+        self.user = _create_user()
+        self.repo = DjangoSubscriptionRepository()
+        self.repo.get_or_create(self.user.id)
+
+    def test_increments_storage_bytes(self):
+        self.repo.increment_storage_bytes(self.user.id, 500)
+        obj = Subscription.objects.get(user_id=self.user.id)
+        self.assertEqual(obj.used_storage_bytes, 500)
+
+    def test_subtracts_bytes_on_negative_delta(self):
+        Subscription.objects.filter(user_id=self.user.id).update(used_storage_bytes=1000)
+        self.repo.increment_storage_bytes(self.user.id, -300)
+        obj = Subscription.objects.get(user_id=self.user.id)
+        self.assertEqual(obj.used_storage_bytes, 700)
+
+    def test_clamps_to_zero_on_over_subtraction(self):
+        Subscription.objects.filter(user_id=self.user.id).update(used_storage_bytes=100)
+        self.repo.increment_storage_bytes(self.user.id, -500)
+        obj = Subscription.objects.get(user_id=self.user.id)
+        self.assertEqual(obj.used_storage_bytes, 0)
+
+    def test_sequential_increments_accumulate(self):
+        """Simulate two sequential increments that must both be recorded."""
+        self.repo.increment_storage_bytes(self.user.id, 500)
+        self.repo.increment_storage_bytes(self.user.id, 600)
+        obj = Subscription.objects.get(user_id=self.user.id)
+        self.assertEqual(obj.used_storage_bytes, 1100)
+
+
+class IncrementProcessingSecondsTests(TestCase):
+    def setUp(self):
+        self.user = _create_user()
+        self.repo = DjangoSubscriptionRepository()
+        self.repo.get_or_create(self.user.id)
+
+    def test_increments_processing_seconds(self):
+        self.repo.increment_processing_seconds(self.user.id, 120)
+        obj = Subscription.objects.get(user_id=self.user.id)
+        self.assertEqual(obj.used_processing_seconds, 120)
+
+    def test_sequential_increments_accumulate(self):
+        """Simulate two sequential increments that must both be recorded."""
+        self.repo.increment_processing_seconds(self.user.id, 60)
+        self.repo.increment_processing_seconds(self.user.id, 90)
+        obj = Subscription.objects.get(user_id=self.user.id)
+        self.assertEqual(obj.used_processing_seconds, 150)
+
+
+class IncrementAiAnswersTests(TestCase):
+    def setUp(self):
+        self.user = _create_user()
+        self.repo = DjangoSubscriptionRepository()
+        self.repo.get_or_create(self.user.id)
+
+    def test_increments_ai_answers_by_one(self):
+        self.repo.increment_ai_answers(self.user.id)
+        obj = Subscription.objects.get(user_id=self.user.id)
+        self.assertEqual(obj.used_ai_answers, 1)
+
+    def test_sequential_increments_accumulate(self):
+        """Simulate two sequential increments that must both be recorded."""
+        self.repo.increment_ai_answers(self.user.id)
+        self.repo.increment_ai_answers(self.user.id)
+        obj = Subscription.objects.get(user_id=self.user.id)
+        self.assertEqual(obj.used_ai_answers, 2)

--- a/backend/app/infrastructure/repositories/django_subscription_repository.py
+++ b/backend/app/infrastructure/repositories/django_subscription_repository.py
@@ -3,6 +3,9 @@
 from datetime import timedelta, timezone
 from typing import Optional
 
+from django.db.models import F, Value
+from django.db.models.functions import Greatest
+
 from app.domain.billing.entities import PlanType, SubscriptionEntity
 from app.domain.billing.ports import SubscriptionRepository
 
@@ -90,6 +93,24 @@ class DjangoSubscriptionRepository(SubscriptionRepository):
             used_processing_seconds=0,
             used_ai_answers=0,
             usage_period_start=period_start,
+        )
+
+    def increment_storage_bytes(self, user_id: int, bytes_delta: int) -> None:
+        Subscription = self._get_model()
+        Subscription.objects.filter(user_id=user_id).update(
+            used_storage_bytes=Greatest(Value(0), F("used_storage_bytes") + bytes_delta)
+        )
+
+    def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
+        Subscription = self._get_model()
+        Subscription.objects.filter(user_id=user_id).update(
+            used_processing_seconds=F("used_processing_seconds") + seconds
+        )
+
+    def increment_ai_answers(self, user_id: int) -> None:
+        Subscription = self._get_model()
+        Subscription.objects.filter(user_id=user_id).update(
+            used_ai_answers=F("used_ai_answers") + 1
         )
 
     def maybe_reset_monthly_usage(self, user_id: int) -> None:

--- a/backend/app/use_cases/auth/tests/test_delete_account_data.py
+++ b/backend/app/use_cases/auth/tests/test_delete_account_data.py
@@ -67,6 +67,15 @@ class _StubSubscriptionRepo(SubscriptionRepository):
     def maybe_reset_monthly_usage(self, user_id: int) -> None:
         pass
 
+    def increment_storage_bytes(self, user_id: int, bytes_delta: int) -> None:
+        pass
+
+    def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
+        pass
+
+    def increment_ai_answers(self, user_id: int) -> None:
+        pass
+
 
 class _StubBillingGateway(BillingGateway):
     def __init__(self):

--- a/backend/app/use_cases/billing/record_ai_answer_usage.py
+++ b/backend/app/use_cases/billing/record_ai_answer_usage.py
@@ -7,6 +7,4 @@ class RecordAiAnswerUsageUseCase:
 
     def execute(self, user_id: int) -> None:
         self._subscription_repo.maybe_reset_monthly_usage(user_id)
-        entity = self._subscription_repo.get_or_create(user_id)
-        entity.used_ai_answers += 1
-        self._subscription_repo.save(entity)
+        self._subscription_repo.increment_ai_answers(user_id)

--- a/backend/app/use_cases/billing/record_processing_usage.py
+++ b/backend/app/use_cases/billing/record_processing_usage.py
@@ -7,6 +7,4 @@ class RecordProcessingUsageUseCase:
 
     def execute(self, user_id: int, seconds: int) -> None:
         self._subscription_repo.maybe_reset_monthly_usage(user_id)
-        entity = self._subscription_repo.get_or_create(user_id)
-        entity.used_processing_seconds += seconds
-        self._subscription_repo.save(entity)
+        self._subscription_repo.increment_processing_seconds(user_id, seconds)

--- a/backend/app/use_cases/billing/record_storage_usage.py
+++ b/backend/app/use_cases/billing/record_storage_usage.py
@@ -6,6 +6,4 @@ class RecordStorageUsageUseCase:
         self._subscription_repo = subscription_repo
 
     def execute(self, user_id: int, bytes_delta: int) -> None:
-        entity = self._subscription_repo.get_or_create(user_id)
-        entity.used_storage_bytes = max(0, entity.used_storage_bytes + bytes_delta)
-        self._subscription_repo.save(entity)
+        self._subscription_repo.increment_storage_bytes(user_id, bytes_delta)

--- a/backend/app/use_cases/billing/tests/test_check_limits.py
+++ b/backend/app/use_cases/billing/tests/test_check_limits.py
@@ -65,6 +65,15 @@ class _StubSubscriptionRepo(SubscriptionRepository):
     def maybe_reset_monthly_usage(self, user_id: int) -> None:
         pass
 
+    def increment_storage_bytes(self, user_id: int, bytes_delta: int) -> None:
+        pass
+
+    def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
+        pass
+
+    def increment_ai_answers(self, user_id: int) -> None:
+        pass
+
 
 class CheckStorageLimitTests(TestCase):
     def test_storage_within_limit_does_not_raise(self):

--- a/backend/app/use_cases/billing/tests/test_create_checkout_session.py
+++ b/backend/app/use_cases/billing/tests/test_create_checkout_session.py
@@ -71,6 +71,15 @@ class _StubSubscriptionRepo(SubscriptionRepository):
     def maybe_reset_monthly_usage(self, user_id: int) -> None:
         pass
 
+    def increment_storage_bytes(self, user_id: int, bytes_delta: int) -> None:
+        pass
+
+    def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
+        pass
+
+    def increment_ai_answers(self, user_id: int) -> None:
+        pass
+
 
 class _StubBillingGateway(BillingGateway):
     def __init__(self, customer_id: str = "cus_test", checkout_url: str = "https://checkout.test"):

--- a/backend/app/use_cases/billing/tests/test_get_subscription.py
+++ b/backend/app/use_cases/billing/tests/test_get_subscription.py
@@ -56,6 +56,15 @@ class _StubSubscriptionRepo(SubscriptionRepository):
     def maybe_reset_monthly_usage(self, user_id: int) -> None:
         pass
 
+    def increment_storage_bytes(self, user_id: int, bytes_delta: int) -> None:
+        pass
+
+    def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
+        pass
+
+    def increment_ai_answers(self, user_id: int) -> None:
+        pass
+
 
 class GetSubscriptionUseCaseTests(TestCase):
     def test_subscription_uses_plan_limits(self):

--- a/backend/app/use_cases/billing/tests/test_handle_webhook.py
+++ b/backend/app/use_cases/billing/tests/test_handle_webhook.py
@@ -67,6 +67,15 @@ class _StubSubscriptionRepo(SubscriptionRepository):
     def maybe_reset_monthly_usage(self, user_id: int) -> None:
         pass
 
+    def increment_storage_bytes(self, user_id: int, bytes_delta: int) -> None:
+        pass
+
+    def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
+        pass
+
+    def increment_ai_answers(self, user_id: int) -> None:
+        pass
+
 
 class _StubBillingGateway(BillingGateway):
     def __init__(self, event: WebhookEvent):

--- a/backend/app/use_cases/billing/tests/test_record_usage.py
+++ b/backend/app/use_cases/billing/tests/test_record_usage.py
@@ -41,6 +41,9 @@ class _TrackingSubscriptionRepo(SubscriptionRepository):
         self.saved: Optional[SubscriptionEntity] = None
         self.reset_calls: list = []
         self.maybe_reset_calls: list = []
+        self.increment_storage_calls: list = []
+        self.increment_processing_calls: list = []
+        self.increment_ai_answer_calls: list = []
 
     def get_or_create(self, user_id: int) -> SubscriptionEntity:
         return self._entity
@@ -64,28 +67,40 @@ class _TrackingSubscriptionRepo(SubscriptionRepository):
     def maybe_reset_monthly_usage(self, user_id: int) -> None:
         self.maybe_reset_calls.append(user_id)
 
+    def increment_storage_bytes(self, user_id: int, bytes_delta: int) -> None:
+        self.increment_storage_calls.append((user_id, bytes_delta))
+
+    def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
+        self.increment_processing_calls.append((user_id, seconds))
+
+    def increment_ai_answers(self, user_id: int) -> None:
+        self.increment_ai_answer_calls.append(user_id)
+
 
 class RecordStorageUsageTests(TestCase):
-    def test_adds_bytes_to_used_storage(self):
+    def test_delegates_to_atomic_increment(self):
+        """Use case must call increment_storage_bytes instead of get→save."""
         entity = _make_subscription(used_storage_bytes=100)
         repo = _TrackingSubscriptionRepo(entity)
         use_case = RecordStorageUsageUseCase(repo)
         use_case.execute(user_id=1, bytes_delta=500)
-        self.assertEqual(repo.saved.used_storage_bytes, 600)
+        self.assertEqual(repo.increment_storage_calls, [(1, 500)])
 
-    def test_subtracts_bytes_on_negative_delta(self):
+    def test_passes_negative_delta_to_repo(self):
+        """Negative delta (file deletion) is passed through to the repo for atomic clamping."""
         entity = _make_subscription(used_storage_bytes=1000)
         repo = _TrackingSubscriptionRepo(entity)
         use_case = RecordStorageUsageUseCase(repo)
         use_case.execute(user_id=1, bytes_delta=-300)
-        self.assertEqual(repo.saved.used_storage_bytes, 700)
+        self.assertEqual(repo.increment_storage_calls, [(1, -300)])
 
-    def test_clamps_to_zero_on_over_subtraction(self):
-        entity = _make_subscription(used_storage_bytes=100)
+    def test_does_not_call_save(self):
+        """save() must NOT be called — the repo handles the atomic write."""
+        entity = _make_subscription()
         repo = _TrackingSubscriptionRepo(entity)
         use_case = RecordStorageUsageUseCase(repo)
-        use_case.execute(user_id=1, bytes_delta=-500)
-        self.assertEqual(repo.saved.used_storage_bytes, 0)
+        use_case.execute(user_id=1, bytes_delta=100)
+        self.assertIsNone(repo.saved)
 
     def test_does_not_call_maybe_reset(self):
         """Storage recording does NOT trigger monthly reset."""
@@ -97,12 +112,13 @@ class RecordStorageUsageTests(TestCase):
 
 
 class RecordProcessingUsageTests(TestCase):
-    def test_adds_seconds_to_used_processing(self):
+    def test_delegates_to_atomic_increment(self):
+        """Use case must call increment_processing_seconds instead of get→save."""
         entity = _make_subscription(used_processing_seconds=60)
         repo = _TrackingSubscriptionRepo(entity)
         use_case = RecordProcessingUsageUseCase(repo)
         use_case.execute(user_id=1, seconds=120)
-        self.assertEqual(repo.saved.used_processing_seconds, 180)
+        self.assertEqual(repo.increment_processing_calls, [(1, 120)])
 
     def test_calls_maybe_reset_before_recording(self):
         entity = _make_subscription(used_processing_seconds=0)
@@ -111,14 +127,23 @@ class RecordProcessingUsageTests(TestCase):
         use_case.execute(user_id=1, seconds=30)
         self.assertEqual(repo.maybe_reset_calls, [1])
 
+    def test_does_not_call_save(self):
+        """save() must NOT be called — the repo handles the atomic write."""
+        entity = _make_subscription()
+        repo = _TrackingSubscriptionRepo(entity)
+        use_case = RecordProcessingUsageUseCase(repo)
+        use_case.execute(user_id=1, seconds=60)
+        self.assertIsNone(repo.saved)
+
 
 class RecordAiAnswerUsageTests(TestCase):
-    def test_increments_ai_answers_by_one(self):
+    def test_delegates_to_atomic_increment(self):
+        """Use case must call increment_ai_answers instead of get→save."""
         entity = _make_subscription(used_ai_answers=5)
         repo = _TrackingSubscriptionRepo(entity)
         use_case = RecordAiAnswerUsageUseCase(repo)
         use_case.execute(user_id=1)
-        self.assertEqual(repo.saved.used_ai_answers, 6)
+        self.assertEqual(repo.increment_ai_answer_calls, [1])
 
     def test_calls_maybe_reset_before_recording(self):
         entity = _make_subscription(used_ai_answers=0)
@@ -126,3 +151,11 @@ class RecordAiAnswerUsageTests(TestCase):
         use_case = RecordAiAnswerUsageUseCase(repo)
         use_case.execute(user_id=1)
         self.assertEqual(repo.maybe_reset_calls, [1])
+
+    def test_does_not_call_save(self):
+        """save() must NOT be called — the repo handles the atomic write."""
+        entity = _make_subscription()
+        repo = _TrackingSubscriptionRepo(entity)
+        use_case = RecordAiAnswerUsageUseCase(repo)
+        use_case.execute(user_id=1)
+        self.assertIsNone(repo.saved)


### PR DESCRIPTION
## 背景

`record_storage_usage.py` / `record_processing_usage.py` / `record_ai_answer_usage.py` の使用量更新が get → 計算 → save の2ステップで実装されており、並行リクエスト時に Lost Update が発生していた。

**再現シナリオ:**
```
T1: get → used_storage_bytes = 1000
T2: get → used_storage_bytes = 1000
T1: save → used_storage_bytes = 1000 + 500 = 1500
T2: save → used_storage_bytes = 1000 + 600 = 1600  ← T1 の更新が失われる
実際は 2100 であるべき
```

## 変更内容

### ドメイン層
- `SubscriptionRepository` に3つのアトミック更新メソッドを追加
  - `increment_storage_bytes(user_id, bytes_delta)` — ゼロクランプ付き
  - `increment_processing_seconds(user_id, seconds)`
  - `increment_ai_answers(user_id)`

### インフラ層
- `DjangoSubscriptionRepository` で Django `F()` 式 + `Greatest()` によるアトミック単一 UPDATE を実装
  - ストレージ: `Greatest(Value(0), F('used_storage_bytes') + bytes_delta)` — ゼロクランプも DB 側で処理
  - 処理時間: `F('used_processing_seconds') + seconds`
  - AI回答: `F('used_ai_answers') + 1`

### ユースケース層
- 3つの `RecordUsageUseCase` からアプリ側の get → save ロジックを削除し、アトミックメソッドの呼び出しに変更

### テスト
- `test_record_usage.py` をアトミックメソッドの呼び出し検証に書き直し（`save()` が呼ばれないことも確認）
- `infrastructure/billing/tests/test_subscription_repository.py` を新規追加（DB 統合テスト）
  - 順次インクリメントが累積されること
  - ストレージのゼロクランプ
- 既存スタブ5ファイルへの no-op 実装追加

## テスト結果

```
Ran 935 tests in 52.713s
OK
```

Closes #511