### PR TITLE
fix: with_error_handling がDRFの4xxを500に潰す問題を修正

### DIFF
--- a/backend/app/presentation/common/decorators.py
+++ b/backend/app/presentation/common/decorators.py
@@ -39,12 +39,20 @@ def authenticated_api_view(methods):
 
 
 def with_error_handling(view_func):
-    """Common error handling decorator."""
+    """Common error handling decorator.
+
+    DRF APIException subclasses (4xx) are re-raised so DRF's
+    custom_exception_handler can convert them to the correct response.
+    Only non-DRF exceptions are caught and normalised to HTTP 500.
+    """
+    from rest_framework.exceptions import APIException
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
         try:
             return view_func(*args, **kwargs)
+        except APIException:
+            raise
         except Exception as e:
             logger.exception("Unhandled exception in %s", view_func.__name__)
             return create_error_response(str(e), status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/backend/app/presentation/common/tests/test_decorators.py
+++ b/backend/app/presentation/common/tests/test_decorators.py
@@ -1,0 +1,100 @@
+"""
+Tests for with_error_handling decorator.
+
+Verifies that DRF APIException subclasses are NOT swallowed
+(they propagate so DRF's custom_exception_handler can convert them
+to the correct 4xx response), while non-DRF exceptions are caught
+and converted to 500.
+"""
+
+import unittest
+
+from rest_framework import status
+from rest_framework.exceptions import (
+    NotAuthenticated,
+    PermissionDenied,
+    ValidationError,
+)
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+
+from app.presentation.common.decorators import with_error_handling
+
+
+def _make_view(exc):
+    """Return a simple view function that raises *exc* when called."""
+
+    @with_error_handling
+    def view(request):
+        raise exc
+
+    return view
+
+
+class WithErrorHandlingDrfExceptionsTest(unittest.TestCase):
+    """DRF APIException subclasses must propagate, not be swallowed."""
+
+    def setUp(self):
+        factory = APIRequestFactory()
+        self.request = factory.get("/")
+
+    def _call(self, exc):
+        view = _make_view(exc)
+        return view(self.request)
+
+    def test_validation_error_propagates(self):
+        """ValidationError (400) must not be converted to 500."""
+        with self.assertRaises(ValidationError):
+            self._call(ValidationError("invalid input"))
+
+    def test_permission_denied_propagates(self):
+        """PermissionDenied (403) must not be converted to 500."""
+        with self.assertRaises(PermissionDenied):
+            self._call(PermissionDenied())
+
+    def test_not_authenticated_propagates(self):
+        """NotAuthenticated (401) must not be converted to 500."""
+        with self.assertRaises(NotAuthenticated):
+            self._call(NotAuthenticated())
+
+
+class WithErrorHandlingNonDrfExceptionsTest(unittest.TestCase):
+    """Non-DRF exceptions must be caught and returned as 500 responses."""
+
+    def setUp(self):
+        factory = APIRequestFactory()
+        self.request = factory.get("/")
+
+    def _call(self, exc):
+        view = _make_view(exc)
+        return view(self.request)
+
+    def test_generic_exception_returns_500(self):
+        """Unhandled Exception must produce HTTP 500, not propagate."""
+        response = self._call(Exception("something went wrong"))
+        self.assertIsInstance(response, Response)
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def test_value_error_returns_500(self):
+        """ValueError must produce HTTP 500."""
+        response = self._call(ValueError("bad value"))
+        self.assertIsInstance(response, Response)
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def test_runtime_error_returns_500(self):
+        """RuntimeError must produce HTTP 500."""
+        response = self._call(RuntimeError("runtime failure"))
+        self.assertIsInstance(response, Response)
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def test_success_response_returned_unchanged(self):
+        """When view succeeds, its response is returned as-is."""
+
+        @with_error_handling
+        def ok_view(request):
+            return Response({"ok": True}, status=status.HTTP_200_OK)
+
+        factory = APIRequestFactory()
+        response = ok_view(factory.get("/"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"ok": True})


### PR DESCRIPTION
## 概要

`with_error_handling` デコレータがDRF標準の例外(`APIException`サブクラス)を握り潰し、本来4xxで返すべきレスポンスを500に変換していた問題を修正する。

Closes #549

## 変更内容

### `backend/app/presentation/common/decorators.py`

`except APIException: raise` を追加し、`ValidationError`・`PermissionDenied`・`NotAuthenticated` 等のDRF例外を再raiseしてDRFの `custom_exception_handler` に委ねるようにした。非DRF例外は引き続き500に正規化される。

```
リクエスト
→ authenticated_api_view (DRF api_view machinery)
  → with_error_handling
    → 元ビュー関数

ビューが APIException を raise
→ with_error_handling が再raise
→ DRF api_view が custom_exception_handler を呼ぶ
→ 正しい 4xx レスポンスが返る  ✓

ビューが ValueError 等を raise
→ with_error_handling が捕捉 → 500 レスポンス  ✓
```

影響ビュー: `add_videos_to_group`、`reorder_videos_in_group`、`add_tags_to_video`、`remove_tag_from_video`

### `backend/app/presentation/common/tests/test_decorators.py`（新規）

TDDで追加。7テスト。

- `WithErrorHandlingDrfExceptionsTest`: `ValidationError`・`PermissionDenied`・`NotAuthenticated` が再raiseされることを確認
- `WithErrorHandlingNonDrfExceptionsTest`: 非DRF例外が500レスポンスに変換されることを確認

## テスト計画

- [x] `test_validation_error_propagates` — ValidationError が伝播する
- [x] `test_permission_denied_propagates` — PermissionDenied が伝播する
- [x] `test_not_authenticated_propagates` — NotAuthenticated が伝播する
- [x] `test_generic_exception_returns_500` — 汎用例外は500
- [x] `test_value_error_returns_500` — ValueError は500
- [x] `test_runtime_error_returns_500` — RuntimeError は500
- [x] `test_success_response_returned_unchanged` — 正常系は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)