### PR TITLE
feat: CD workflow - mainブランチへのマージで本番自動デプロイ

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,167 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          base: ${{ github.event.workflow_run.head_sha }}^
+          ref: ${{ github.event.workflow_run.head_sha }}
+          filters: |
+            backend:
+              - 'backend/**'
+              - '.github/workflows/cd.yml'
+
+  backend-deploy:
+    name: Deploy Backend API
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push backend image
+        id: build-backend
+        working-directory: backend
+        env:
+          IMAGE_URI: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY_API }}:${{ github.event.workflow_run.head_sha }}
+          IMAGE_URI_LATEST: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY_API }}:latest
+        run: |
+          docker build -f Dockerfile.lambda -t "$IMAGE_URI" -t "$IMAGE_URI_LATEST" .
+          docker push "$IMAGE_URI"
+          docker push "$IMAGE_URI_LATEST"
+          echo "image_uri=$IMAGE_URI" >> "$GITHUB_OUTPUT"
+
+      - name: Run Django migrations
+        working-directory: backend
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          DJANGO_SECRET_KEY: ${{ secrets.PROD_DJANGO_SECRET_KEY }}
+          DJANGO_SETTINGS_MODULE: videoq.settings
+        run: |
+          pip install -r requirements.txt --quiet
+          python manage.py migrate --noinput
+
+      - name: Update Lambda function code
+        env:
+          IMAGE_URI: ${{ steps.build-backend.outputs.image_uri }}
+        run: |
+          aws lambda update-function-code \
+            --function-name "${{ secrets.LAMBDA_API_FUNCTION_NAME }}" \
+            --image-uri "$IMAGE_URI"
+
+      - name: Wait for Lambda update
+        run: |
+          aws lambda wait function-updated \
+            --function-name "${{ secrets.LAMBDA_API_FUNCTION_NAME }}"
+
+  worker-deploy:
+    name: Deploy Worker
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push worker image
+        id: build-worker
+        working-directory: backend
+        env:
+          IMAGE_URI: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY_WORKER }}:${{ github.event.workflow_run.head_sha }}
+          IMAGE_URI_LATEST: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY_WORKER }}:latest
+        run: |
+          docker build -f Dockerfile.worker -t "$IMAGE_URI" -t "$IMAGE_URI_LATEST" .
+          docker push "$IMAGE_URI"
+          docker push "$IMAGE_URI_LATEST"
+          echo "image_uri=$IMAGE_URI" >> "$GITHUB_OUTPUT"
+
+      - name: Update Lambda function code
+        env:
+          IMAGE_URI: ${{ steps.build-worker.outputs.image_uri }}
+        run: |
+          aws lambda update-function-code \
+            --function-name "${{ secrets.LAMBDA_WORKER_FUNCTION_NAME }}" \
+            --image-uri "$IMAGE_URI"
+
+      - name: Wait for Lambda update
+        run: |
+          aws lambda wait function-updated \
+            --function-name "${{ secrets.LAMBDA_WORKER_FUNCTION_NAME }}"
+
+  health-check:
+    name: Health Check
+    runs-on: ubuntu-latest
+    needs:
+      - backend-deploy
+      - worker-deploy
+    if: |
+      always() &&
+      (needs.backend-deploy.result == 'success' || needs.backend-deploy.result == 'skipped') &&
+      (needs.worker-deploy.result == 'success' || needs.worker-deploy.result == 'skipped') &&
+      (needs.backend-deploy.result == 'success' || needs.worker-deploy.result == 'success')
+    steps:
+      - name: Wait for Lambda warmup
+        run: sleep 15
+
+      - name: Health check
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            --max-time 30 \
+            --retry 3 \
+            --retry-delay 10 \
+            "${{ secrets.PROD_HEALTH_CHECK_URL }}")
+          if [ "$HTTP_STATUS" -ne 200 ]; then
+            echo "Health check failed: HTTP $HTTP_STATUS"
+            exit 1
+          fi
+          echo "Health check passed: HTTP $HTTP_STATUS"


### PR DESCRIPTION
## Summary

- `.github/workflows/cd.yml` を新規追加
- `CI` ワークフロー成功後、`main` ブランチへの push をトリガーに backend API・worker を自動デプロイ
- `dorny/paths-filter` で `backend/**` に変更がある場合のみデプロイジョブを実行

## ジョブ構成

| ジョブ | 内容 |
|---|---|
| `changes` | 変更検知（backend/**・cd.yml） |
| `backend-deploy` | Dockerfile.lambda でビルド → ECR push → マイグレーション → Lambda 更新 |
| `worker-deploy` | Dockerfile.worker でビルド → ECR push → Lambda 更新（backend-deploy と並列） |
| `health-check` | デプロイ完了後に `/api/health/` へ HTTP 200 確認 |

## GitHub Secrets

CI/CD 専用 IAM ユーザー `videoq-github-actions-cd`（最小権限）を新規作成し、必要な Secrets をすべて登録済み。

## Test plan

- [ ] develop → main へマージ後、CI 成功を確認
- [ ] CD ワークフローが自動発火することを確認
- [ ] `backend-deploy` / `worker-deploy` が並列実行されることを確認
- [ ] マイグレーションが正常完了することを確認
- [ ] Lambda が新イメージに更新されることを確認
- [ ] ヘルスチェックが HTTP 200 を返すことを確認

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)