### PR TITLE
Fix #593: YouTube文字起こしの処理時間を事前チェックして上限超過を防ぐ

### DIFF
--- a/backend/app/composition_root/video.py
+++ b/backend/app/composition_root/video.py
@@ -16,6 +16,10 @@ class TranscriptionExecutionFailed(Exception):
     """Composition-root boundary error for failed transcription execution."""
 
 
+class TranscriptionRejected(Exception):
+    """Composition-root boundary error for non-retryable transcription rejection."""
+
+
 class FileSizeExceeded(Exception):
     """Composition-root boundary error for uploaded file exceeding size limit."""
 
@@ -66,6 +70,7 @@ def run_transcription(video_id: int) -> None:
     from app.use_cases.video.exceptions import (
         FileSizeExceeded as UseCaseFileSizeExceeded,
         TranscriptionExecutionFailed as UseCaseTranscriptionExecutionFailed,
+        TranscriptionRejected as UseCaseTranscriptionRejected,
         TranscriptionTargetMissing as UseCaseTranscriptionTargetMissing,
     )
 
@@ -75,6 +80,8 @@ def run_transcription(video_id: int) -> None:
         raise TranscriptionTargetMissing(str(exc)) from exc
     except UseCaseFileSizeExceeded as exc:
         raise FileSizeExceeded(str(exc)) from exc
+    except UseCaseTranscriptionRejected as exc:
+        raise TranscriptionRejected(str(exc)) from exc
     except UseCaseTranscriptionExecutionFailed as exc:
         raise TranscriptionExecutionFailed(str(exc)) from exc
 

--- a/backend/app/dependencies/tasks.py
+++ b/backend/app/dependencies/tasks.py
@@ -12,6 +12,10 @@ class TranscriptionExecutionFailedError(Exception):
     """Raised when transcription execution fails and retry is allowed."""
 
 
+class TranscriptionRejectedError(Exception):
+    """Raised when transcription is blocked and should not be retried."""
+
+
 class FileSizeExceededError(Exception):
     """Raised when the uploaded file exceeds the size limit. No retry needed."""
 
@@ -35,6 +39,8 @@ def run_transcription(video_id: int) -> None:
         raise TranscriptionTargetMissingError(str(exc)) from exc
     except _cr_video.FileSizeExceeded as exc:
         raise FileSizeExceededError(str(exc)) from exc
+    except _cr_video.TranscriptionRejected as exc:
+        raise TranscriptionRejectedError(str(exc)) from exc
     except _cr_video.TranscriptionExecutionFailed as exc:
         raise TranscriptionExecutionFailedError(str(exc)) from exc
 

--- a/backend/app/domain/video/gateways.py
+++ b/backend/app/domain/video/gateways.py
@@ -94,6 +94,15 @@ class YoutubeTranscriptionGateway(ABC):
     """Abstract interface for fetching YouTube transcripts from video IDs."""
 
     @abstractmethod
+    def estimate_duration_seconds(
+        self,
+        youtube_video_id: str,
+        api_key: Optional[str] = None,
+    ) -> Optional[int]:
+        """Estimate YouTube transcript duration in whole seconds before transcription."""
+        ...
+
+    @abstractmethod
     def run(self, youtube_video_id: str, api_key: Optional[str] = None) -> str:
         """Fetch and normalize a YouTube transcript into SRT format."""
         ...

--- a/backend/app/entrypoints/tasks/tests/test_transcription.py
+++ b/backend/app/entrypoints/tasks/tests/test_transcription.py
@@ -4,12 +4,15 @@ Business logic (audio extraction, Whisper, scene splitting) is tested separately
 at the infrastructure/use-case level.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from app.dependencies.tasks import TranscriptionTargetMissingError
+from app.dependencies.tasks import (
+    TranscriptionRejectedError,
+    TranscriptionTargetMissingError,
+)
 from app.entrypoints.tasks.transcription import transcribe_video
 from app.infrastructure.models import Video
 
@@ -78,3 +81,20 @@ class TranscribeVideoTaskTests(TestCase):
         """Non-existent video raises an exception"""
         with self.assertRaises(TranscriptionTargetMissingError):
             transcribe_video(99999)
