### PR TITLE
fix: allow CD workflow to run on workflow_dispatch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:


### PR DESCRIPTION
## Summary

- `changes` ジョブの `if` 条件を修正：`workflow_dispatch` 時は `github.event.workflow_run` が空になるためスキップされていた
- `github.event_name == 'workflow_dispatch'` の条件を追加して手動実行を有効化

## Root cause

```yaml
# Before (broken for manual runs)
if: ${{ github.event.workflow_run.conclusion == 'success' }}

# After
if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)