### PR TITLE
fix: force full deploy when CD triggered via workflow_dispatch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
+      backend: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.backend == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,6 +30,7 @@ jobs:
           fetch-depth: 2
       - uses: dorny/paths-filter@v3
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             backend:


### PR DESCRIPTION
## Summary

- 手動実行（`workflow_dispatch`）時は paths-filter をスキップし、常にデプロイを実行するよう修正
- `workflow_dispatch` 時は `changes.outputs.backend` を強制的に `true` に設定
- paths-filter は `workflow_run` トリガー時のみ実行

## Why

手動実行時も HEAD^ との差分を見てしまい、直近コミットに backend 変更がなければスキップされていた。手動実行はデプロイを強制したい意図のはずなので、常にデプロイするのが正しい動作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)