### PR TITLE
fix: Stripe の戻り先 URL に許可ドメイン制限を追加する

### DIFF
--- a/backend/app/composition_root/billing.py
+++ b/backend/app/composition_root/billing.py
@@ -48,8 +48,10 @@ def _get_price_map() -> dict:
 
 
 def _get_allowed_origins() -> list:
-    from django.conf import settings
-    return list(getattr(settings, "CORS_ALLOWED_ORIGINS", []))
+    env = os.environ.get("CORS_ALLOWED_ORIGINS")
+    if env:
+        return [o.strip() for o in env.split(",") if o.strip()]
+    return ["http://localhost:3000", "http://127.0.0.1:3000"]
 
 
 def _get_plan_price_map() -> dict:

--- a/backend/app/composition_root/billing.py
+++ b/backend/app/composition_root/billing.py
@@ -47,6 +47,11 @@ def _get_price_map() -> dict:
     return {k: v for k, v in entries.items() if k}
 
 
+def _get_allowed_origins() -> list:
+    from django.conf import settings
+    return list(getattr(settings, "CORS_ALLOWED_ORIGINS", []))
+
+
 def _get_plan_price_map() -> dict:
     """Returns PlanType -> {currency -> price_id} mapping for checkout."""
     from app.domain.billing.entities import PlanType
@@ -82,6 +87,7 @@ def get_create_checkout_session_use_case() -> CreateCheckoutSessionUseCase:
         billing_enabled=_billing_enabled(),
         price_map=_get_plan_price_map(),
         user_repo=_new_user_repo(),
+        allowed_origins=_get_allowed_origins(),
     )
 
 
@@ -90,6 +96,7 @@ def get_create_billing_portal_use_case() -> CreateBillingPortalUseCase:
         subscription_repo=_new_subscription_repo(),
         billing_gateway=_new_billing_gateway(),
         billing_enabled=_billing_enabled(),
+        allowed_origins=_get_allowed_origins(),
     )
 
 

--- a/backend/app/presentation/billing/tests/test_views.py
+++ b/backend/app/presentation/billing/tests/test_views.py
@@ -15,6 +15,7 @@ from app.use_cases.billing.dtos import (
 )
 from app.use_cases.billing.exceptions import (
     BillingNotEnabled,
+    InvalidReturnUrl,
     NoStripeCustomer,
 )
 
@@ -290,6 +291,26 @@ class CreateCheckoutSessionViewTests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_checkout_invalid_return_url_returns_400(self):
+        url = reverse("billing-checkout")
+        mock_use_case = MagicMock()
+        mock_use_case.execute.side_effect = InvalidReturnUrl("URL origin is not allowed.")
+        with patch(
+            "app.presentation.billing.views.CreateCheckoutSessionView.resolve_dependency",
+            return_value=mock_use_case,
+        ):
+            response = self.client.post(
+                url,
+                {
+                    "plan": "lite",
+                    "success_url": "https://evil.example.com/success",
+                    "cancel_url": "https://app.test/cancel",
+                },
+                format="json",
+            )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"]["code"], "INVALID_RETURN_URL")
+
     def test_checkout_allows_downgrade_regardless_of_storage_usage(self):
         """Downgrade is always permitted; is_over_quota handles post-downgrade enforcement."""
         url = reverse("billing-checkout")
@@ -350,6 +371,22 @@ class CreateBillingPortalViewTests(APITestCase):
             response.data["portal_url"],
             "https://billing.stripe.com/portal_test",
         )
+
+    def test_portal_invalid_return_url_returns_400(self):
+        url = reverse("billing-portal")
+        mock_use_case = MagicMock()
+        mock_use_case.execute.side_effect = InvalidReturnUrl("URL origin is not allowed.")
+        with patch(
+            "app.presentation.billing.views.CreateBillingPortalView.resolve_dependency",
+            return_value=mock_use_case,
+        ):
+            response = self.client.post(
+                url,
+                {"return_url": "https://evil.example.com/billing"},
+                format="json",
+            )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"]["code"], "INVALID_RETURN_URL")
 
     def test_portal_no_stripe_customer_returns_400(self):
         url = reverse("billing-portal")

