### PR TITLE
fix: 削除済みアカウントのusername/emailからuser_idを除去しUUIDに置き換える

### DIFF
--- a/backend/app/domain/auth/gateways.py
+++ b/backend/app/domain/auth/gateways.py
@@ -49,13 +49,12 @@ class AccountDeletionGateway(ABC):
         ...
 
     @abstractmethod
-    def deactivate_user(self, user_id: int, suffix: str) -> None:
+    def deactivate_user(self, user_id: int) -> None:
         """
         Deactivate the user account: set is_active=False, anonymize username/email.
 
         Args:
             user_id: ID of the user to deactivate.
-            suffix: Timestamp suffix for unique username/email generation.
         """
         ...
 

--- a/backend/app/infrastructure/repositories/django_account_deletion_repository.py
+++ b/backend/app/infrastructure/repositories/django_account_deletion_repository.py
@@ -3,6 +3,8 @@ Infrastructure implementation of AccountDeletionGateway.
 Handles persistence of deletion requests and user deactivation.
 """
 
+import uuid
+
 from django.utils import timezone
 
 from app.domain.auth.gateways import AccountDeletionGateway
@@ -19,7 +21,7 @@ class DjangoAccountDeletionGateway(AccountDeletionGateway):
         user = User.objects.get(pk=user_id)
         AccountDeletionRequest.objects.create(user=user, reason=reason)
 
-    def deactivate_user(self, user_id: int, suffix: str) -> None:
+    def deactivate_user(self, user_id: int) -> None:
         """Anonymize and deactivate the user account."""
         from django.contrib.auth import get_user_model
 
@@ -28,6 +30,7 @@ class DjangoAccountDeletionGateway(AccountDeletionGateway):
         now = timezone.now()
         user.is_active = False
         user.deactivated_at = now
-        user.username = f"deleted__{user_id}__{suffix}"
-        user.email = f"deleted__{user_id}__{suffix}@invalid.local"
+        random_id = uuid.uuid4().hex
+        user.username = f"deleted__{random_id}"
+        user.email = f"deleted__{random_id}@invalid.local"
         user.save(update_fields=["is_active", "deactivated_at", "username", "email"])

--- a/backend/app/infrastructure/repositories/tests/test_django_account_deletion_repository.py
+++ b/backend/app/infrastructure/repositories/tests/test_django_account_deletion_repository.py
@@ -1,0 +1,80 @@
+"""
+Tests for DjangoAccountDeletionGateway.deactivate_user — security: user_id must not
+appear in anonymized username or email address.
+"""
+
+import re
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.infrastructure.repositories.django_account_deletion_repository import (
+    DjangoAccountDeletionGateway,
+)
+
+User = get_user_model()
+
+# Expected formats after anonymization:
+#   username: deleted__<32-char lowercase hex>
+#   email:    deleted__<32-char lowercase hex>@invalid.local
+_USERNAME_PATTERN = re.compile(r"^deleted__[0-9a-f]{32}$")
+_EMAIL_PATTERN = re.compile(r"^deleted__[0-9a-f]{32}@invalid\.local$")
+
+
+class DeactivateUserAnonymizationTests(TestCase):
+    """deactivate_user must not embed user_id in username or email."""
+
+    def _create_user(self):
+        return User.objects.create_user(
+            username="targetuser",
+            email="target@example.com",
+            password="testpass123",
+        )
+
+    def test_username_does_not_contain_user_id_as_segment(self):
+        """user_id must not appear as a __ delimited segment in the username."""
+        user = self._create_user()
+        gateway = DjangoAccountDeletionGateway()
+        gateway.deactivate_user(user.id)
+
+        user.refresh_from_db()
+        # The old format was "deleted__{user_id}__{suffix}" — verify that exact
+        # user_id segment is absent regardless of surrounding delimiters.
+        self.assertNotIn(f"__{user.id}__", user.username)
+        self.assertNotRegex(user.username, rf"(^|__)0*{user.id}(__|\b)")
+
+    def test_email_does_not_contain_user_id_as_segment(self):
+        """user_id must not appear as a __ delimited segment in the email."""
+        user = self._create_user()
+        gateway = DjangoAccountDeletionGateway()
+        gateway.deactivate_user(user.id)
+
+        user.refresh_from_db()
+        self.assertNotIn(f"__{user.id}__", user.email)
+        self.assertNotRegex(user.email, rf"(^|__)0*{user.id}(__|\b)")
+
+    def test_username_matches_uuid_hex_format(self):
+        """Username must follow deleted__<uuid_hex> format."""
+        user = self._create_user()
+        gateway = DjangoAccountDeletionGateway()
+        gateway.deactivate_user(user.id)
+
+        user.refresh_from_db()
+        self.assertRegex(user.username, _USERNAME_PATTERN)
+
+    def test_email_matches_uuid_hex_format(self):
+        """Email must follow deleted__<uuid_hex>@invalid.local format."""
+        user = self._create_user()
+        gateway = DjangoAccountDeletionGateway()
+        gateway.deactivate_user(user.id)
+
+        user.refresh_from_db()
+        self.assertRegex(user.email, _EMAIL_PATTERN)
+
+    def test_user_is_deactivated(self):
+        user = self._create_user()
+        gateway = DjangoAccountDeletionGateway()
+        gateway.deactivate_user(user.id)
+
+        user.refresh_from_db()
+        self.assertFalse(user.is_active)

--- a/backend/app/use_cases/auth/delete_account.py
+++ b/backend/app/use_cases/auth/delete_account.py
@@ -2,7 +2,6 @@
 Use case: Deactivate a user account and enqueue data cleanup.
 """
 
