### PR TITLE
chore: .gitignore に .venv を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 *.pyc
 *.pyo
 *.egg-info
+.venv
 
 # Node / Frontend
 node_modules


### PR DESCRIPTION
## Summary

- `backend/.venv` がローカル生成物として未追跡になりやすいため、`.venv` パターンを `.gitignore` に追加

## Related Issue

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)