--- a/backend/app/presentation/billing/views.py
+++ b/backend/app/presentation/billing/views.py
@@ -23,6 +23,7 @@ from app.presentation.common.responses import create_error_response
 from app.use_cases.billing.exceptions import (
     BillingNotEnabled,
     InvalidPlan,
+    InvalidReturnUrl,
     NoStripeCustomer,
 )
 
@@ -88,6 +89,10 @@ class CreateCheckoutSessionView(AuthenticatedAPIView):
             )
         except InvalidPlan as e:
             return create_error_response(str(e), status.HTTP_400_BAD_REQUEST)
+        except InvalidReturnUrl as e:
+            return create_error_response(
+                str(e), status.HTTP_400_BAD_REQUEST, code="INVALID_RETURN_URL"
+            )
         except Exception as e:
             logger.exception("Unexpected error creating checkout session: %s", e)
             return create_error_response(
@@ -127,6 +132,10 @@ class CreateBillingPortalView(AuthenticatedAPIView):
                 "No billing account found.",
                 status.HTTP_400_BAD_REQUEST,
                 code="NO_STRIPE_CUSTOMER",
+            )
+        except InvalidReturnUrl as e:
+            return create_error_response(
+                str(e), status.HTTP_400_BAD_REQUEST, code="INVALID_RETURN_URL"
             )
         except Exception as e:
             logger.exception("Unexpected error creating billing portal: %s", e)

--- a/backend/app/use_cases/billing/create_billing_portal.py
+++ b/backend/app/use_cases/billing/create_billing_portal.py
@@ -1,6 +1,8 @@
+from urllib.parse import urlparse
+
 from app.domain.billing.ports import BillingGateway, SubscriptionRepository
 from app.use_cases.billing.dtos import BillingPortalDTO
-from app.use_cases.billing.exceptions import BillingNotEnabled, NoStripeCustomer
+from app.use_cases.billing.exceptions import BillingNotEnabled, InvalidReturnUrl, NoStripeCustomer
 
 
 class CreateBillingPortalUseCase:
@@ -9,14 +11,21 @@ class CreateBillingPortalUseCase:
         subscription_repo: SubscriptionRepository,
         billing_gateway: BillingGateway,
         billing_enabled: bool,
+        allowed_origins: list,
     ):
         self._subscription_repo = subscription_repo
         self._billing_gateway = billing_gateway
         self._billing_enabled = billing_enabled
+        self._allowed_origins = allowed_origins
 
     def execute(self, user_id: int, return_url: str) -> BillingPortalDTO:
         if not self._billing_enabled:
             raise BillingNotEnabled("Billing is not enabled.")
+
+        parsed = urlparse(return_url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        if origin not in self._allowed_origins:
+            raise InvalidReturnUrl(f"URL origin '{origin}' is not in the allowed list.")
 
         entity = self._subscription_repo.get_or_create(user_id)
 

--- a/backend/app/use_cases/billing/create_checkout_session.py
+++ b/backend/app/use_cases/billing/create_checkout_session.py
@@ -1,9 +1,12 @@
+from urllib.parse import urlparse
+
 from app.domain.billing.entities import PlanType
 from app.domain.billing.ports import BillingGateway, SubscriptionRepository
 from app.use_cases.billing.dtos import CheckoutSessionDTO
 from app.use_cases.billing.exceptions import (
     BillingNotEnabled,
     InvalidPlan,
+    InvalidReturnUrl,
 )
 
 
@@ -15,12 +18,14 @@ class CreateCheckoutSessionUseCase:
         billing_enabled: bool,
         price_map: dict,
         user_repo,
+        allowed_origins: list,
     ):
         self._subscription_repo = subscription_repo
         self._billing_gateway = billing_gateway
         self._billing_enabled = billing_enabled
         self._price_map = price_map  # {PlanType.LITE: {"jpy": "price_xxx", "usd": "price_yyy"}, ...}
         self._user_repo = user_repo
+        self._allowed_origins = allowed_origins
 
     def execute(
         self,
@@ -32,6 +37,9 @@ class CreateCheckoutSessionUseCase:
     ) -> CheckoutSessionDTO:
         if not self._billing_enabled:
             raise BillingNotEnabled("Billing is not enabled.")
