### PR TITLE
fix: workflow_runトリガー時にデプロイがスキップされる問題を修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      backend: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.backend == 'true' }}
+      backend: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' || steps.filter.outputs.backend == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 2
       - uses: dorny/paths-filter@v3
         id: filter
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_run'
         with:
           filters: |
             backend:


### PR DESCRIPTION
## Summary

- `workflow_run` トリガー時に `dorny/paths-filter` がマージコミットのdiffを0件と判定し、デプロイがスキップされていた問題を修正
- `workflow_run` と `workflow_dispatch` トリガー時は paths-filter をスキップして常にデプロイするよう変更

## 原因

`workflow_run` イベントにはペイロードに `before` フィールドが含まれないため、paths-filter は最後のコミットの変更を検出しようとする。しかしマージコミットはデフォルトで diff を表示しないため **0 changed files** と判定され `backend = false` となっていた。

## 変更内容

```yaml
# Before
backend: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.backend == 'true' }}
if: github.event_name != 'workflow_dispatch'

# After
backend: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' || steps.filter.outputs.backend == 'true' }}
if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_run'
```

## Test plan

- [ ] main ブランチへのマージ後に CD ワークフローが正常にトリガーされ、デプロイが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)