### PR TITLE
fix: テスト完了時の scan_counts デバッグ出力を削除し再発防止テストを追加する

### DIFF
--- a/backend/app/tests/test_import_rules.py
+++ b/backend/app/tests/test_import_rules.py
@@ -385,7 +385,6 @@ class ImportRulesTest(unittest.TestCase):
             "composition_root": self._count_python_files("composition_root"),
             "entrypoints": self._count_python_files("entrypoints"),
         }
-        print("scan_counts", counts)
         for layer, count in counts.items():
             self.assertGreater(
                 count,
@@ -1104,4 +1103,29 @@ class ImportRulesTest(unittest.TestCase):
             disallowed_files,
             "No files other than app/presentation/tasks/__init__.py are allowed:\n"
             + "\n".join(f"  {v}" for v in disallowed_files),
+        )
+
+    def test_no_print_statements_in_test_files(self):
+        """Test files must not contain print() calls (prevents debug noise in CI output)."""
+        violations = []
+        for fp in get_python_files(APP_TESTS_ROOT):
+            with open(fp, encoding="utf-8") as f:
+                source = f.read()
+            try:
+                tree = ast.parse(source, filename=fp)
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "print"
+                ):
+                    rel = os.path.relpath(fp, BASE)
+                    violations.append(f"{rel}:{node.lineno}")
+        self.assertEqual(
+            [],
+            violations,
+            "print() calls must be removed from test files to keep CI output clean:\n"
+            + "\n".join(f"  {v}" for v in violations),
         )

--- a/backend/app/tests/test_import_rules.py
+++ b/backend/app/tests/test_import_rules.py
@@ -1108,7 +1108,13 @@ class ImportRulesTest(unittest.TestCase):
     def test_no_print_statements_in_test_files(self):
         """Test files must not contain print() calls (prevents debug noise in CI output)."""
         violations = []
-        for fp in get_python_files(APP_TESTS_ROOT):
+        test_files = [
+            str(Path(root) / f)
+            for root, _, files in os.walk(APP_TESTS_ROOT)
+            for f in files
+            if f.endswith(".py")
+        ]
+        for fp in test_files:
             with open(fp, encoding="utf-8") as f:
                 source = f.read()
             try:


### PR DESCRIPTION
## Summary

- `test_layer_scan_counts_are_non_zero` に残っていた `print("scan_counts", counts)` を削除し、テスト成功時に余計な標準出力が出ないようにした
- `test_no_print_statements_in_test_files` を追加し、`app/tests/` 配下のテストファイルに `print()` が残った場合は CI で検出できるようにした (AST 静的解析)

Closes #553

## Test plan

- [x] `docker compose run --rm backend python manage.py test app.tests.test_import_rules` が `scan_counts` 出力なしで OK になること
- [x] テストファイルに `print()` を追加すると `test_no_print_statements_in_test_files` が失敗することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)