+
+        self._validate_url(success_url)
+        self._validate_url(cancel_url)
 
         # Validate plan — only paid, non-enterprise plans can be checked out
         try:
@@ -124,3 +132,9 @@ class CreateCheckoutSessionUseCase:
                 raise
 
         return CheckoutSessionDTO(checkout_url=session.url)
+
+    def _validate_url(self, url: str) -> None:
+        parsed = urlparse(url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        if origin not in self._allowed_origins:
+            raise InvalidReturnUrl(f"URL origin '{origin}' is not in the allowed list.")

--- a/backend/app/use_cases/billing/exceptions.py
+++ b/backend/app/use_cases/billing/exceptions.py
@@ -22,6 +22,10 @@ class InvalidPlan(Exception):
     pass
 
 
+class InvalidReturnUrl(Exception):
+    pass
+
+
 class DowngradeNotAllowed(Exception):
     def __init__(self, *, used_storage_bytes: int, target_limit_bytes: int):
         self.used_storage_bytes = used_storage_bytes

--- a/backend/app/use_cases/billing/tests/test_create_billing_portal.py
+++ b/backend/app/use_cases/billing/tests/test_create_billing_portal.py
@@ -1,0 +1,195 @@
+"""Unit tests for CreateBillingPortalUseCase."""
+
+from typing import Optional
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from app.domain.billing.entities import PlanType, SubscriptionEntity
+from app.domain.billing.ports import (
+    BillingGateway,
+    SubscriptionEventData,
+    SubscriptionRepository,
+    WebhookEvent,
+)
+from app.use_cases.billing.create_billing_portal import CreateBillingPortalUseCase
+from app.use_cases.billing.exceptions import (
+    BillingNotEnabled,
+    InvalidReturnUrl,
+    NoStripeCustomer,
+)
+
+
+def _make_subscription(**kwargs) -> SubscriptionEntity:
+    defaults = {
+        "user_id": 1,
+        "plan": PlanType.FREE,
+        "stripe_customer_id": "cus_test",
+        "stripe_subscription_id": None,
+        "stripe_status": "",
+        "current_period_end": None,
+        "cancel_at_period_end": False,
+        "used_storage_bytes": 0,
+        "used_processing_seconds": 0,
+        "used_ai_answers": 0,
+        "usage_period_start": None,
+        "custom_storage_gb": None,
+        "custom_processing_minutes": None,
+        "custom_ai_answers": None,
+        "unlimited_processing_minutes": False,
+        "unlimited_ai_answers": False,
+    }
+    defaults.update(kwargs)
+    return SubscriptionEntity(**defaults)  # type: ignore[arg-type]
+
+
+class _StubSubscriptionRepo(SubscriptionRepository):
+    def __init__(self, entity: SubscriptionEntity):
+        self._entity = entity
+
+    def get_or_create(self, user_id: int) -> SubscriptionEntity:
+        return self._entity
+
+    def get_by_user_id(self, user_id: int) -> Optional[SubscriptionEntity]:
+        return self._entity
+
+    def get_by_stripe_customer_id(self, customer_id: str) -> Optional[SubscriptionEntity]:
+        return None
+
+    def save(self, entity: SubscriptionEntity) -> SubscriptionEntity:
+        return entity
+
+    def create_stripe_customer(self, user_id: int, customer_id: str) -> SubscriptionEntity:
+        return self._entity
+
+    def clear_stripe_customer(self, user_id: int) -> None:
+        pass
+
+    def get_or_create_stripe_customer(self, user_id: int, create_fn, replace_if_stale=None) -> tuple:
+        return self._entity.stripe_customer_id, self._entity
+
+    def reset_monthly_usage(self, user_id: int, period_start) -> None:
+        pass
+
+    def maybe_reset_monthly_usage(self, user_id: int) -> None:
+        pass
+
+    def check_and_reserve_storage(self, user_id: int, additional_bytes: int) -> None:
+        pass
+
+    def increment_storage_bytes(self, user_id: int, bytes_delta: int) -> None:
+        pass
+
+    def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
+        pass
+
+    def increment_ai_answers(self, user_id: int) -> None:
+        pass
+
+    def clear_over_quota_if_within_limit(self, user_id: int) -> None:
+        pass
+
+
+class _StubBillingGateway(BillingGateway):
+    def __init__(self, portal_url: str = "https://billing.stripe.com/portal_test"):
+        self._portal_url = portal_url
+
+    def get_or_create_customer(self, user_id, email, username) -> str:
+        return "cus_test"
+
+    def create_checkout_session(self, customer_id, price_id, success_url, cancel_url, user_id, plan):
+        session = MagicMock()
+        session.url = "https://checkout.test"
+        return session
+
+    def update_subscription(self, subscription_id, price_id) -> None:
+        pass
+
+    def create_billing_portal(self, customer_id, return_url):
+        portal = MagicMock()
+        portal.url = self._portal_url
+        return portal
+
+    def verify_webhook(self, payload, sig_header, secret) -> WebhookEvent:
+        return WebhookEvent(
+            type="",
+            data_object=SubscriptionEventData(
+                id="",
+                customer="",
+                status="",
+                cancel_at_period_end=False,
+                current_period_end=None,
+                price_id=None,
+            ),
+        )
+
+    def cancel_subscription(self, subscription_id: str) -> None:
+        pass
+
+
+_DEFAULT_ALLOWED_ORIGINS = ["https://app.example.com"]
+
+
+def _make_use_case(
+    entity: Optional[SubscriptionEntity] = None,
+    billing_enabled: bool = True,
+    gateway: Optional[_StubBillingGateway] = None,
+    allowed_origins: Optional[list] = None,
+) -> CreateBillingPortalUseCase:
+    if entity is None:
+        entity = _make_subscription()
+    if gateway is None:
+        gateway = _StubBillingGateway()
+    if allowed_origins is None:
+        allowed_origins = _DEFAULT_ALLOWED_ORIGINS
+    return CreateBillingPortalUseCase(
+        subscription_repo=_StubSubscriptionRepo(entity),
+        billing_gateway=gateway,
+        billing_enabled=billing_enabled,
+        allowed_origins=allowed_origins,
+    )
+
+
+class BillingNotEnabledTests(TestCase):
+    def test_raises_billing_not_enabled(self):
+        use_case = _make_use_case(billing_enabled=False)
+        with self.assertRaises(BillingNotEnabled):
+            use_case.execute(user_id=1, return_url="https://app.example.com/billing")
+
+
+class NoStripeCustomerTests(TestCase):
+    def test_raises_no_stripe_customer_when_customer_id_missing(self):
+        entity = _make_subscription(stripe_customer_id=None)
+        use_case = _make_use_case(entity=entity)
+        with self.assertRaises(NoStripeCustomer):
+            use_case.execute(user_id=1, return_url="https://app.example.com/billing")
+
+
+class PortalCreationTests(TestCase):
+    def test_returns_portal_url(self):
+        use_case = _make_use_case()
+        dto = use_case.execute(user_id=1, return_url="https://app.example.com/billing")
+        self.assertEqual(dto.portal_url, "https://billing.stripe.com/portal_test")
+
+
+class ReturnUrlAllowlistTests(TestCase):
+    def test_raises_invalid_return_url_when_not_in_allowlist(self):
+        use_case = _make_use_case(allowed_origins=["https://app.example.com"])
+        with self.assertRaises(InvalidReturnUrl):
+            use_case.execute(user_id=1, return_url="https://evil.example.com/billing")
+
+    def test_allowed_return_url_passes_validation(self):
+        use_case = _make_use_case(allowed_origins=["https://app.example.com"])
+        dto = use_case.execute(user_id=1, return_url="https://app.example.com/billing")
+        self.assertEqual(dto.portal_url, "https://billing.stripe.com/portal_test")
+
+    def test_multiple_allowed_origins_accepts_any(self):
+        use_case = _make_use_case(
+            allowed_origins=["https://app.example.com", "https://www.example.com"]
+        )
+        dto = use_case.execute(user_id=1, return_url="https://www.example.com/billing")
+        self.assertEqual(dto.portal_url, "https://billing.stripe.com/portal_test")
+
+    def test_raises_invalid_return_url_when_allowed_origins_is_empty(self):
+        use_case = _make_use_case(allowed_origins=[])
+        with self.assertRaises(InvalidReturnUrl):
+            use_case.execute(user_id=1, return_url="https://app.example.com/billing")

--- a/backend/app/use_cases/billing/tests/test_create_checkout_session.py
+++ b/backend/app/use_cases/billing/tests/test_create_checkout_session.py
@@ -15,6 +15,7 @@ from app.use_cases.billing.create_checkout_session import CreateCheckoutSessionU
 from app.use_cases.billing.exceptions import (
     BillingNotEnabled,
     InvalidPlan,
+    InvalidReturnUrl,
 )
 
 
@@ -152,11 +153,15 @@ class _StubUserRepo:
         return user
 
 
+_DEFAULT_ALLOWED_ORIGINS = ["https://app.example.com"]
+
+
 def _make_use_case(
     entity: SubscriptionEntity,
     billing_enabled: bool = True,
     price_map: Optional[dict] = None,
     gateway: Optional[_StubBillingGateway] = None,
+    allowed_origins: Optional[list] = None,
 ) -> CreateCheckoutSessionUseCase:
     if price_map is None:
         price_map = {
@@ -165,12 +170,15 @@ def _make_use_case(
         }
     if gateway is None:
         gateway = _StubBillingGateway()
+    if allowed_origins is None:
+        allowed_origins = _DEFAULT_ALLOWED_ORIGINS
     return CreateCheckoutSessionUseCase(
         subscription_repo=_StubSubscriptionRepo(entity),
         billing_gateway=gateway,
         billing_enabled=billing_enabled,
         price_map=price_map,
         user_repo=_StubUserRepo(),
+        allowed_origins=allowed_origins,
     )
 
 
@@ -182,8 +190,8 @@ class BillingNotEnabledTests(TestCase):
             use_case.execute(
                 user_id=1,
                 plan="lite",
-                success_url="https://success",
-                cancel_url="https://cancel",
+                success_url="https://app.example.com/success",
+                cancel_url="https://app.example.com/cancel",
             )
 
 
@@ -194,8 +202,8 @@ class ValidPlanTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
             currency="jpy",
         )
         self.assertEqual(dto.checkout_url, "https://checkout.test")
@@ -206,8 +214,8 @@ class ValidPlanTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="standard",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
             currency="jpy",
         )
         self.assertEqual(dto.checkout_url, "https://checkout.test")
