### PR TITLE
develop -> main: YouTube処理時間事前チェックとグループ詳細の動画削除UI改善

### DIFF
--- a/backend/app/composition_root/video.py
+++ b/backend/app/composition_root/video.py
@@ -16,6 +16,10 @@ class TranscriptionExecutionFailed(Exception):
     """Composition-root boundary error for failed transcription execution."""
 
 
+class TranscriptionRejected(Exception):
+    """Composition-root boundary error for non-retryable transcription rejection."""
+
+
 class FileSizeExceeded(Exception):
     """Composition-root boundary error for uploaded file exceeding size limit."""
 
@@ -66,6 +70,7 @@ def run_transcription(video_id: int) -> None:
     from app.use_cases.video.exceptions import (
         FileSizeExceeded as UseCaseFileSizeExceeded,
         TranscriptionExecutionFailed as UseCaseTranscriptionExecutionFailed,
+        TranscriptionRejected as UseCaseTranscriptionRejected,
         TranscriptionTargetMissing as UseCaseTranscriptionTargetMissing,
     )
 
@@ -75,6 +80,8 @@ def run_transcription(video_id: int) -> None:
         raise TranscriptionTargetMissing(str(exc)) from exc
     except UseCaseFileSizeExceeded as exc:
         raise FileSizeExceeded(str(exc)) from exc
+    except UseCaseTranscriptionRejected as exc:
+        raise TranscriptionRejected(str(exc)) from exc
     except UseCaseTranscriptionExecutionFailed as exc:
         raise TranscriptionExecutionFailed(str(exc)) from exc
 

--- a/backend/app/dependencies/tasks.py
+++ b/backend/app/dependencies/tasks.py
@@ -12,6 +12,10 @@ class TranscriptionExecutionFailedError(Exception):
     """Raised when transcription execution fails and retry is allowed."""
 
 
+class TranscriptionRejectedError(Exception):
+    """Raised when transcription is blocked and should not be retried."""
+
+
 class FileSizeExceededError(Exception):
     """Raised when the uploaded file exceeds the size limit. No retry needed."""
 
@@ -35,6 +39,8 @@ def run_transcription(video_id: int) -> None:
         raise TranscriptionTargetMissingError(str(exc)) from exc
     except _cr_video.FileSizeExceeded as exc:
         raise FileSizeExceededError(str(exc)) from exc
+    except _cr_video.TranscriptionRejected as exc:
+        raise TranscriptionRejectedError(str(exc)) from exc
     except _cr_video.TranscriptionExecutionFailed as exc:
         raise TranscriptionExecutionFailedError(str(exc)) from exc
 

--- a/backend/app/domain/video/gateways.py
+++ b/backend/app/domain/video/gateways.py
@@ -94,6 +94,15 @@ class YoutubeTranscriptionGateway(ABC):
     """Abstract interface for fetching YouTube transcripts from video IDs."""
 
     @abstractmethod
+    def estimate_duration_seconds(
+        self,
+        youtube_video_id: str,
+        api_key: Optional[str] = None,
+    ) -> Optional[int]:
+        """Estimate YouTube transcript duration in whole seconds before transcription."""
+        ...
+
+    @abstractmethod
     def run(self, youtube_video_id: str, api_key: Optional[str] = None) -> str:
         """Fetch and normalize a YouTube transcript into SRT format."""
         ...

--- a/backend/app/entrypoints/tasks/tests/test_transcription.py
+++ b/backend/app/entrypoints/tasks/tests/test_transcription.py
@@ -4,12 +4,15 @@ Business logic (audio extraction, Whisper, scene splitting) is tested separately
 at the infrastructure/use-case level.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from app.dependencies.tasks import TranscriptionTargetMissingError
+from app.dependencies.tasks import (
+    TranscriptionRejectedError,
+    TranscriptionTargetMissingError,
+)
 from app.entrypoints.tasks.transcription import transcribe_video
 from app.infrastructure.models import Video
 
@@ -78,3 +81,20 @@ class TranscribeVideoTaskTests(TestCase):
         """Non-existent video raises an exception"""
         with self.assertRaises(TranscriptionTargetMissingError):
             transcribe_video(99999)
