### PR TITLE
Fix #514: アカウント削除をベストエフォート方式に変更し途中失敗でも全ステップを実行

### DIFF
--- a/backend/app/use_cases/auth/delete_account_data.py
+++ b/backend/app/use_cases/auth/delete_account_data.py
@@ -33,12 +33,24 @@ class DeleteAccountDataUseCase:
         self._billing_gateway = billing_gateway
 
     def execute(self, user_id: int) -> None:
-        self.gateway.delete_all_videos_for_user(user_id)
-        self.gateway.delete_chat_history_for_user(user_id)
-        self.gateway.delete_video_groups_for_user(user_id)
-        self.gateway.delete_tags_for_user(user_id)
+        data_steps = [
+            ("delete_all_videos_for_user", self.gateway.delete_all_videos_for_user),
+            ("delete_chat_history_for_user", self.gateway.delete_chat_history_for_user),
+            ("delete_video_groups_for_user", self.gateway.delete_video_groups_for_user),
+            ("delete_tags_for_user", self.gateway.delete_tags_for_user),
+        ]
+        for step_name, step in data_steps:
+            try:
+                step(user_id)
+            except Exception:
+                logger.error(
+                    "Account deletion step %s failed for user %s",
+                    step_name,
+                    user_id,
+                    exc_info=True,
+                )
         self._cancel_subscription_if_active(user_id)
-        logger.info("Account data deleted for user %s", user_id)
+        logger.info("Account data deletion completed for user %s", user_id)
 
     def _cancel_subscription_if_active(self, user_id: int) -> None:
         if self._subscription_repo is None or self._billing_gateway is None:

--- a/backend/app/use_cases/auth/tests/test_delete_account_data.py
+++ b/backend/app/use_cases/auth/tests/test_delete_account_data.py
@@ -247,3 +247,85 @@ class CancelSubscriptionOnDeleteTests(TestCase):
         deletion_gw.delete_chat_history_for_user.assert_called_once_with(42)
         deletion_gw.delete_video_groups_for_user.assert_called_once_with(42)
         deletion_gw.delete_tags_for_user.assert_called_once_with(42)
+
+
+class BestEffortDeletionTests(TestCase):
+    """ベストエフォート方式: 途中のステップが失敗しても残りが実行される"""
+
+    def test_continues_after_videos_deletion_failure(self):
+        """動画削除が失敗してもチャット/グループ/タグ削除が続行される"""
+        deletion_gw = _make_deletion_gateway()
+        deletion_gw.delete_all_videos_for_user.side_effect = Exception("R2 error")
+
+        use_case = DeleteAccountDataUseCase(user_data_deletion_gateway=deletion_gw)
+        use_case.execute(user_id=1)
+
+        deletion_gw.delete_chat_history_for_user.assert_called_once_with(1)
+        deletion_gw.delete_video_groups_for_user.assert_called_once_with(1)
+        deletion_gw.delete_tags_for_user.assert_called_once_with(1)
+
+    def test_continues_after_chat_deletion_failure(self):
+        """チャット履歴削除が失敗してもグループ/タグ削除が続行される"""
+        deletion_gw = _make_deletion_gateway()
+        deletion_gw.delete_chat_history_for_user.side_effect = Exception("DB error")
+
+        use_case = DeleteAccountDataUseCase(user_data_deletion_gateway=deletion_gw)
+        use_case.execute(user_id=1)
+
+        deletion_gw.delete_video_groups_for_user.assert_called_once_with(1)
+        deletion_gw.delete_tags_for_user.assert_called_once_with(1)
+
+    def test_continues_after_groups_deletion_failure(self):
+        """グループ削除が失敗してもタグ削除が続行される"""
+        deletion_gw = _make_deletion_gateway()
+        deletion_gw.delete_video_groups_for_user.side_effect = Exception("DB error")
+
+        use_case = DeleteAccountDataUseCase(user_data_deletion_gateway=deletion_gw)
+        use_case.execute(user_id=1)
+
+        deletion_gw.delete_tags_for_user.assert_called_once_with(1)
+
+    def test_stripe_cancel_runs_even_if_data_step_fails(self):
+        """データ削除ステップが失敗してもStripeキャンセルが実行される"""
+        entity = _make_subscription(stripe_subscription_id="sub_abc")
+        billing_gw = _StubBillingGateway()
+        deletion_gw = _make_deletion_gateway()
+        deletion_gw.delete_all_videos_for_user.side_effect = Exception("R2 error")
+
+        use_case = DeleteAccountDataUseCase(
+            user_data_deletion_gateway=deletion_gw,
+            subscription_repo=_StubSubscriptionRepo(entity),
+            billing_gateway=billing_gw,
+        )
+        use_case.execute(user_id=1)
+
+        self.assertEqual(billing_gw.cancelled, ["sub_abc"])
+
+    def test_data_step_failure_is_logged(self):
+        """失敗したステップがERRORレベルでログに記録される"""
+        deletion_gw = _make_deletion_gateway()
+        deletion_gw.delete_all_videos_for_user.side_effect = Exception("R2 error")
+
+        use_case = DeleteAccountDataUseCase(user_data_deletion_gateway=deletion_gw)
+
+        with self.assertLogs("app.use_cases.auth.delete_account_data", level="ERROR") as cm:
+            use_case.execute(user_id=1)
+
+        self.assertTrue(
+            any("delete_all_videos_for_user" in msg for msg in cm.output),
+            f"Expected delete_all_videos_for_user in logs, got: {cm.output}",
+        )
+
+    def test_multiple_step_failures_all_logged(self):
+        """複数ステップが失敗した場合、すべてERRORログに記録される"""
+        deletion_gw = _make_deletion_gateway()
+        deletion_gw.delete_all_videos_for_user.side_effect = Exception("R2 error")
+        deletion_gw.delete_chat_history_for_user.side_effect = Exception("Chat error")
+
+        use_case = DeleteAccountDataUseCase(user_data_deletion_gateway=deletion_gw)
+
+        with self.assertLogs("app.use_cases.auth.delete_account_data", level="ERROR") as cm:
+            use_case.execute(user_id=1)
+
+        errors_logged = sum(1 for msg in cm.output if "ERROR" in msg)
+        self.assertGreaterEqual(errors_logged, 2)


### PR DESCRIPTION
## Summary

- データ削除の各ステップ（動画・チャット履歴・グループ・タグ）を `try/except` でラップし、失敗しても残りのステップを続行するベストエフォート方式に変更
- 失敗したステップは `logger.error(..., exc_info=True)` でスタックトレース付きERRORログを記録
- Stripeキャンセルは例外を伝播させたままにし、Celeryの `autoretry_for=(Exception,)` による最大3回のリトライを維持

## Test plan

- [x] `test_continues_after_videos_deletion_failure` — 動画削除失敗後にチャット/グループ/タグが続行される
- [x] `test_continues_after_chat_deletion_failure` — チャット削除失敗後にグループ/タグが続行される
- [x] `test_continues_after_groups_deletion_failure` — グループ削除失敗後にタグが続行される
- [x] `test_stripe_cancel_runs_even_if_data_step_fails` — データステップ失敗後もStripeキャンセルが実行される
- [x] `test_data_step_failure_is_logged` — 失敗がERRORログに記録される
- [x] `test_multiple_step_failures_all_logged` — 複数失敗がすべてログに記録される
- [x] 既存の14テストがすべて引き続きパスする

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)