@@ -219,8 +227,8 @@ class ValidPlanTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
             currency="usd",
         )
         self.assertEqual(dto.checkout_url, "https://checkout.test")
@@ -233,8 +241,8 @@ class ValidPlanTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="standard",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
             currency="usd",
         )
         self.assertEqual(dto.checkout_url, "https://checkout.test")
@@ -247,8 +255,8 @@ class ValidPlanTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
         )
         self.assertEqual(dto.checkout_url, "https://checkout.test")
         self.assertEqual(gateway.last_price_id, "price_lite_jpy_001")
@@ -260,8 +268,8 @@ class ValidPlanTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
             currency="USD",
         )
         self.assertEqual(dto.checkout_url, "https://checkout.test")
@@ -283,8 +291,8 @@ class PendingCancellationTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="standard",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
         )
         self.assertTrue(dto.upgraded)
         self.assertEqual(dto.checkout_url, "")
@@ -304,8 +312,8 @@ class AlreadySubscribedTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="standard",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
         )
         self.assertTrue(dto.upgraded)
         self.assertEqual(dto.checkout_url, "")
@@ -326,8 +334,8 @@ class AlreadySubscribedTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="standard",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
         )
 
         self.assertFalse(dto.upgraded)
@@ -356,8 +364,8 @@ class DowngradeTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
         )
 
         self.assertTrue(dto.upgraded)