+
+    @patch("app.entrypoints.tasks.transcription.run_transcription")
+    def test_does_not_retry_rejected_transcription(self, mock_run_transcription):
+        mock_run_transcription.side_effect = TranscriptionRejectedError("Processing limit exceeded")
+
+        video = Video.objects.create(user=self.user, title="Test Video", status="pending")
+
+        original_retry = transcribe_video.retry
+        original_retries = getattr(transcribe_video.request, "retries", 0)
+        transcribe_video.retry = MagicMock()
+        transcribe_video.request.retries = 0
+        self.addCleanup(setattr, transcribe_video, "retry", original_retry)
+        self.addCleanup(setattr, transcribe_video.request, "retries", original_retries)
+
+        transcribe_video(video.id)
+
+        transcribe_video.retry.assert_not_called()

--- a/backend/app/entrypoints/tasks/transcription.py
+++ b/backend/app/entrypoints/tasks/transcription.py
@@ -11,6 +11,7 @@ from app.contracts.tasks import TRANSCRIBE_VIDEO_TASK
 from app.dependencies.tasks import (
     FileSizeExceededError,
     TranscriptionExecutionFailedError,
+    TranscriptionRejectedError,
     TranscriptionTargetMissingError,
     run_transcription,
 )
@@ -37,6 +38,8 @@ def transcribe_video(self, video_id):
         raise
     except FileSizeExceededError:
         logger.warning("File size exceeded for video %d, no retry", video_id)
+    except TranscriptionRejectedError as e:
+        logger.warning("Transcription rejected for video %d, no retry: %s", video_id, e)
     except TranscriptionExecutionFailedError as e:
         if self.request.retries < self.max_retries:
             raise self.retry(exc=e, countdown=60 * (self.request.retries + 1))

--- a/backend/app/infrastructure/external/tests/test_youtube_transcript_gateway.py
+++ b/backend/app/infrastructure/external/tests/test_youtube_transcript_gateway.py
@@ -83,6 +83,27 @@ class YoutubeTranscriptGatewayTests(TestCase):
         self.assertEqual(len(transport.calls), 1)
         self.assertEqual(transport.calls[0][0]["only_available"], "true")
 
+    def test_estimates_duration_from_last_transcript_segment(self):
+        transport = _FakeTransport(
+            {
+                (
+                    ("only_available", "true"),
+                    ("transcript_type", "manual"),
+                    ("video_id", "abc123def45"),
+                ): {
+                    "transcripts": [
+                        {"text": "first", "start": 0.0, "duration": 2.0},
+                        {"text": "second", "start": 7.2, "duration": 1.1},
+                    ]
+                }
+            }
+        )
+        gateway = YoutubeTranscriptGateway(transport=transport)
+
+        result = gateway.estimate_duration_seconds("abc123def45", api_key="searchapi-test-key")
+
+        self.assertEqual(result, 9)
+
     @patch("app.infrastructure.external.youtube_transcript_gateway.apply_scene_splitting")
     def test_raises_when_no_transcripts_are_available(self, _mock_apply_scene_splitting):
         transport = _FakeTransport({})

--- a/backend/app/infrastructure/external/youtube_transcript_gateway.py
+++ b/backend/app/infrastructure/external/youtube_transcript_gateway.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import socket
 import time
 from urllib.error import HTTPError, URLError
@@ -30,11 +31,7 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
         self._transport = transport
 
     def run(self, youtube_video_id: str, api_key=None) -> str:
-        if not api_key:
-            raise RuntimeError(
-                "SearchAPI API key is not configured. Set your SearchAPI API key in Settings before importing YouTube videos."
-            )
-
+        self._ensure_api_key(api_key)
         transcript = self._select_transcript(youtube_video_id, api_key)
         blocks = []
         for index, item in enumerate(transcript, start=1):
@@ -57,6 +54,25 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
             len(blocks),
         )
         return scene_split_srt
