### PR TITLE
fix: resolve CD workflow paths-filter failure on workflow_run trigger

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,8 +30,6 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          base: ${{ github.event.workflow_run.head_sha }}^
-          ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             backend:
               - 'backend/**'


### PR DESCRIPTION
## Summary

- `dorny/paths-filter@v3` の `base` に `SHA^` を渡していたが、`^` は `git fetch` の refspec として無効なため CD が即時失敗していた
- `base` / `ref` パラメータを削除し、`fetch-depth: 2` で取得済みの `HEAD^1` を自動使用させる形に修正

## Root cause

```yaml
# Before (broken)
base: ${{ github.event.workflow_run.head_sha }}^   # ^ は git fetch の refspec として無効
ref:  ${{ github.event.workflow_run.head_sha }}

# After (fixed)
# base/ref なし → fetch-depth: 2 で HEAD^1 を自動参照
```

## Test plan

- [ ] この PR を main にマージ後、CD ワークフローが `success` で完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)