@@ -372,8 +380,8 @@ class DowngradeTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
         )
 
         self.assertEqual(dto.checkout_url, "https://checkout.test")
@@ -387,8 +395,8 @@ class InvalidPlanTests(TestCase):
             use_case.execute(
                 user_id=1,
                 plan="enterprise",
-                success_url="https://success",
-                cancel_url="https://cancel",
+                success_url="https://app.example.com/success",
+                cancel_url="https://app.example.com/cancel",
             )
 
     def test_free_plan_raises_invalid_plan(self):
@@ -398,8 +406,8 @@ class InvalidPlanTests(TestCase):
             use_case.execute(
                 user_id=1,
                 plan="free",
-                success_url="https://success",
-                cancel_url="https://cancel",
+                success_url="https://app.example.com/success",
+                cancel_url="https://app.example.com/cancel",
             )
 
     def test_unknown_plan_raises_invalid_plan(self):
@@ -409,8 +417,8 @@ class InvalidPlanTests(TestCase):
             use_case.execute(
                 user_id=1,
                 plan="super_premium",
-                success_url="https://success",
-                cancel_url="https://cancel",
+                success_url="https://app.example.com/success",
+                cancel_url="https://app.example.com/cancel",
             )
 
     def test_invalid_currency_raises_invalid_plan(self):
