### PR TITLE
feat: add workflow_dispatch to CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,6 +7,7 @@ on:
       - completed
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- CD ワークフローに `workflow_dispatch` トリガーを追加
- GitHub Actions UI または `gh workflow run cd.yml --ref main` で手動実行が可能になる

## Why

- PR #535 のデプロイが paths-filter エラー（修正済み）により未実行のため、手動トリガーで即時再デプロイが必要
- 今後も緊急時や検証時に手動実行できるようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)