### PR TITLE
fix: アカウント削除時の動画ベクトル削除にエラーハンドリングを追加 (#518)

### DIFF
--- a/backend/app/infrastructure/repositories/django_user_data_deletion_gateway.py
+++ b/backend/app/infrastructure/repositories/django_user_data_deletion_gateway.py
@@ -27,7 +27,12 @@ class DjangoUserDataDeletionGateway(UserDataDeletionGateway):
                 video.delete()
                 if file_field:
                     transaction.on_commit(lambda f=file_field: f.delete(save=False))
-            delete_video_vectors(video_id)
+            try:
+                delete_video_vectors(video_id)
+            except Exception:
+                logger.warning(
+                    "Failed to delete vectors for video %s", video_id, exc_info=True
+                )
 
     def delete_chat_history_for_user(self, user_id: int) -> None:
         from app.infrastructure.models import ChatLog

--- a/backend/app/infrastructure/repositories/tests/test_django_user_data_deletion_gateway.py
+++ b/backend/app/infrastructure/repositories/tests/test_django_user_data_deletion_gateway.py
@@ -1,0 +1,91 @@
+"""
+Tests for DjangoUserDataDeletionGateway — vector deletion error handling.
+"""
+
+import logging
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from app.infrastructure.models import Video
+from app.infrastructure.repositories.django_user_data_deletion_gateway import (
+    DjangoUserDataDeletionGateway,
+)
+
+User = get_user_model()
+
+_PATCH_TARGET = "app.infrastructure.repositories.django_user_data_deletion_gateway.delete_video_vectors"
+
+
+class DeleteAllVideosVectorErrorHandlingTests(TestCase):
+    """delete_all_videos_for_user continues and logs when vector deletion fails."""
+
+    def _create_user(self):
+        return User.objects.create_user(
+            username="vectortestuser",
+            email="vectortest@example.com",
+            password="testpass123",
+        )
+
+    def _create_video(self, user):
+        return Video.objects.create(
+            user=user,
+            file=SimpleUploadedFile("v.mp4", b"fake", content_type="video/mp4"),
+            title="Test Video",
+            description="",
+        )
+
+    @patch(_PATCH_TARGET, side_effect=Exception("PGVector unavailable"))
+    def test_video_is_deleted_even_when_vector_deletion_fails(self, _mock):
+        user = self._create_user()
+        self._create_video(user)
+
+        gateway = DjangoUserDataDeletionGateway()
+        gateway.delete_all_videos_for_user(user.id)
+
+        self.assertEqual(Video.objects.filter(user=user).count(), 0)
+
+    @patch(_PATCH_TARGET, side_effect=Exception("PGVector unavailable"))
+    def test_warning_is_logged_when_vector_deletion_fails(self, _mock):
+        user = self._create_user()
+        video = self._create_video(user)
+
+        gateway = DjangoUserDataDeletionGateway()
+        with self.assertLogs(
+            "app.infrastructure.repositories.django_user_data_deletion_gateway",
+            level=logging.WARNING,
+        ) as cm:
+            gateway.delete_all_videos_for_user(user.id)
+
+        self.assertTrue(
+            any(str(video.id) in line for line in cm.output),
+            msg=f"Expected video id {video.id} in warning logs: {cm.output}",
+        )
+
+    @patch(_PATCH_TARGET, side_effect=Exception("PGVector unavailable"))
+    def test_subsequent_videos_are_deleted_after_vector_failure(self, _mock):
+        """All videos are deleted even when vector deletion keeps failing."""
+        user = self._create_user()
+        self._create_video(user)
+        self._create_video(user)
+
+        gateway = DjangoUserDataDeletionGateway()
+        gateway.delete_all_videos_for_user(user.id)
+
+        self.assertEqual(Video.objects.filter(user=user).count(), 0)
+
+    @patch(_PATCH_TARGET)
+    def test_no_warning_logged_when_vector_deletion_succeeds(self, _mock):
+        user = self._create_user()
+        self._create_video(user)
+
+        gateway = DjangoUserDataDeletionGateway()
+        import logging as _logging
+
+        with self.assertNoLogs(
+            "app.infrastructure.repositories.django_user_data_deletion_gateway",
+            level=_logging.WARNING,
+        ):
+            gateway.delete_all_videos_for_user(user.id)


### PR DESCRIPTION
## 概要

アカウント削除時の `delete_video_vectors()` 呼び出しに `try/except` を追加し、ベクトルDB障害時でも削除処理が継続されるよう修正しました。

Closes #518

## 変更内容

- `DjangoUserDataDeletionGateway.delete_all_videos_for_user()` 内の `delete_video_vectors()` を `try/except Exception` で囲む
- 失敗時は `logger.warning(..., exc_info=True)` でvideo_idとスタックトレースをログに記録
- 新規テストファイル `tests/test_django_user_data_deletion_gateway.py` を追加

## テスト計画

- [x] ベクトル削除失敗時もDBからVideoレコードが削除される
- [x] ベクトル削除失敗時にvideo_idを含むwarningログが出力される
- [x] 複数動画でベクトル削除が連続失敗しても全動画がDBから削除される
- [x] 正常時はwarningログが出力されない
- [x] 既存の `test_account_deletion` テストが引き続きパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)