@@ -420,8 +428,8 @@ class InvalidPlanTests(TestCase):
             use_case.execute(
                 user_id=1,
                 plan="lite",
-                success_url="https://success",
-                cancel_url="https://cancel",
+                success_url="https://app.example.com/success",
+                cancel_url="https://app.example.com/cancel",
                 currency="eur",
             )
 
@@ -452,8 +460,8 @@ class CustomerCreationAtomicityTests(TestCase):
         use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
         )
         self.assertEqual(len(create_customer_calls), 0)
 
@@ -473,8 +481,8 @@ class CustomerCreationAtomicityTests(TestCase):
         use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
         )
         self.assertEqual(len(create_customer_calls), 1)
 
@@ -510,6 +518,7 @@ class CustomerCreationAtomicityTests(TestCase):
                 PlanType.LITE: {"jpy": "price_lite_jpy_001"},
             },
             user_repo=_StubUserRepo(),
+            allowed_origins=_DEFAULT_ALLOWED_ORIGINS,
         )
         original_get_or_create = gateway.get_or_create_customer
 
@@ -521,8 +530,8 @@ class CustomerCreationAtomicityTests(TestCase):
         use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
             currency="jpy",
         )
         self.assertEqual(len(create_customer_calls), 0)
@@ -549,8 +558,8 @@ class CustomerCreationAtomicityTests(TestCase):
         dto = use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
         )
         # Recovery creates a new customer exactly once via the atomic repo method
         self.assertEqual(len(create_customer_calls), 1)
@@ -584,12 +593,13 @@ class CustomerCreationAtomicityTests(TestCase):
             billing_enabled=True,
             price_map={PlanType.LITE: {"jpy": "price_lite_jpy_001"}},
             user_repo=_StubUserRepo(),
+            allowed_origins=_DEFAULT_ALLOWED_ORIGINS,
         )
         use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
             currency="jpy",
         )
         self.assertFalse(
@@ -633,12 +643,13 @@ class CasRecoveryTests(TestCase):
             billing_enabled=True,
             price_map={PlanType.LITE: {"jpy": "price_lite_jpy_001"}},
             user_repo=_StubUserRepo(),
+            allowed_origins=_DEFAULT_ALLOWED_ORIGINS,
         )
         use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
             currency="jpy",
         )
         # 通常パス: replace_if_stale=None
@@ -699,12 +710,13 @@ class CasRecoveryTests(TestCase):
             billing_enabled=True,
             price_map={PlanType.LITE: {"jpy": "price_lite_jpy_001"}},
             user_repo=_StubUserRepo(),
+            allowed_origins=_DEFAULT_ALLOWED_ORIGINS,
         )
         dto = use_case.execute(
             user_id=1,
             plan="lite",
-            success_url="https://success",
-            cancel_url="https://cancel",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
             currency="jpy",
         )
         self.assertEqual(dto.checkout_url, "https://checkout.test")
@@ -714,3 +726,63 @@ class CasRecoveryTests(TestCase):
             "Thread A がすでに新顧客を作っていた場合、Thread B は Stripe API を呼ばずに再利用すべき。"
             "create_fn が呼ばれると orphan 顧客が Stripe 上に生まれる。",
         )
