### PR TITLE
動画グループ詳細で個別動画の削除導線を常時表示にする

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -419,6 +419,7 @@
         "processing": "Processing"
       },
       "remove": "Remove",
+      "removeFromGroup": "Remove from group",
       "deleteError": "Failed to delete the chat group"
     },
     "shared": {

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -419,6 +419,7 @@
         "processing": "処理中"
       },
       "remove": "削除",
+      "removeFromGroup": "グループから削除",
       "deleteError": "チャットグループの削除に失敗しました"
     },
     "shared": {

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -108,6 +108,7 @@ interface SortableVideoItemProps {
 }
 
 function SortableVideoItem({ video, isSelected, onSelect, onRemove, isMobile = false }: SortableVideoItemProps) {
+  const { t } = useTranslation();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: video.id,
     disabled: isMobile,
@@ -150,7 +151,8 @@ function SortableVideoItem({ video, isSelected, onSelect, onRemove, isMobile = f
         onClick={(e) => { e.stopPropagation(); onRemove(video.id); }}
         onPointerDown={(e) => e.stopPropagation()}
         onMouseDown={(e) => e.stopPropagation()}
-        className="opacity-0 group-hover:opacity-100 p-1 text-stone-300 hover:text-red-500 transition-all shrink-0"
+        aria-label={t('videos.groupDetail.removeFromGroup')}
+        className="inline-flex items-center rounded-lg p-1.5 text-red-600 hover:bg-red-50 transition-colors shrink-0"
       >
         <Trash2 className="w-3.5 h-3.5" />
       </button>

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -212,11 +212,19 @@ describe('VideoGroupDetailPage - Share Link', () => {
 
 describe('VideoGroupDetailPage - Delete', () => {
   const originalConfirm = window.confirm
+  let currentGroup = structuredClone(mockGroup)
 
   beforeEach(() => {
     vi.clearAllMocks()
-      ; (apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
+    currentGroup = structuredClone(mockGroup)
+      ; (apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockImplementation(() => Promise.resolve(structuredClone(currentGroup)))
       ; (apiClient.deleteVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({})
+      ; (apiClient.removeVideoFromGroup as ReturnType<typeof vi.fn>).mockImplementation(async (_groupId: number, videoId: number) => {
+        currentGroup = {
+          ...currentGroup,
+          videos: currentGroup.videos.filter((video) => video.id !== videoId),
+        }
+      })
     window.confirm = vi.fn(() => true)
   })
 
@@ -235,6 +243,36 @@ describe('VideoGroupDetailPage - Delete', () => {
 
     await waitFor(() => {
       expect(apiClient.deleteVideoGroup).toHaveBeenCalledWith(1)
+    })
+  })
+
+  it('should show a visible remove-from-group action for each video without hover-only classes', async () => {
+    render(<VideoGroupDetailPage />)
+
+    const removeButtons = await screen.findAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
+
+    expect(removeButtons).toHaveLength(2)
+    removeButtons.forEach((button) => {
+      expect(button).not.toHaveClass('opacity-0')
+      expect(button).not.toHaveClass('group-hover:opacity-100')
+      expect(button).toHaveTextContent('')
+    })
+  })
+
+  it('should remove the video from the group list when removal is confirmed', async () => {
+    render(<VideoGroupDetailPage />)
+
+    const [firstRemoveButton] = await screen.findAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
+    fireEvent.click(firstRemoveButton)
+
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledWith('videos.groupDetail.removeVideoConfirm')
+      expect(apiClient.removeVideoFromGroup).toHaveBeenCalledWith(1, 1)
+    })
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('Video 1')).toHaveLength(0)
+      expect(screen.getAllByText('Video 2').length).toBeGreaterThan(0)
     })
   })
 })


### PR DESCRIPTION
## 概要
- 動画グループ詳細画面で、各動画の削除アクションを hover 依存ではなく常時表示に変更
- 表示はアイコンのみとしつつ、グループ削除と混同しにくいようアクセシビリティラベルを付与
- 個別削除導線の表示と、削除後に一覧から対象動画が消えることをコンポーネントテストで担保

## テスト
- npm test -- VideoGroupDetailPage.test.tsx
- npx eslint src/pages/VideoGroupDetailPage.tsx src/pages/__tests__/VideoGroupDetailPage.test.tsx

Closes #591