+
+    def estimate_duration_seconds(self, youtube_video_id: str, api_key=None) -> int | None:
+        self._ensure_api_key(api_key)
+        transcript = self._select_transcript(youtube_video_id, api_key)
+        max_end_seconds = 0.0
+        for item in transcript:
+            start = float(item.get("start", 0))
+            duration = float(item.get("duration", 0))
+            max_end_seconds = max(max_end_seconds, start + duration)
+        if max_end_seconds <= 0:
+            return None
+        return max(1, math.ceil(max_end_seconds))
+
+    def _ensure_api_key(self, api_key: str | None) -> None:
+        if api_key:
+            return
+        raise RuntimeError(
+            "SearchAPI API key is not configured. Set your SearchAPI API key in Settings before importing YouTube videos."
+        )
 
     def _select_transcript(self, youtube_video_id: str, api_key: str):
         attempts = [

--- a/backend/app/use_cases/video/exceptions.py
+++ b/backend/app/use_cases/video/exceptions.py
@@ -88,6 +88,15 @@ class TranscriptionExecutionFailed(Exception):
         super().__init__(f"Transcription failed for video {video_id}: {reason}")
 
 
+class TranscriptionRejected(Exception):
+    """Raised when transcription is blocked for a non-retryable reason."""
+
+    def __init__(self, video_id: int, reason: str):
+        self.video_id = video_id
+        self.reason = reason
+        super().__init__(f"Transcription rejected for video {video_id}: {reason}")
+
+
 class InvalidYoutubeUrl(ValueError):
     """Raised when a YouTube URL cannot be parsed into a valid video ID."""
 
@@ -122,6 +131,7 @@ __all__ = [
     "ResourceNotFound",
     "ShareSlugAlreadyExists",
     "TranscriptionExecutionFailed",
+    "TranscriptionRejected",
     "TranscriptionTargetMissing",
     "VideoAlreadyInGroup",
     "VideoLimitExceeded",

--- a/backend/app/use_cases/video/run_transcription.py
+++ b/backend/app/use_cases/video/run_transcription.py
@@ -7,6 +7,7 @@ import re
 
 from typing import Callable, Optional
 
+from app.domain.billing.exceptions import ProcessingLimitExceeded
 from app.domain.shared.transaction import TransactionPort
 from app.domain.user.repositories import UserRepository
 from app.domain.video.gateways import (
@@ -20,6 +21,7 @@ from app.domain.video.services import VideoTranscriptionLifecycle
 from app.use_cases.video.exceptions import (
     FileSizeExceeded,
     TranscriptionExecutionFailed,
+    TranscriptionRejected,
     TranscriptionTargetMissing,
 )
 
@@ -91,6 +93,16 @@ class RunTranscriptionUseCase:
             return None
         return self._duration_estimator(video_id)
 
+    def _estimate_processing_duration_seconds(self, video, user=None) -> Optional[int]:
+        if video.source_type == "youtube":
+            if not video.youtube_video_id or self._youtube_transcription_gateway is None:
+                return None
+            return self._youtube_transcription_gateway.estimate_duration_seconds(
+                video.youtube_video_id,
+                api_key=(getattr(user, "searchapi_api_key", None) if user is not None else None),
+            )
+        return self._estimate_video_duration_seconds(video.id)
+
     def execute(self, video_id: int) -> None:
         video = self.video_repo.get_by_id_for_task(video_id)
         if video is None:
@@ -127,7 +139,12 @@ class RunTranscriptionUseCase:
                 self._processing_limit_check_use_case is not None
                 and video.user_id
             ):
-                estimated_duration_seconds = self._estimate_video_duration_seconds(video_id)
+                estimated_duration_seconds = self._estimate_processing_duration_seconds(video, user)
+                if video.source_type == "youtube" and estimated_duration_seconds is None:
+                    raise TranscriptionRejected(
+                        video_id=video_id,
+                        reason="Unable to determine YouTube video duration before transcription.",
+                    )
                 if estimated_duration_seconds is not None:
                     self._processing_limit_check_use_case.execute(
                         video.user_id,
@@ -154,6 +171,10 @@ class RunTranscriptionUseCase:
                 to_status=to_status,
                 error_message=error_msg,
             )
+            if isinstance(e, ProcessingLimitExceeded):
+                raise TranscriptionRejected(video_id=video_id, reason=error_msg) from e
+            if isinstance(e, TranscriptionRejected):
+                raise e
             raise TranscriptionExecutionFailed(video_id=video_id, reason=error_msg) from e
 
         logger.info("Transcription completed for video %d; indexing task enqueued", video_id)

--- a/backend/app/use_cases/video/tests/test_run_transcription.py
+++ b/backend/app/use_cases/video/tests/test_run_transcription.py
@@ -11,6 +11,7 @@ from app.domain.video.exceptions import InvalidVideoStatusTransition
 from app.domain.video.status import VideoStatus
 from app.use_cases.video.exceptions import (
     TranscriptionExecutionFailed,
+    TranscriptionRejected,
     TranscriptionTargetMissing,
 )
 from app.use_cases.video.run_transcription import RunTranscriptionUseCase, _parse_srt_duration_seconds
@@ -64,12 +65,18 @@ class _FakeYoutubeTranscriptionGateway:
         self.transcript = transcript
         self.error = error
         self.calls: list[tuple[str, str | None]] = []
+        self.duration_calls: list[tuple[str, str | None]] = []
+        self.estimated_duration_seconds: Optional[int] = None
 
     def run(self, youtube_video_id: str, api_key=None) -> str:
         self.calls.append((youtube_video_id, api_key))
         if self.error:
             raise self.error
         return self.transcript
+
+    def estimate_duration_seconds(self, youtube_video_id: str, api_key=None) -> Optional[int]:
+        self.duration_calls.append((youtube_video_id, api_key))
+        return self.estimated_duration_seconds
 
 
 class _FakeVideoTaskGateway:
@@ -278,7 +285,7 @@ class RunTranscriptionUseCaseTests(TestCase):
             processing_limit_check_use_case=mock_check,
         )
 
-        with self.assertRaises(TranscriptionExecutionFailed) as exc:
+        with self.assertRaises(TranscriptionRejected) as exc:
             use_case.execute(video.id)
 
         mock_check.execute.assert_called_once_with(10, 62)
@@ -318,6 +325,7 @@ class RunTranscriptionUseCaseTests(TestCase):
         self.assertEqual(video.transcript, youtube_transcription.transcript)
         self.assertEqual(transcription.calls, [])
         self.assertEqual(youtube_transcription.calls, [("dQw4w9WgXcQ", None)])
+        self.assertEqual(youtube_transcription.duration_calls, [])
 
     def test_uses_user_searchapi_key_for_youtube_transcription(self):
         from app.domain.user.entities import UserEntity
@@ -389,6 +397,87 @@ class RunTranscriptionUseCaseTests(TestCase):
         self.assertEqual(video.status, "error")
         self.assertIn("youtube_video_id", str(exc.exception))
         self.assertEqual(youtube_transcription.calls, [])
+
+    def test_youtube_processing_limit_exceeded_uses_estimated_duration_and_skips_transcription(self):
+        video = VideoEntity(
+            id=1,
+            user_id=10,
+            title="yt",
+            status="pending",
+            source_type="youtube",
+            youtube_video_id="dQw4w9WgXcQ",
+        )
+        repo = _FakeVideoTranscriptionRepository(video)
+        transcription = _FakeTranscriptionGateway(transcript="file transcript")
+        youtube_transcription = _FakeYoutubeTranscriptionGateway(
+            transcript="1\n00:00:00,000 --> 00:08:00,000\nHello from YouTube\n"
+        )
+        youtube_transcription.estimated_duration_seconds = 8 * 60
+        task_gateway = _FakeVideoTaskGateway()
+        upload_gw = _FakeUploadGateway()
+        tx = _FakeTransactionPort()
+        mock_check = MagicMock()
+        mock_check.execute.side_effect = ProcessingLimitExceeded("Processing limit exceeded")
+        mock_processing_record = MagicMock()
+        use_case = RunTranscriptionUseCase(
+            repo,
+            transcription,
+            task_gateway,
+            upload_gw,
+            tx,
+            processing_limit_check_use_case=mock_check,
+            processing_record_use_case=mock_processing_record,
+            youtube_transcription_gateway=youtube_transcription,
+        )
+
+        with self.assertRaises(TranscriptionRejected) as exc:
+            use_case.execute(video.id)
+
+        mock_check.execute.assert_called_once_with(10, 8 * 60)
+        mock_processing_record.execute.assert_not_called()
+        self.assertEqual(video.status, "error")
+        self.assertEqual(transcription.calls, [])
+        self.assertEqual(youtube_transcription.calls, [])
+        self.assertEqual(youtube_transcription.duration_calls, [("dQw4w9WgXcQ", None)])
+        self.assertIn("Processing limit exceeded", str(exc.exception))
+
+    def test_youtube_duration_estimation_failure_blocks_transcription(self):
+        video = VideoEntity(
+            id=1,
+            user_id=10,
+            title="yt",
+            status="pending",
+            source_type="youtube",
+            youtube_video_id="dQw4w9WgXcQ",
+        )
+        repo = _FakeVideoTranscriptionRepository(video)
+        transcription = _FakeTranscriptionGateway(transcript="file transcript")
+        youtube_transcription = _FakeYoutubeTranscriptionGateway(
+            transcript="1\n00:00:00,000 --> 00:03:00,000\nHello from YouTube\n"
+        )
+        task_gateway = _FakeVideoTaskGateway()
+        upload_gw = _FakeUploadGateway()
+        tx = _FakeTransactionPort()
+        mock_check = MagicMock()
+        use_case = RunTranscriptionUseCase(
+            repo,
+            transcription,
+            task_gateway,
+            upload_gw,
+            tx,
+            processing_limit_check_use_case=mock_check,
+            youtube_transcription_gateway=youtube_transcription,
+        )
+
+        with self.assertRaises(TranscriptionRejected) as exc:
+            use_case.execute(video.id)
+
+        mock_check.execute.assert_not_called()
+        self.assertEqual(video.status, "error")
+        self.assertEqual(transcription.calls, [])
+        self.assertEqual(youtube_transcription.calls, [])
+        self.assertEqual(youtube_transcription.duration_calls, [("dQw4w9WgXcQ", None)])
+        self.assertIn("Unable to determine YouTube video duration", str(exc.exception))
 
 
 class ParseSrtDurationTests(TestCase):

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -419,6 +419,7 @@
         "processing": "Processing"
       },
       "remove": "Remove",
