### PR TITLE
feat(cd): infra変更時の cdk diff / cdk deploy CI/CD を追加する

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -1,0 +1,84 @@
+name: CDK Deploy
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cdk-deploy
+  cancel-in-progress: false
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      infra: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.infra == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            infra:
+              - 'infra/**'
+              - '.github/workflows/cdk-deploy.yml'
+
+  cdk-deploy:
+    name: CDK Deploy (production)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.infra == 'true'
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install AWS CDK CLI
+        run: npm install -g aws-cdk
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install CDK dependencies
+        working-directory: infra
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Run cdk deploy
+        working-directory: infra
+        env:
+          PAGES_DOMAIN: ${{ secrets.PAGES_DOMAIN }}
+          CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
+          CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}
+        run: |
+          source .venv/bin/activate
+          cdk deploy --all -c env=prod --require-approval never

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -1,0 +1,98 @@
+name: CDK Diff
+
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+      - '.github/workflows/cdk-diff.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: cdk-diff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cdk-diff:
+    name: CDK Diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install AWS CDK CLI
+        run: npm install -g aws-cdk
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install CDK dependencies
+        working-directory: infra
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Run cdk diff
+        id: cdk-diff
+        working-directory: infra
+        env:
+          PAGES_DOMAIN: ${{ secrets.PAGES_DOMAIN }}
+          CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
+          CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}
+        run: |
+          source .venv/bin/activate
+          set +e
+          DIFF_OUTPUT=$(cdk diff --all -c env=prod --no-color 2>&1)
+          CDK_EXIT_CODE=$?
+          set -e
+          {
+            echo "diff_output<<DIFF_EOF"
+            echo "$DIFF_OUTPUT"
+            echo "DIFF_EOF"
+            echo "exit_code=$CDK_EXIT_CODE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- cdk-diff -->'
+
+      - name: Post cdk diff comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- cdk-diff -->
+            ## CDK Diff
+
+            `infra/**` に変更が検出されました。以下の差分を確認してからマージしてください。
+
+            <details>
+            <summary>cdk diff の結果（クリックで展開）</summary>
+
+            ```
+            ${{ steps.cdk-diff.outputs.diff_output }}
+            ```
+
+            </details>
+
+            > `main` マージ後、手動承認を経て `cdk deploy` が自動実行されます。

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -110,12 +110,24 @@ aws configure get region
 
 ---
 
-## Step 3: CDK Bootstrap & デプロイ
+## Step 3: CDK Bootstrap（初回のみ）
+
+> **重要:** `cdk bootstrap` は **AWS アカウント × リージョンに対して初回のみ実行する一回限りの操作**です。
+> CI/CD には含めず、環境構築時に手動で実施してください。
 
 ```bash
 # 初回のみ: CDK 実行環境をアカウントに準備
 cdk bootstrap aws://<AWS_ACCOUNT_ID>/<REGION>
+```
 
+Bootstrap が完了すると `CDKToolkit` という CloudFormation スタックが作成される。
+以降の `cdk deploy` はこのスタックのリソースを使用する。
+
+---
+
+## Step 4（旧 Step 3）: 初回 CDK デプロイ
+
+```bash
 # CloudFront + カスタムドメインを有効化する場合 (Step 1-3 の証明書が必要)
 PAGES_DOMAIN=videoq.pages.dev \
 CUSTOM_DOMAIN=videoq.jp \
@@ -124,6 +136,17 @@ CERTIFICATE_ARN=arn:aws:acm:us-east-1:<account>:certificate/<uuid> \
 ```
 
 > **CdnStack は条件付き:** `CUSTOM_DOMAIN` と `CERTIFICATE_ARN` の両方が設定されている場合のみ CloudFront ディストリビューションが作成される。
+
+### infra 変更時の継続デプロイ（GitHub Actions）
+
+初回セットアップ後は、`infra/**` を変更した PR をマージすることで自動的に `cdk deploy` が実行される。
+
+| タイミング | 動作 |
+|---|---|
+| PR 作成・更新時 | `cdk diff` を実行し結果を PR にコメント |
+| `main` マージ後 | GitHub Environment `production` の手動承認後に `cdk deploy` を自動実行 |
+
+GitHub Environment `production` に承認者を設定しておくこと（Settings → Environments → production → Required reviewers）。
 
 デプロイ完了後、以下の Output をメモしておく:
 
@@ -139,7 +162,7 @@ VideoQ-Cdn-prod.DistributionId           = EXXXXXXXXXXXXX              # CloudFr
 
 ---
 
-## Step 4: シークレットを登録
+## Step 5: シークレットを登録
 
 ### DB シークレット (Neon 接続文字列)
 
@@ -172,10 +195,10 @@ aws secretsmanager put-secret-value \
 
 ---
 
-## Step 5: コンテナイメージをビルド & プッシュ
+## Step 6: コンテナイメージをビルド & プッシュ
 
 ```bash
-# ECR URI を変数に設定 (Step 3 の Output から)
+# ECR URI を変数に設定 (Step 4 の Output から)
 API_ECR=<account>.dkr.ecr.<region>.amazonaws.com/videoq-api-prod
 WORKER_ECR=<account>.dkr.ecr.<region>.amazonaws.com/videoq-worker-prod
 REGION=ap-northeast-1
@@ -200,7 +223,7 @@ docker push $WORKER_ECR:latest
 
 ---
 
-## Step 6: Lambda イメージを更新
+## Step 7: Lambda イメージを更新
 
 ```bash
 aws lambda update-function-code \
@@ -222,7 +245,7 @@ aws lambda wait function-updated \
 
 ---
 
-## Step 7: Django マイグレーション (初回 & スキーマ変更時)
+## Step 8: Django マイグレーション (初回 & スキーマ変更時)
 
 Docker を使った方法:
 ```bash
@@ -237,7 +260,7 @@ docker run --rm \
 
 ---
 
-## Step 8: Cloudflare Pages セットアップ (初回のみ)
+## Step 9: Cloudflare Pages セットアップ (初回のみ)
 
 1. Cloudflare ダッシュボード → **Pages** → プロジェクト作成
 2. Git リポジトリを接続 (GitHub)
@@ -259,13 +282,13 @@ docker run --rm \
 
 ---
 
-## Step 9: DNS レコード設定
+## Step 10: DNS レコード設定
 
-Step 3 で出力された `DistributionDomainName` を DNS に登録する。
+Step 4 で出力された `DistributionDomainName` を DNS に登録する。
 
 | タイプ | 名前 | 値 |
 |---|---|---|
-| CNAME (または ALIAS) | `videoq.jp` | `dxxxxxxxxx.cloudfront.net` (Step 3 の DistributionDomainName) |
+| CNAME (または ALIAS) | `videoq.jp` | `dxxxxxxxxx.cloudfront.net` (Step 4 の DistributionDomainName) |
 
 > **注意:** ルートドメイン (`videoq.jp`) の場合、CNAME は使えないため ALIAS レコード (Route 53) または CNAME フラットニング (Cloudflare DNS 等) が必要。
 
@@ -283,7 +306,22 @@ curl -I https://videoq.jp/api/health/
 
 ## 以降のデプロイ (コード変更時)
 
+### backend / worker の変更
+
+`backend/**` の変更は `main` マージ後に GitHub Actions (CD workflow) が自動デプロイする。
+
+### infra の変更
+
+`infra/**` の変更は GitHub Actions (CDK Deploy workflow) が処理する。
+
+1. PR を作成すると `cdk diff` 結果が PR に自動コメントされる
+2. `main` マージ後、GitHub Environment `production` の承認者に通知が届く
+3. 承認すると `cdk deploy` が自動実行される
+
+### 手動デプロイが必要な場合
+
 ```bash
+# backend
 # 1. イメージをリビルド & プッシュ
 docker build --platform linux/amd64 --provenance=false -f backend/Dockerfile.lambda -t $API_ECR:latest ./backend && docker push $API_ECR:latest
 docker build --platform linux/amd64 --provenance=false -f backend/Dockerfile.worker -t $WORKER_ECR:latest ./backend && docker push $WORKER_ECR:latest
@@ -294,6 +332,11 @@ aws lambda update-function-code --function-name videoq-worker-prod --image-uri $
 
 # 3. マイグレーションがある場合
 DATABASE_URL="<Neon pooler URL>" python backend/manage.py migrate
+
+# infra
+cd infra && source .venv/bin/activate
+PAGES_DOMAIN=videoq.pages.dev CUSTOM_DOMAIN=videoq.jp CERTIFICATE_ARN=... \
+  cdk deploy --all -c env=prod
 
 # フロントエンドは Cloudflare Pages が Git push で自動デプロイ
 ```
@@ -310,7 +353,7 @@ aws logs tail /aws/lambda/videoq-api-prod --follow --region $REGION
 ```
 
 よくある原因:
-- `DB_SECRET_ARN` / `APP_SECRET_ARN` の値が未設定 → Step 4 を再実行
+- `DB_SECRET_ARN` / `APP_SECRET_ARN` の値が未設定 → Step 5 を再実行
 - `SECRET_KEY` が未設定で production 起動に失敗 → App シークレットを確認
 
 ### DB 接続エラー


### PR DESCRIPTION
## Summary

- `infra/**` に変更がある PR で `cdk diff` を実行し、結果を PR に自動コメントするワークフロー（`.github/workflows/cdk-diff.yml`）を追加
- `main` マージ後、`infra/**` に変更がある場合に GitHub Environment `production` の手動承認付きで `cdk deploy` を自動実行するワークフロー（`.github/workflows/cdk-deploy.yml`）を追加
- `infra/DEPLOY.md` の `cdk bootstrap` を初回専用ステップとして独立させ、継続デプロイは GitHub Actions で行う旨を明記

Closes #528

## 変更内容

### `.github/workflows/cdk-diff.yml`（新規）
- トリガー: `infra/**` に変更がある PR
- `cdk diff --all --no-color` を実行し出力をキャプチャ
- `peter-evans/find-comment` + `peter-evans/create-or-update-comment` で既存コメントを上書き更新（同一PRへの複数プッシュでコメントが増殖しない）

### `.github/workflows/cdk-deploy.yml`（新規）
- トリガー: CI 成功後（`workflow_run`）+ `workflow_dispatch`（手動）
- `dorny/paths-filter` で `infra/**` 変更がない場合はスキップ
- `environment: production` による手動承認ゲート後に `cdk deploy --require-approval never` を実行
- `cd.yml` と同じパターン（`cancel-in-progress: false`、`workflow_dispatch` 対応）

### `infra/DEPLOY.md`（更新）
- Step 3 を「CDK Bootstrap（初回のみ）」として独立
- Step 4 に継続デプロイの GitHub Actions フロー説明を追記
- 後続ステップ番号を繰り上げ（旧4→5 ... 旧9→10）

## 必要な設定（実施済み）

| 項目 | 内容 |
|---|---|
| `PAGES_DOMAIN` Secret | `videoq.pages.dev` |
| `CUSTOM_DOMAIN` Secret | `videoq.jp` |
| `CERTIFICATE_ARN` Secret | `arn:aws:acm:us-east-1:257240362763:certificate/246b9a38-...` |
| GitHub Environment `production` | `yukiharada1228` を Required reviewer に設定済み |

## Test plan

- [ ] `infra/**` を変更した PR を作成し、`cdk diff` 結果がコメントされることを確認
- [ ] 同じ PR に追加プッシュしてもコメントが1件のみ更新されることを確認
- [ ] `main` マージ後に `cdk-deploy` ワークフローが承認待ち状態になることを確認
- [ ] 承認後に `cdk deploy` が正常完了することを確認
- [ ] `infra/**` に変更がない PR/マージでは両ワークフローがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)