### PR TITLE
fix: CDワークフローでマージコミット時にデプロイがスキップされる問題を修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,7 @@ jobs:
         id: filter
         if: github.event_name != 'workflow_dispatch'
         with:
+          base: HEAD~1
           filters: |
             backend:
               - 'backend/**'


### PR DESCRIPTION
## Summary

- `dorny/paths-filter@v3` に `base: HEAD~1` を追加
- `workflow_run` トリガー時は `before` フィールドがイベントペイロードに含まれないため、フォールバックとして最後のコミットの変更を検出しようとするが、マージコミットはデフォルトでdiffを表示しないため **0 changed files** と判定されデプロイがスキップされていた
- `base: HEAD~1` を明示することで親コミットとの差分を正しく検出できるようになる（`fetch-depth: 2` で親コミットは取得済み）

## Test plan

- [ ] mainブランチへのマージ後にCDワークフローが正常にトリガーされ、`backend = true` と判定されてデプロイが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)