### PR TITLE
fix: coverage ディレクトリを ESLint の ignore 対象に追加する

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/frontend/src/__tests__/eslintConfig.test.ts
+++ b/frontend/src/__tests__/eslintConfig.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { describe, it, expect } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+describe('eslint.config.js', () => {
+  const configContent = readFileSync(
+    resolve(__dirname, '../../eslint.config.js'),
+    'utf-8',
+  )
+
+  it('ignores coverage directory', () => {
+    expect(configContent).toMatch(/globalIgnores\(\[.*'coverage'.*\]\)/s)
+  })
+})


### PR DESCRIPTION
## Summary

- `frontend/eslint.config.js` の `globalIgnores` に `'coverage'` を追加し、カバレッジ生成物を ESLint の走査対象から除外した
- `src/__tests__/eslintConfig.test.ts` を追加し、`coverage` が ignore 対象に含まれることをテストで保証した

Closes #548

## Test plan

- [ ] `npm run lint` が警告・エラーなしで通過することを確認
- [ ] `npm test` が全テスト (443 tests) パスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)