### PR TITLE
fix: OpenAI互換 chat endpoint で課金上限例外が 500 に化ける問題を修正する

### DIFF
--- a/backend/app/presentation/chat/tests/test_views.py
+++ b/backend/app/presentation/chat/tests/test_views.py
@@ -13,7 +13,7 @@ from rest_framework.test import APIClient, APITestCase
 
 from app.domain.chat.dtos import CitationDTO
 from app.domain.chat.gateways import LLMConfigurationError, RagResult
-from app.use_cases.billing.exceptions import OverQuotaError
+from app.use_cases.billing.exceptions import AiAnswersLimitExceeded, OverQuotaError
 from app.use_cases.chat.exceptions import LLMProviderError
 
 User = get_user_model()
@@ -270,3 +270,45 @@ class ChatViewTests(APITestCase):
         self.assertEqual(citation["start_time"], "00:00:10")
         self.assertEqual(response.data["citations"][0]["id"], 1)
         self.assertEqual(response.data["citations"][0]["video_id"], self.video.id)
+
+
+class OpenAIChatCompletionsViewTests(APITestCase):
+    """Regression tests for OpenAIChatCompletionsView billing exception handling."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="openai_testuser",
+            email="openai_test@example.com",
+            password="testpass123",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse("openai-chat-completions")
+        self.payload = {
+            "model": "videoq",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+
+    @patch("app.use_cases.billing.check_ai_answers_limit.CheckAiAnswersLimitUseCase.execute")
+    def test_over_quota_returns_403_with_openai_error_format(self, mock_check):
+        """OverQuotaError must return 403 in OpenAI-compatible error format."""
+        mock_check.side_effect = OverQuotaError(
+            "AI chat is unavailable: account storage is over the plan limit."
+        )
+
+        response = self.client.post(self.url, self.payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("error", response.data)
+        self.assertEqual(response.data["error"]["type"], "insufficient_quota")
+
+    @patch("app.use_cases.billing.check_ai_answers_limit.CheckAiAnswersLimitUseCase.execute")
+    def test_ai_answers_limit_exceeded_returns_400_with_openai_error_format(self, mock_check):
+        """AiAnswersLimitExceeded must return 400 in OpenAI-compatible error format."""
+        mock_check.side_effect = AiAnswersLimitExceeded("AI answers limit exceeded. Limit: 100.")
+
+        response = self.client.post(self.url, self.payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error", response.data)
+        self.assertEqual(response.data["error"]["type"], "insufficient_quota")

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -473,6 +473,10 @@ class OpenAIChatCompletionsView(DependencyResolverMixin, APIView):
             return self._error(str(e), "invalid_request_error", status.HTTP_404_NOT_FOUND)
         except PermissionDenied as e:
             return self._error(str(e), "permission_denied", status.HTTP_403_FORBIDDEN)
+        except OverQuotaError as e:
+            return self._error(str(e), "insufficient_quota", status.HTTP_403_FORBIDDEN)
+        except AiAnswersLimitExceeded as e:
+            return self._error(str(e), "insufficient_quota", status.HTTP_400_BAD_REQUEST)
         except LLMConfigurationError as e:
             return self._error(str(e), "invalid_request_error", status.HTTP_400_BAD_REQUEST)
         except LLMProviderError as e:


### PR DESCRIPTION
## 概要

OpenAI互換 chat endpoint (`POST /api/v1/chat/completions`) が `SendMessageUseCase` から送出される課金上限例外をキャッチしていなかった問題を修正する。

- `OverQuotaError`（ストレージ容量超過）
- `AiAnswersLimitExceeded`（AI回答回数上限超過）

通常の chat endpoint では 403 / 400 に変換されるこれらの例外が、OpenAI互換エンドポイントでは未処理のまま 500 に化けていた。

Closes #567

## 変更内容

- `OpenAIChatCompletionsView.post` に `OverQuotaError` / `AiAnswersLimitExceeded` の `except` 節を追加
  - `OverQuotaError` → 403、`error.type: "insufficient_quota"`
  - `AiAnswersLimitExceeded` → 400、`error.type: "insufficient_quota"`
- `OpenAIChatCompletionsViewTests` クラスを新設し、回帰テスト2件を追加

## テスト計画

- [x] `OpenAIChatCompletionsViewTests.test_over_quota_returns_403_with_openai_error_format`
- [x] `OpenAIChatCompletionsViewTests.test_ai_answers_limit_exceeded_returns_400_with_openai_error_format`
- [x] 既存の chat view テスト 14件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)