### PR TITLE
Fix: webhookエラー時に内部例外メッセージが外部に露出する (#520)

### DIFF
--- a/backend/app/presentation/billing/tests/test_views.py
+++ b/backend/app/presentation/billing/tests/test_views.py
@@ -395,10 +395,15 @@ class StripeWebhookViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("message", response.json())
 
-    def test_webhook_invalid_signature_returns_400(self):
+    def test_webhook_signature_verification_error_returns_400(self):
+        import stripe
+
         url = reverse("billing-webhook")
         mock_use_case = MagicMock()
-        mock_use_case.execute.side_effect = Exception("Invalid signature")
+        mock_use_case.execute.side_effect = stripe.error.SignatureVerificationError(
+            "No signatures found matching the expected signature for payload",
+            sig_header="invalid",
+        )
         with patch(
             "app.composition_root.billing.get_handle_webhook_use_case",
             return_value=mock_use_case,
@@ -410,3 +415,26 @@ class StripeWebhookViewTests(APITestCase):
                 HTTP_STRIPE_SIGNATURE="invalid",
             )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        body = response.json()
+        self.assertEqual(body["error"]["code"], "INVALID_SIGNATURE")
+        self.assertNotIn("message", body["error"])
+
+    def test_webhook_unexpected_error_returns_500(self):
+        url = reverse("billing-webhook")
+        mock_use_case = MagicMock()
+        mock_use_case.execute.side_effect = Exception("internal db error details")
+        with patch(
+            "app.composition_root.billing.get_handle_webhook_use_case",
+            return_value=mock_use_case,
+        ):
+            response = self.client.post(
+                url,
+                data=b"{}",
+                content_type="application/json",
+                HTTP_STRIPE_SIGNATURE="t=123,v1=abc",
+            )
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        body = response.json()
+        self.assertEqual(body["error"]["code"], "WEBHOOK_ERROR")
+        self.assertNotIn("message", body["error"])
+        self.assertNotIn("internal db error details", str(body))

--- a/backend/app/presentation/billing/views.py
+++ b/backend/app/presentation/billing/views.py
@@ -147,6 +147,7 @@ class StripeWebhookView(View):
     """
 
     def post(self, request):
+        import stripe
         from app.dependencies.billing import get_handle_webhook_use_case
 
         sig_header = request.META.get("HTTP_STRIPE_SIGNATURE", "")
@@ -155,12 +156,12 @@ class StripeWebhookView(View):
         use_case = get_handle_webhook_use_case()
         try:
             use_case.execute(payload=payload, sig_header=sig_header)
-        except Exception as e:
-            logger.warning("Stripe webhook error: %s", e)
-            return JsonResponse(
-                {"error": {"code": "WEBHOOK_ERROR", "message": str(e)}},
-                status=400,
-            )
+        except stripe.error.SignatureVerificationError:
+            logger.warning("Webhook signature verification failed")
+            return JsonResponse({"error": {"code": "INVALID_SIGNATURE"}}, status=400)
+        except Exception:
+            logger.exception("Unexpected webhook error")
+            return JsonResponse({"error": {"code": "WEBHOOK_ERROR"}}, status=500)
 
         return JsonResponse({"message": "Webhook processed."})
 


### PR DESCRIPTION
## Summary

- `stripe.error.SignatureVerificationError` 発生時は 400 + `INVALID_SIGNATURE` コードのみを返すよう変更（`str(e)` を除去）
- 予期しない `Exception` 発生時は 500 + `WEBHOOK_ERROR` コードのみを返すよう変更（旧実装は 400 かつ `str(e)` を露出）
- ログも区別: 署名エラーは `logger.warning`、予期しないエラーは `logger.exception`（スタックトレース付き）

## Test plan

- [x] `test_webhook_handles_valid_event` — 正常系 200 OK
- [x] `test_webhook_signature_verification_error_returns_400` — `SignatureVerificationError` → 400、`INVALID_SIGNATURE` コード、`message` フィールドなし
- [x] `test_webhook_unexpected_error_returns_500` — 予期しない `Exception` → 500、`WEBHOOK_ERROR` コード、内部エラー文字列が leakしないこと

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)