### PR TITLE
Fix: cancel_at_period_end=true のサブスクリプションがアクティブとして扱われる (#516)

### DIFF
--- a/backend/app/domain/billing/entities.py
+++ b/backend/app/domain/billing/entities.py
@@ -54,7 +54,16 @@ class SubscriptionEntity:
             return True
         if self.plan == PlanType.ENTERPRISE:
             return True
+        if self.cancel_at_period_end:
+            return False
         return self.stripe_status in ("active", "trialing")
+
+    @property
+    def is_pending_cancellation(self) -> bool:
+        """True when the subscription is scheduled to cancel at period end but still running."""
+        if self.plan in (PlanType.FREE, PlanType.ENTERPRISE):
+            return False
+        return self.cancel_at_period_end and self.stripe_status in ("active", "trialing")
 
     def get_storage_limit_bytes(self) -> Optional[int]:
         """Returns storage limit in bytes. None = unlimited."""

--- a/backend/app/domain/billing/tests/test_entities.py
+++ b/backend/app/domain/billing/tests/test_entities.py
@@ -184,3 +184,54 @@ class IsStripeActiveTests(TestCase):
     def test_paid_plan_inactive_with_canceled_status(self):
         sub = _make_subscription(plan=PlanType.LITE, stripe_status="canceled")
         self.assertFalse(sub.is_stripe_active)
+
+    def test_cancel_at_period_end_active_status_is_not_active(self):
+        """A subscription scheduled for cancellation should not be treated as active."""
+        sub = _make_subscription(
+            plan=PlanType.LITE, stripe_status="active", cancel_at_period_end=True
+        )
+        self.assertFalse(sub.is_stripe_active)
+
+    def test_cancel_at_period_end_trialing_status_is_not_active(self):
+        sub = _make_subscription(
+            plan=PlanType.STANDARD, stripe_status="trialing", cancel_at_period_end=True
+        )
+        self.assertFalse(sub.is_stripe_active)
+
+
+class IsPendingCancellationTests(TestCase):
+    def test_pending_cancellation_with_active_status(self):
+        sub = _make_subscription(
+            plan=PlanType.LITE, stripe_status="active", cancel_at_period_end=True
+        )
+        self.assertTrue(sub.is_pending_cancellation)
+
+    def test_pending_cancellation_with_trialing_status(self):
+        sub = _make_subscription(
+            plan=PlanType.STANDARD, stripe_status="trialing", cancel_at_period_end=True
+        )
+        self.assertTrue(sub.is_pending_cancellation)
+
+    def test_not_pending_when_cancel_at_period_end_is_false(self):
+        sub = _make_subscription(
+            plan=PlanType.LITE, stripe_status="active", cancel_at_period_end=False
+        )
+        self.assertFalse(sub.is_pending_cancellation)
+
+    def test_not_pending_when_already_canceled(self):
+        sub = _make_subscription(
+            plan=PlanType.LITE, stripe_status="canceled", cancel_at_period_end=True
+        )
+        self.assertFalse(sub.is_pending_cancellation)
+
+    def test_free_plan_never_pending_cancellation(self):
+        sub = _make_subscription(
+            plan=PlanType.FREE, stripe_status="", cancel_at_period_end=True
+        )
+        self.assertFalse(sub.is_pending_cancellation)
+
+    def test_enterprise_plan_never_pending_cancellation(self):
+        sub = _make_subscription(
+            plan=PlanType.ENTERPRISE, stripe_status="", cancel_at_period_end=True
+        )
+        self.assertFalse(sub.is_pending_cancellation)

--- a/backend/app/use_cases/billing/create_checkout_session.py
+++ b/backend/app/use_cases/billing/create_checkout_session.py
@@ -69,8 +69,8 @@ class CreateCheckoutSessionUseCase:
             ),
         )
 
-        # If already has active paid subscription, update the plan in place
-        if entity.stripe_subscription_id and entity.is_stripe_active and entity.plan != PlanType.FREE:
+        # If already has active (or pending-cancellation) paid subscription, update the plan in place
+        if entity.stripe_subscription_id and (entity.is_stripe_active or entity.is_pending_cancellation) and entity.plan != PlanType.FREE:
             try:
                 self._billing_gateway.update_subscription(entity.stripe_subscription_id, price_id)
             except Exception as e:

--- a/backend/app/use_cases/billing/tests/test_create_checkout_session.py
+++ b/backend/app/use_cases/billing/tests/test_create_checkout_session.py
@@ -268,6 +268,29 @@ class ValidPlanTests(TestCase):
         self.assertEqual(gateway.last_price_id, "price_lite_usd_001")
 
 
+class PendingCancellationTests(TestCase):
+    def test_updates_subscription_in_place_when_pending_cancellation(self):
+        """A subscription with cancel_at_period_end=True should be updated in place, not recreated."""
+        entity = _make_subscription(
+            plan=PlanType.LITE,
+            stripe_status="active",
+            stripe_subscription_id="sub_pending",
+            stripe_customer_id="cus_existing",
+            cancel_at_period_end=True,
+        )
+        gateway = _StubBillingGateway()
+        use_case = _make_use_case(entity, gateway=gateway)
+        dto = use_case.execute(
+            user_id=1,
+            plan="standard",
+            success_url="https://success",
+            cancel_url="https://cancel",
+        )
+        self.assertTrue(dto.upgraded)
+        self.assertEqual(dto.checkout_url, "")
+        self.assertEqual(gateway.updated_subscription_id, "sub_pending")
+
+
 class AlreadySubscribedTests(TestCase):
     def test_upgrades_in_place_when_active_paid_subscription_exists(self):
         entity = _make_subscription(


### PR DESCRIPTION
## 概要

`cancel_at_period_end=True` のサブスクリプションが `is_stripe_active=True` として扱われ、UI に「サブスクリプションアクティブ」と誤表示される問題を修正します。

## 変更内容

- **`is_stripe_active` の修正** (`entities.py`): `cancel_at_period_end=True` の場合に `False` を返すよう変更。UIの `is_active` フィールドが正しくなる
- **`is_pending_cancellation` の追加** (`entities.py`): キャンセル保留状態（`cancel_at_period_end=True` かつ `stripe_status` が `active`/`trialing`）を明示的に識別する新プロパティ
- **`CreateCheckoutSessionUseCase` の修正** (`create_checkout_session.py`): キャンセル保留中でもプラン変更時に `update_subscription` を呼ぶよう条件を拡張

## テスト計画

- [x] `IsStripeActiveTests`: `cancel_at_period_end=True` のとき `is_stripe_active=False` になることを確認（2件追加）
- [x] `IsPendingCancellationTests`: 各状態での `is_pending_cancellation` の返り値を確認（6件追加）
- [x] `PendingCancellationTests`: キャンセル保留中のサブスクリプションに対してプラン変更が `update_subscription` 経由で正しく動作することを確認（1件追加）
- [x] 全981テストがパス、リグレッションなし

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)