+      "removeFromGroup": "Remove from group",
       "deleteError": "Failed to delete the chat group"
     },
     "shared": {

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -419,6 +419,7 @@
         "processing": "処理中"
       },
       "remove": "削除",
+      "removeFromGroup": "グループから削除",
       "deleteError": "チャットグループの削除に失敗しました"
     },
     "shared": {

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -108,6 +108,7 @@ interface SortableVideoItemProps {
 }
 
 function SortableVideoItem({ video, isSelected, onSelect, onRemove, isMobile = false }: SortableVideoItemProps) {
+  const { t } = useTranslation();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: video.id,
     disabled: isMobile,
@@ -150,7 +151,8 @@ function SortableVideoItem({ video, isSelected, onSelect, onRemove, isMobile = f
         onClick={(e) => { e.stopPropagation(); onRemove(video.id); }}
         onPointerDown={(e) => e.stopPropagation()}
         onMouseDown={(e) => e.stopPropagation()}
-        className="opacity-0 group-hover:opacity-100 p-1 text-stone-300 hover:text-red-500 transition-all shrink-0"
+        aria-label={t('videos.groupDetail.removeFromGroup')}
+        className="inline-flex items-center rounded-lg p-1.5 text-red-600 hover:bg-red-50 transition-colors shrink-0"
       >
         <Trash2 className="w-3.5 h-3.5" />
       </button>

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -212,11 +212,19 @@ describe('VideoGroupDetailPage - Share Link', () => {
 
 describe('VideoGroupDetailPage - Delete', () => {
   const originalConfirm = window.confirm
+  let currentGroup = structuredClone(mockGroup)
 
   beforeEach(() => {
     vi.clearAllMocks()
-      ; (apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
+    currentGroup = structuredClone(mockGroup)
+      ; (apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockImplementation(() => Promise.resolve(structuredClone(currentGroup)))
       ; (apiClient.deleteVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({})
+      ; (apiClient.removeVideoFromGroup as ReturnType<typeof vi.fn>).mockImplementation(async (_groupId: number, videoId: number) => {
+        currentGroup = {
+          ...currentGroup,
+          videos: currentGroup.videos.filter((video) => video.id !== videoId),
+        }
+      })
     window.confirm = vi.fn(() => true)
   })
 
@@ -235,6 +243,36 @@ describe('VideoGroupDetailPage - Delete', () => {
 
     await waitFor(() => {
       expect(apiClient.deleteVideoGroup).toHaveBeenCalledWith(1)
+    })
+  })
+
+  it('should show a visible remove-from-group action for each video without hover-only classes', async () => {
+    render(<VideoGroupDetailPage />)
+
+    const removeButtons = await screen.findAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
+
+    expect(removeButtons).toHaveLength(2)
+    removeButtons.forEach((button) => {
+      expect(button).not.toHaveClass('opacity-0')
+      expect(button).not.toHaveClass('group-hover:opacity-100')
+      expect(button).toHaveTextContent('')
+    })
+  })
+
+  it('should remove the video from the group list when removal is confirmed', async () => {
+    render(<VideoGroupDetailPage />)
+
+    const [firstRemoveButton] = await screen.findAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
+    fireEvent.click(firstRemoveButton)
+
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledWith('videos.groupDetail.removeVideoConfirm')
+      expect(apiClient.removeVideoFromGroup).toHaveBeenCalledWith(1, 1)
+    })
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('Video 1')).toHaveLength(0)
+      expect(screen.getAllByText('Video 2').length).toBeGreaterThan(0)
     })
   })
 })


### PR DESCRIPTION
## 概要

`develop` の変更を `main` に取り込む PR です。主な変更は以下です。

- YouTube 動画の処理時間上限を文字起こし開始前に事前チェックする機能を追加
- 動画グループ詳細画面で個別動画を削除する導線を明示

## 変更内容

### 1. YouTube 文字起こしの事前時間チェック

- `YoutubeTranscriptionGateway` に `estimate_duration_seconds` を追加し、文字起こし前に YouTube 動画の尺を取得できるよう変更
- 処理時間上限を超える場合、または尺の推定に失敗した場合に `TranscriptionRejected`（非リトライ）を送出し、文字起こしを開始せずに弾く
- `RunTranscriptionUseCase` で `TranscriptionRejected` を伝播し、Celery タスク側でリトライなし終了を保証
- `composition_root` / `dependencies` レイヤーに `estimate_duration_seconds` の配線を追加

### 2. グループ詳細の動画削除 UI 改善

- グループ詳細画面で個別動画を削除できるアクションを明示的に表示するよう変更
- i18n（ja/en）に対応した削除アクションのラベルを追加

## 影響範囲

- Backend
  - `domain/video/gateways.py` — `YoutubeTranscriptionGateway` インターフェース拡張
  - `use_cases/video/run_transcription.py` — 事前チェックロジック追加
  - `use_cases/video/exceptions.py` — `TranscriptionRejected` 例外追加
  - `infrastructure/external/youtube_transcript_gateway.py` — `estimate_duration_seconds` 実装
  - `entrypoints/tasks/transcription.py` — `TranscriptionRejected` のノーリトライ処理
  - `composition_root/video.py`, `dependencies/tasks.py` — DI 配線更新
- Frontend
  - `VideoGroupDetailPage.tsx` — 動画削除アクション表示
  - `i18n/locales/ja,en/translation.json` — ラベル追加

## 確認ポイント

- 処理時間上限を超える YouTube URL を登録した際、文字起こしが開始されず即座に失敗ステータスになること
- 尺が取得できない YouTube URL でも同様に安全に弾かれること
- 通常の YouTube URL は従来通り文字起こしが実行されること
- グループ詳細画面で個別動画の削除ボタンが表示されること

## テスト

- Backend
  - `test_transcription.py` — `TranscriptionRejected` の非リトライ動作を追加
  - `test_youtube_transcript_gateway.py` — `estimate_duration_seconds` のテストを追加
  - `test_run_transcription.py` — 事前チェックのユースケーステストを追加
- Frontend
  - `VideoGroupDetailPage.test.tsx` — 動画削除アクションの表示テストを追加