+
+    @patch("app.entrypoints.tasks.transcription.run_transcription")
+    def test_does_not_retry_rejected_transcription(self, mock_run_transcription):
+        mock_run_transcription.side_effect = TranscriptionRejectedError("Processing limit exceeded")
+
+        video = Video.objects.create(user=self.user, title="Test Video", status="pending")
+
+        original_retry = transcribe_video.retry
+        original_retries = getattr(transcribe_video.request, "retries", 0)
+        transcribe_video.retry = MagicMock()
+        transcribe_video.request.retries = 0
+        self.addCleanup(setattr, transcribe_video, "retry", original_retry)
+        self.addCleanup(setattr, transcribe_video.request, "retries", original_retries)
+
+        transcribe_video(video.id)
+
+        transcribe_video.retry.assert_not_called()

--- a/backend/app/entrypoints/tasks/transcription.py
+++ b/backend/app/entrypoints/tasks/transcription.py
@@ -11,6 +11,7 @@ from app.contracts.tasks import TRANSCRIBE_VIDEO_TASK
 from app.dependencies.tasks import (
     FileSizeExceededError,
     TranscriptionExecutionFailedError,
+    TranscriptionRejectedError,
     TranscriptionTargetMissingError,
     run_transcription,
 )
@@ -37,6 +38,8 @@ def transcribe_video(self, video_id):
         raise
     except FileSizeExceededError:
         logger.warning("File size exceeded for video %d, no retry", video_id)
+    except TranscriptionRejectedError as e:
+        logger.warning("Transcription rejected for video %d, no retry: %s", video_id, e)
     except TranscriptionExecutionFailedError as e:
         if self.request.retries < self.max_retries:
             raise self.retry(exc=e, countdown=60 * (self.request.retries + 1))

--- a/backend/app/infrastructure/external/tests/test_youtube_transcript_gateway.py
+++ b/backend/app/infrastructure/external/tests/test_youtube_transcript_gateway.py
@@ -83,6 +83,27 @@ class YoutubeTranscriptGatewayTests(TestCase):
         self.assertEqual(len(transport.calls), 1)
         self.assertEqual(transport.calls[0][0]["only_available"], "true")
 
+    def test_estimates_duration_from_last_transcript_segment(self):
+        transport = _FakeTransport(
+            {
+                (
+                    ("only_available", "true"),
+                    ("transcript_type", "manual"),
+                    ("video_id", "abc123def45"),
+                ): {
+                    "transcripts": [
+                        {"text": "first", "start": 0.0, "duration": 2.0},
+                        {"text": "second", "start": 7.2, "duration": 1.1},
+                    ]
+                }
+            }
+        )
+        gateway = YoutubeTranscriptGateway(transport=transport)
+
+        result = gateway.estimate_duration_seconds("abc123def45", api_key="searchapi-test-key")
+
+        self.assertEqual(result, 9)
+
     @patch("app.infrastructure.external.youtube_transcript_gateway.apply_scene_splitting")
     def test_raises_when_no_transcripts_are_available(self, _mock_apply_scene_splitting):
         transport = _FakeTransport({})

--- a/backend/app/infrastructure/external/youtube_transcript_gateway.py
+++ b/backend/app/infrastructure/external/youtube_transcript_gateway.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import socket
 import time
 from urllib.error import HTTPError, URLError
@@ -30,11 +31,7 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
         self._transport = transport
 
     def run(self, youtube_video_id: str, api_key=None) -> str:
-        if not api_key:
-            raise RuntimeError(
-                "SearchAPI API key is not configured. Set your SearchAPI API key in Settings before importing YouTube videos."
-            )
-
+        self._ensure_api_key(api_key)
         transcript = self._select_transcript(youtube_video_id, api_key)
         blocks = []
         for index, item in enumerate(transcript, start=1):
@@ -57,6 +54,25 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
             len(blocks),
         )
         return scene_split_srt