+
+
+class ReturnUrlAllowlistTests(TestCase):
+    def test_raises_invalid_return_url_when_success_url_not_in_allowlist(self):
+        entity = _make_subscription()
+        use_case = _make_use_case(entity, allowed_origins=["https://app.example.com"])
+        with self.assertRaises(InvalidReturnUrl):
+            use_case.execute(
+                user_id=1,
+                plan="lite",
+                success_url="https://evil.example.com/success",
+                cancel_url="https://app.example.com/cancel",
+            )
+
+    def test_raises_invalid_return_url_when_cancel_url_not_in_allowlist(self):
+        entity = _make_subscription()
+        use_case = _make_use_case(entity, allowed_origins=["https://app.example.com"])
+        with self.assertRaises(InvalidReturnUrl):
+            use_case.execute(
+                user_id=1,
+                plan="lite",
+                success_url="https://app.example.com/success",
+                cancel_url="https://evil.example.com/cancel",
+            )
+
+    def test_allowed_url_passes_validation(self):
+        entity = _make_subscription()
+        use_case = _make_use_case(entity, allowed_origins=["https://app.example.com"])
+        dto = use_case.execute(
+            user_id=1,
+            plan="lite",
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
+        )
+        self.assertEqual(dto.checkout_url, "https://checkout.test")
+
+    def test_multiple_allowed_origins_accepts_any(self):
+        entity = _make_subscription()
+        use_case = _make_use_case(
+            entity,
+            allowed_origins=["https://app.example.com", "https://www.example.com"],
+        )
+        dto = use_case.execute(
+            user_id=1,
+            plan="lite",
+            success_url="https://www.example.com/success",
+            cancel_url="https://app.example.com/cancel",
+        )
+        self.assertEqual(dto.checkout_url, "https://checkout.test")
+
+    def test_raises_invalid_return_url_when_allowed_origins_is_empty(self):
+        entity = _make_subscription()
+        use_case = _make_use_case(entity, allowed_origins=[])
+        with self.assertRaises(InvalidReturnUrl):
+            use_case.execute(
+                user_id=1,
+                plan="lite",
+                success_url="https://app.example.com/success",
+                cancel_url="https://app.example.com/cancel",
+            )


### PR DESCRIPTION
## 関連 Issue

Closes #568

## 概要

課金系 endpoint (`/billing/checkout`, `/billing/portal`) の `success_url` / `cancel_url` / `return_url` に対し、許可済み origin の allowlist 検証を追加しました。

- **修正前**: `URLField` による URL 形式チェックのみ。任意の外部ドメインを指定可能。
- **修正後**: `CORS_ALLOWED_ORIGINS` を allowlist として origin を照合し、許可外の場合は `InvalidReturnUrl` 例外 → HTTP 400 (`code: "INVALID_RETURN_URL"`) を返す。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `use_cases/billing/exceptions.py` | `InvalidReturnUrl` 例外を追加 |
| `use_cases/billing/create_checkout_session.py` | `allowed_origins` パラメータを追加、`success_url` / `cancel_url` を検証 |
| `use_cases/billing/create_billing_portal.py` | `allowed_origins` パラメータを追加、`return_url` を検証 |
| `composition_root/billing.py` | `_get_allowed_origins()` を追加し `CORS_ALLOWED_ORIGINS` を両 use case に注入 |
| `presentation/billing/views.py` | `InvalidReturnUrl` を catch → HTTP 400 で返却 |
| `presentation/billing/tests/test_views.py` | view 層の `InvalidReturnUrl` → 400 テストを追加 |
| `use_cases/billing/tests/test_create_checkout_session.py` | URL allowlist 検証テストを追加、既存テストの URL を allowlist 対応に更新 |
| `use_cases/billing/tests/test_create_billing_portal.py` | `CreateBillingPortalUseCase` の新規テストファイルを作成 |

## テスト計画

- [x] `success_url` が allowlist 外のドメイン → `InvalidReturnUrl` が raise される
- [x] `cancel_url` が allowlist 外のドメイン → `InvalidReturnUrl` が raise される
- [x] `return_url` が allowlist 外のドメイン → `InvalidReturnUrl` が raise される
- [x] 許可済み origin の URL → 正常に通過する
- [x] 複数の許可済み origin → いずれかにマッチすれば通過する
- [x] `allowed_origins` が空リスト → すべて拒否される
- [x] view 層: `InvalidReturnUrl` → HTTP 400 + `code: "INVALID_RETURN_URL"`
- [x] 全テスト 114 件パス (`docker compose run --rm backend python manage.py test app.use_cases.billing app.presentation.billing`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)