### PR TITLE
fix: BILLING_ENABLED=false のときプラン一覧を返さないようにする

### DIFF
--- a/backend/app/composition_root/billing.py
+++ b/backend/app/composition_root/billing.py
@@ -68,7 +68,7 @@ def _new_user_repo():
 
 
 def get_plans_use_case() -> GetPlansUseCase:
-    return GetPlansUseCase()
+    return GetPlansUseCase(billing_enabled=_billing_enabled())
 
 
 def get_subscription_use_case() -> GetSubscriptionUseCase:

--- a/backend/app/use_cases/billing/get_plans.py
+++ b/backend/app/use_cases/billing/get_plans.py
@@ -5,7 +5,12 @@ from app.use_cases.billing.dtos import PlanDTO
 
 
 class GetPlansUseCase:
+    def __init__(self, billing_enabled: bool = True) -> None:
+        self._billing_enabled = billing_enabled
+
     def execute(self) -> List[PlanDTO]:
+        if not self._billing_enabled:
+            return []
         plans = []
         for plan_type in [PlanType.FREE, PlanType.LITE, PlanType.STANDARD, PlanType.ENTERPRISE]:
             limits = PLAN_LIMITS[plan_type]

--- a/backend/app/use_cases/billing/tests/test_get_plans.py
+++ b/backend/app/use_cases/billing/tests/test_get_plans.py
@@ -69,3 +69,21 @@ class GetPlansUseCaseTests(TestCase):
         plans = self.use_case.execute()
         free = next(p for p in plans if p.plan_id == "free")
         self.assertEqual(free.ai_answers, 500)
+
+
+class GetPlansUseCaseBillingDisabledTests(TestCase):
+    def setUp(self):
+        self.use_case = GetPlansUseCase(billing_enabled=False)
+
+    def test_returns_empty_list_when_billing_disabled(self):
+        plans = self.use_case.execute()
+        self.assertEqual(plans, [])
+
+
+class GetPlansUseCaseBillingEnabledTests(TestCase):
+    def setUp(self):
+        self.use_case = GetPlansUseCase(billing_enabled=True)
+
+    def test_returns_four_plans_when_billing_enabled(self):
+        plans = self.use_case.execute()
+        self.assertEqual(len(plans), 4)

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -856,7 +856,8 @@
         "storage": "Custom",
         "transcription": "Custom",
         "aiAnswers": "Custom"
-      }
+      },
+      "notEnabled": "Billing is not enabled."
     },
     "manage": {
       "title": "Manage Subscription",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -856,7 +856,8 @@
         "storage": "カスタム",
         "transcription": "カスタム",
         "aiAnswers": "カスタム"
-      }
+      },
+      "notEnabled": "課金機能は現在利用できません。"
     },
     "manage": {
       "title": "サブスクリプション管理",

--- a/frontend/src/pages/BillingPage.tsx
+++ b/frontend/src/pages/BillingPage.tsx
@@ -459,7 +459,7 @@ export default function BillingPage() {
           )}
 
           {plans.length === 0 ? (
-            <p className="text-sm text-[#6f7a6e]">Billing is not enabled.</p>
+            <p className="text-sm text-[#6f7a6e]">{t('billing.plans.notEnabled')}</p>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
               {plans.map((plan) => (
@@ -485,7 +485,7 @@ export default function BillingPage() {
         </section>
 
         {/* ── Section 3: Manage Subscription ───────────────────────────── */}
-        {isActivePaidSub && (
+        {plans.length > 0 && isActivePaidSub && (
           <section className="bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] p-5">
             <h2 className="text-base font-bold text-[#191c19] mb-1">
               {t('billing.manage.title')}


### PR DESCRIPTION
## 概要

`BILLING_ENABLED=false` のとき `GET /api/billing/plans/` が常に4プランを返していた問題を修正。

closes #558

## 変更内容

### Backend
- `GetPlansUseCase.__init__` に `billing_enabled: bool = True` を追加し、`false` のとき `execute()` が空リストを返すよう変更
- `composition_root/billing.py` の `get_plans_use_case()` で `billing_enabled=_billing_enabled()` を渡すよう変更

### Frontend
- `BillingPage.tsx`: `plans.length === 0` 時のメッセージをハードコードから `t('billing.plans.notEnabled')` に変更
- `BillingPage.tsx`: `plans.length === 0` 時はサブスクリプション管理セクションも非表示に
- `ja/translation.json` / `en/translation.json`: `billing.plans.notEnabled` キーを追加

## テスト

- `billing_enabled=False` → `[]` を返すことを確認するテストを追加
- `billing_enabled=True` → 4プランを返すことを確認するテストを追加

## Test plan

- [ ] `BILLING_ENABLED=false` で `/billing` ページを開き、プランセクションに「課金機能は現在利用できません。」が表示されることを確認
- [ ] `BILLING_ENABLED=false` でサブスクリプション管理セクションが表示されないことを確認
- [ ] `BILLING_ENABLED=true` で従来通り4プランが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)