+
+    def estimate_duration_seconds(self, youtube_video_id: str, api_key=None) -> int | None:
+        self._ensure_api_key(api_key)
+        transcript = self._select_transcript(youtube_video_id, api_key)
+        max_end_seconds = 0.0
+        for item in transcript:
+            start = float(item.get("start", 0))
+            duration = float(item.get("duration", 0))
+            max_end_seconds = max(max_end_seconds, start + duration)
+        if max_end_seconds <= 0:
+            return None
+        return max(1, math.ceil(max_end_seconds))
+
+    def _ensure_api_key(self, api_key: str | None) -> None:
+        if api_key:
+            return
+        raise RuntimeError(
+            "SearchAPI API key is not configured. Set your SearchAPI API key in Settings before importing YouTube videos."
+        )
 
     def _select_transcript(self, youtube_video_id: str, api_key: str):
         attempts = [

--- a/backend/app/use_cases/video/exceptions.py
+++ b/backend/app/use_cases/video/exceptions.py
@@ -88,6 +88,15 @@ class TranscriptionExecutionFailed(Exception):
         super().__init__(f"Transcription failed for video {video_id}: {reason}")
 
 
+class TranscriptionRejected(Exception):
+    """Raised when transcription is blocked for a non-retryable reason."""
+
+    def __init__(self, video_id: int, reason: str):
+        self.video_id = video_id
+        self.reason = reason
+        super().__init__(f"Transcription rejected for video {video_id}: {reason}")
+
+
 class InvalidYoutubeUrl(ValueError):
     """Raised when a YouTube URL cannot be parsed into a valid video ID."""
 
@@ -122,6 +131,7 @@ __all__ = [
     "ResourceNotFound",
     "ShareSlugAlreadyExists",
     "TranscriptionExecutionFailed",
+    "TranscriptionRejected",
     "TranscriptionTargetMissing",
     "VideoAlreadyInGroup",
     "VideoLimitExceeded",

--- a/backend/app/use_cases/video/run_transcription.py
+++ b/backend/app/use_cases/video/run_transcription.py
@@ -7,6 +7,7 @@ import re
 
 from typing import Callable, Optional
 
+from app.domain.billing.exceptions import ProcessingLimitExceeded
 from app.domain.shared.transaction import TransactionPort
 from app.domain.user.repositories import UserRepository
 from app.domain.video.gateways import (
@@ -20,6 +21,7 @@ from app.domain.video.services import VideoTranscriptionLifecycle
 from app.use_cases.video.exceptions import (
     FileSizeExceeded,
     TranscriptionExecutionFailed,
+    TranscriptionRejected,
     TranscriptionTargetMissing,
 )
 
@@ -91,6 +93,16 @@ class RunTranscriptionUseCase:
             return None
         return self._duration_estimator(video_id)
 
+    def _estimate_processing_duration_seconds(self, video, user=None) -> Optional[int]:
+        if video.source_type == "youtube":
+            if not video.youtube_video_id or self._youtube_transcription_gateway is None:
+                return None
+            return self._youtube_transcription_gateway.estimate_duration_seconds(
+                video.youtube_video_id,
+                api_key=(getattr(user, "searchapi_api_key", None) if user is not None else None),
+            )
+        return self._estimate_video_duration_seconds(video.id)
+
     def execute(self, video_id: int) -> None:
         video = self.video_repo.get_by_id_for_task(video_id)
         if video is None:
@@ -127,7 +139,12 @@ class RunTranscriptionUseCase:
                 self._processing_limit_check_use_case is not None
                 and video.user_id
             ):
-                estimated_duration_seconds = self._estimate_video_duration_seconds(video_id)
+                estimated_duration_seconds = self._estimate_processing_duration_seconds(video, user)
+                if video.source_type == "youtube" and estimated_duration_seconds is None:
+                    raise TranscriptionRejected(
+                        video_id=video_id,
+                        reason="Unable to determine YouTube video duration before transcription.",
+                    )
                 if estimated_duration_seconds is not None:
                     self._processing_limit_check_use_case.execute(
                         video.user_id,
@@ -154,6 +171,10 @@ class RunTranscriptionUseCase:
                 to_status=to_status,
                 error_message=error_msg,
             )
+            if isinstance(e, ProcessingLimitExceeded):
+                raise TranscriptionRejected(video_id=video_id, reason=error_msg) from e
+            if isinstance(e, TranscriptionRejected):
+                raise e
             raise TranscriptionExecutionFailed(video_id=video_id, reason=error_msg) from e
 
         logger.info("Transcription completed for video %d; indexing task enqueued", video_id)

--- a/backend/app/use_cases/video/tests/test_run_transcription.py
+++ b/backend/app/use_cases/video/tests/test_run_transcription.py
@@ -11,6 +11,7 @@ from app.domain.video.exceptions import InvalidVideoStatusTransition
 from app.domain.video.status import VideoStatus
 from app.use_cases.video.exceptions import (
     TranscriptionExecutionFailed,
+    TranscriptionRejected,
     TranscriptionTargetMissing,
 )
 from app.use_cases.video.run_transcription import RunTranscriptionUseCase, _parse_srt_duration_seconds
@@ -64,12 +65,18 @@ class _FakeYoutubeTranscriptionGateway:
         self.transcript = transcript
         self.error = error
         self.calls: list[tuple[str, str | None]] = []
+        self.duration_calls: list[tuple[str, str | None]] = []
+        self.estimated_duration_seconds: Optional[int] = None
 
     def run(self, youtube_video_id: str, api_key=None) -> str:
         self.calls.append((youtube_video_id, api_key))
         if self.error:
             raise self.error
         return self.transcript
+
+    def estimate_duration_seconds(self, youtube_video_id: str, api_key=None) -> Optional[int]:
+        self.duration_calls.append((youtube_video_id, api_key))
+        return self.estimated_duration_seconds
 
 
 class _FakeVideoTaskGateway:
@@ -278,7 +285,7 @@ class RunTranscriptionUseCaseTests(TestCase):
             processing_limit_check_use_case=mock_check,
         )
 
-        with self.assertRaises(TranscriptionExecutionFailed) as exc:
+        with self.assertRaises(TranscriptionRejected) as exc:
             use_case.execute(video.id)
 
         mock_check.execute.assert_called_once_with(10, 62)
@@ -318,6 +325,7 @@ class RunTranscriptionUseCaseTests(TestCase):
         self.assertEqual(video.transcript, youtube_transcription.transcript)
         self.assertEqual(transcription.calls, [])
         self.assertEqual(youtube_transcription.calls, [("dQw4w9WgXcQ", None)])
+        self.assertEqual(youtube_transcription.duration_calls, [])
 
     def test_uses_user_searchapi_key_for_youtube_transcription(self):
         from app.domain.user.entities import UserEntity
@@ -389,6 +397,87 @@ class RunTranscriptionUseCaseTests(TestCase):
         self.assertEqual(video.status, "error")
         self.assertIn("youtube_video_id", str(exc.exception))
         self.assertEqual(youtube_transcription.calls, [])
+
+    def test_youtube_processing_limit_exceeded_uses_estimated_duration_and_skips_transcription(self):
+        video = VideoEntity(
+            id=1,
+            user_id=10,
+            title="yt",
+            status="pending",
+            source_type="youtube",
+            youtube_video_id="dQw4w9WgXcQ",
+        )
+        repo = _FakeVideoTranscriptionRepository(video)
+        transcription = _FakeTranscriptionGateway(transcript="file transcript")
+        youtube_transcription = _FakeYoutubeTranscriptionGateway(
+            transcript="1\n00:00:00,000 --> 00:08:00,000\nHello from YouTube\n"
+        )
+        youtube_transcription.estimated_duration_seconds = 8 * 60
+        task_gateway = _FakeVideoTaskGateway()
+        upload_gw = _FakeUploadGateway()
+        tx = _FakeTransactionPort()
+        mock_check = MagicMock()
+        mock_check.execute.side_effect = ProcessingLimitExceeded("Processing limit exceeded")
+        mock_processing_record = MagicMock()
+        use_case = RunTranscriptionUseCase(
+            repo,
+            transcription,
+            task_gateway,
+            upload_gw,
+            tx,
+            processing_limit_check_use_case=mock_check,
+            processing_record_use_case=mock_processing_record,
+            youtube_transcription_gateway=youtube_transcription,
+        )
+
+        with self.assertRaises(TranscriptionRejected) as exc:
+            use_case.execute(video.id)
+
+        mock_check.execute.assert_called_once_with(10, 8 * 60)
+        mock_processing_record.execute.assert_not_called()
+        self.assertEqual(video.status, "error")
+        self.assertEqual(transcription.calls, [])
+        self.assertEqual(youtube_transcription.calls, [])
+        self.assertEqual(youtube_transcription.duration_calls, [("dQw4w9WgXcQ", None)])
+        self.assertIn("Processing limit exceeded", str(exc.exception))
+
+    def test_youtube_duration_estimation_failure_blocks_transcription(self):
+        video = VideoEntity(
+            id=1,
+            user_id=10,
+            title="yt",
+            status="pending",
+            source_type="youtube",
+            youtube_video_id="dQw4w9WgXcQ",
+        )
+        repo = _FakeVideoTranscriptionRepository(video)
+        transcription = _FakeTranscriptionGateway(transcript="file transcript")
+        youtube_transcription = _FakeYoutubeTranscriptionGateway(
+            transcript="1\n00:00:00,000 --> 00:03:00,000\nHello from YouTube\n"
+        )
+        task_gateway = _FakeVideoTaskGateway()
+        upload_gw = _FakeUploadGateway()
+        tx = _FakeTransactionPort()
+        mock_check = MagicMock()
+        use_case = RunTranscriptionUseCase(
+            repo,
+            transcription,
+            task_gateway,
+            upload_gw,
+            tx,
+            processing_limit_check_use_case=mock_check,
+            youtube_transcription_gateway=youtube_transcription,
+        )
+
+        with self.assertRaises(TranscriptionRejected) as exc:
+            use_case.execute(video.id)
+
+        mock_check.execute.assert_not_called()
+        self.assertEqual(video.status, "error")
+        self.assertEqual(transcription.calls, [])
+        self.assertEqual(youtube_transcription.calls, [])
+        self.assertEqual(youtube_transcription.duration_calls, [("dQw4w9WgXcQ", None)])
+        self.assertIn("Unable to determine YouTube video duration", str(exc.exception))
 
 
 class ParseSrtDurationTests(TestCase):


### PR DESCRIPTION
## 概要

YouTube動画の文字起こし処理において、動画の長さを**事前に推定**することで処理時間上限の超過を事前検知し、完了後に超過計上されるバグを修正します。

## 変更点

- `YoutubeTranscriptionGateway` に `estimate_duration_seconds` メソッドを追加
  - 文字起こし実行前にYouTube字幕データから動画長（秒）を推定
  - 字幕セグメントの `start + duration` の最大値を切り上げで返す
- `RunTranscriptionUseCase` でYouTube動画の場合は `estimate_duration_seconds` で事前チェック
  - 長さが取得できない場合は `TranscriptionRejected` を送出して処理をブロック
  - 処理時間上限を超える場合（`ProcessingLimitExceeded`）も `TranscriptionRejected` に変換
- `TranscriptionRejected` 例外を全レイヤーに伝播（composition_root → dependencies → Celery task）
- Celery タスクで `TranscriptionRejected` はリトライなしで終了（`FileSizeExceededError` と同様の扱い）

## テスト

- `test_youtube_processing_limit_exceeded_uses_estimated_duration_and_skips_transcription`: 上限超過時に推定時間でチェックが走り、実際の文字起こしはスキップされることを確認
- `test_youtube_duration_estimation_failure_blocks_transcription`: 長さ推定失敗時に文字起こしがブロックされることを確認
- `test_estimates_duration_from_last_transcript_segment`: ゲートウェイの duration 推定ロジックの単体テスト
- `test_does_not_retry_rejected_transcription`: Celery タスクレベルでリトライされないことを確認

## Test plan

- [x] 上限超過するYouTube動画で文字起こしを実行 → エラーステータスになりリトライされないことを確認
- [x] 通常のYouTube動画 → 従来通り正常に文字起こしされることを確認
- [x] ファイルアップロード動画 → 影響なし（従来の `estimate_video_duration_seconds` を使用）
- [x] `docker compose run --rm backend python manage.py test app` で全テストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)