-import datetime
 import logging
 
 from app.domain.auth.gateways import AccountDeletionGateway, AuthTaskGateway
@@ -33,8 +32,7 @@ class AccountDeletionUseCase:
         with self.tx.atomic():
             self.deletion_gateway.record_deletion_request(user_id, reason)
 
-            suffix = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S")
-            self.deletion_gateway.deactivate_user(user_id, suffix)
+            self.deletion_gateway.deactivate_user(user_id)
             self.task_queue.enqueue_account_deletion(user_id)
 
         logger.info("Account deletion initiated for user %s", user_id)

--- a/backend/app/use_cases/auth/tests/test_delete_account.py
+++ b/backend/app/use_cases/auth/tests/test_delete_account.py
@@ -34,7 +34,7 @@ class AccountDeletionUseCaseTests(TestCase):
         use_case.execute(user_id=1, reason="cleanup")
 
         deletion_gateway.record_deletion_request.assert_called_once_with(1, "cleanup")
-        deletion_gateway.deactivate_user.assert_called_once()
+        deletion_gateway.deactivate_user.assert_called_once_with(1)
         task_gateway.enqueue_account_deletion.assert_called_once_with(1)
 
     def test_works_without_reason(self):
@@ -43,5 +43,5 @@ class AccountDeletionUseCaseTests(TestCase):
         use_case.execute(user_id=42)
 
         deletion_gateway.record_deletion_request.assert_called_once_with(42, "")
-        deletion_gateway.deactivate_user.assert_called_once()
+        deletion_gateway.deactivate_user.assert_called_once_with(42)
         task_gateway.enqueue_account_deletion.assert_called_once_with(42)


### PR DESCRIPTION
## 関連Issue
Closes #519

## 変更内容

削除済みアカウントのusername・emailに`user_id`が直接含まれており、外部からIDの推測が可能だったセキュリティ上の問題を修正。

**変更前**
```python
user.username = f"deleted__{user_id}__{suffix}"
user.email = f"deleted__{user_id}__{suffix}@invalid.local"
```

**変更後**
```python
random_id = uuid.uuid4().hex
user.username = f"deleted__{random_id}"
user.email = f"deleted__{random_id}@invalid.local"
```

あわせて、UUID導入により不要になった`suffix`パラメータを全レイヤー（domain / use_case / infrastructure）から削除。

## 修正ファイル

| ファイル | 変更内容 |
|---|---|
| `domain/auth/gateways.py` | `deactivate_user`シグネチャから`suffix`を削除 |
| `use_cases/auth/delete_account.py` | `suffix`生成ロジックと`datetime` importを削除 |
| `infrastructure/repositories/django_account_deletion_repository.py` | `uuid4().hex`を使ったID匿名化に変更 |
| `use_cases/auth/tests/test_delete_account.py` | `deactivate_user`の引数を正確に検証するよう更新 |
| `infrastructure/repositories/tests/test_django_account_deletion_repository.py` | 新規: UUID形式・user_id不在を検証するテストを追加 |

## テスト計画

- [x] `test_username_does_not_contain_user_id_as_segment` — usernameに`user_id`が含まれないことを検証
- [x] `test_email_does_not_contain_user_id_as_segment` — emailに`user_id`が含まれないことを検証
- [x] `test_username_matches_uuid_hex_format` — `deleted__<32文字hex>`形式を正規表現で検証
- [x] `test_email_matches_uuid_hex_format` — `deleted__<32文字hex>@invalid.local`形式を検証
- [x] `test_user_is_deactivated` — `is_active=False`になることを検証
- [x] 既存テスト（use_case / account_deletion task）すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)