### PR TITLE
企業研修向けユースケース LP を追加

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -99,4 +99,18 @@
     <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/education"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/education"/>
   </url>
+  <url>
+    <loc>https://videoq.jp/use-cases/corporate-training</loc>
+    <lastmod>2026-03-30</lastmod>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/corporate-training"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/corporate-training"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/corporate-training"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/use-cases/corporate-training</loc>
+    <lastmod>2026-03-30</lastmod>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/corporate-training"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/corporate-training"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/corporate-training"/>
+  </url>
 </urlset>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ const TermsPage = lazy(() => import('@/pages/TermsPage'));
 const PrivacyPolicyPage = lazy(() => import('@/pages/PrivacyPolicyPage'));
 const CommercialDisclosurePage = lazy(() => import('@/pages/CommercialDisclosurePage'));
 const UseCaseEducationPage = lazy(() => import('@/pages/UseCaseEducationPage'));
+const UseCaseCorporateTrainingPage = lazy(() => import('@/pages/UseCaseCorporateTrainingPage'));
 
 function LocaleGate() {
   const params = useParams<{ locale?: string }>();
@@ -71,6 +72,7 @@ const routeChildren = (
     <Route path="privacy" element={<PrivacyPolicyPage />} />
     <Route path="commercial-disclosure" element={<CommercialDisclosurePage />} />
     <Route path="use-cases/education" element={<UseCaseEducationPage />} />
+    <Route path="use-cases/corporate-training" element={<UseCaseCorporateTrainingPage />} />
   </>
 );
 

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1096,6 +1096,69 @@
       "footer": {
         "link": "For Education"
       }
+    },
+    "corporateTraining": {
+      "hero": {
+        "title": "Search & Leverage Corporate Training Videos with AI. Maximize Training Effectiveness",
+        "subtitle": "Just upload your training videos. Employees can find exactly what they need, anytime.",
+        "ctaSignup": "Get Started for Free",
+        "ctaApiDocs": "View API Documentation"
+      },
+      "problems": {
+        "title": "Solving Corporate Training Challenges",
+        "tooMany": {
+          "problem": "Too many training videos — employees never rewatch them",
+          "solution": "Ask the AI \"How do I submit paid leave?\" and jump to the exact scene instantly"
+        },
+        "noRecord": {
+          "problem": "Training content is explained verbally and never recorded",
+          "solution": "Whisper transcription converts every word into searchable text"
+        },
+        "newHire": {
+          "problem": "New hires can't understand manuals and ask the same questions repeatedly",
+          "solution": "Video + AI Q&A enables self-directed learning"
+        },
+        "highCost": {
+          "problem": "Training coordinators spend too much time managing materials",
+          "solution": "Organize training programs with video groups and distribute instantly"
+        }
+      },
+      "useCases": {
+        "title": "Use Case Examples",
+        "onboarding": {
+          "title": "New Employee Onboarding Video Archive",
+          "description": "Centralize onboarding videos so new hires can learn at their own pace and get instant answers via AI chat."
+        },
+        "compliance": {
+          "title": "Compliance Training Review",
+          "description": "Digitize required training on harassment and security. Combine with attendance records to strengthen compliance."
+        },
+        "manual": {
+          "title": "Turn Product & Process Manuals into Internal Knowledge",
+          "description": "Convert procedural how-to videos into a searchable internal wiki. AI search instantly answers \"how do I do this again?\""
+        },
+        "seminar": {
+          "title": "Reuse Past Internal Seminars & Study Sessions",
+          "description": "Share recorded internal talks with the whole company. Employees who couldn't attend can catch up anytime."
+        }
+      },
+      "api": {
+        "title": "Integrate with Internal Systems via API",
+        "slack": {
+          "title": "Connect to Slack Bots & LMS",
+          "description": "Use the OpenAI-compatible API to power video search and AI Q&A from your internal Slack bot or LMS."
+        },
+        "mcp": {
+          "title": "Search Directly from Claude Desktop",
+          "description": "Via MCP server, search and reference corporate training videos directly from Claude Desktop."
+        }
+      },
+      "cta": {
+        "title": "Start Activating Your Corporate Training Videos Today"
+      },
+      "footer": {
+        "link": "For Corporate Training"
+      }
     }
   }
 }

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1096,6 +1096,69 @@
       "footer": {
         "link": "教育機関向け"
       }
+    },
+    "corporateTraining": {
+      "hero": {
+        "title": "社内研修動画を AI で検索・活用。研修効果を最大化する動画プラットフォーム",
+        "subtitle": "研修動画をアップロードするだけ。社員がいつでも必要な場面を自分で探せる",
+        "ctaSignup": "無料で始める",
+        "ctaApiDocs": "API ドキュメントを見る"
+      },
+      "problems": {
+        "title": "企業研修の課題を解決",
+        "tooMany": {
+          "problem": "研修動画が多すぎて社員が見返さない",
+          "solution": "AI チャットで「有給申請の手順は？」と聞くと該当シーンへジャンプ"
+        },
+        "noRecord": {
+          "problem": "研修内容が口頭説明で記録に残らない",
+          "solution": "Whisper 文字起こしで全発言をテキスト化・検索可能に"
+        },
+        "newHire": {
+          "problem": "新入社員がマニュアルを理解できず何度も質問",
+          "solution": "動画 + AI 質問応答でセルフラーニング化"
+        },
+        "highCost": {
+          "problem": "研修担当者の工数が多い",
+          "solution": "動画グループで研修プログラムを構造化して配布"
+        }
+      },
+      "useCases": {
+        "title": "ユースケース例",
+        "onboarding": {
+          "title": "新入社員研修動画のアーカイブ・検索",
+          "description": "入社研修の動画を一元管理。新入社員が自分のペースで見返し、AI チャットで疑問を即解決できます。"
+        },
+        "compliance": {
+          "title": "コンプライアンス研修の振り返り",
+          "description": "ハラスメント・情報セキュリティなど法定研修を動画化。受講記録と合わせてコンプライアンスを強化します。"
+        },
+        "manual": {
+          "title": "製品・業務マニュアル動画の社内ナレッジ化",
+          "description": "業務手順の説明動画を社内 Wiki 化。「あの操作どうやるんだっけ？」を AI 検索で即解決します。"
+        },
+        "seminar": {
+          "title": "過去の社内セミナー・勉強会の活用",
+          "description": "録画した社内勉強会を全社員に共有。参加できなかった社員も後から動画で学習できます。"
+        }
+      },
+      "api": {
+        "title": "API 連携で社内システムと統合",
+        "slack": {
+          "title": "Slack bot・LMS と連携",
+          "description": "OpenAI 互換 API で社内 Slack bot や LMS からビデオ検索・AI 質問応答を呼び出せます。"
+        },
+        "mcp": {
+          "title": "Claude Desktop から直接検索",
+          "description": "MCP サーバー経由で Claude Desktop から社内研修動画を直接検索・参照できます。"
+        }
+      },
+      "cta": {
+        "title": "社内研修の動画活用を、今すぐ始めよう"
+      },
+      "footer": {
+        "link": "企業研修向け"
+      }
     }
   }
 }

--- a/frontend/src/pages/UseCaseCorporateTrainingPage.tsx
+++ b/frontend/src/pages/UseCaseCorporateTrainingPage.tsx
@@ -1,0 +1,298 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Archive,
+  ShieldCheck,
+  BookMarked,
+  Users,
+  Code2,
+  Bot,
+  ArrowRight,
+  CheckCircle,
+} from 'lucide-react';
+import { AppPageShell } from '@/components/layout/AppPageShell';
+import { Link, useLocale } from '@/lib/i18n';
+
+const BASE_URL = 'https://videoq.jp';
+const EN_URL = `${BASE_URL}/use-cases/corporate-training`;
+const JA_URL = `${BASE_URL}/ja/use-cases/corporate-training`;
+
+const CONTAINER = 'max-w-screen-xl mx-auto px-6 lg:px-8';
+
+const FAQ_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: '料金はどのくらいかかりますか？',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'VideoQ は無料プランからご利用いただけます。チームの規模や利用量に応じたプランをご用意しています。',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'セキュリティは大丈夫ですか？社内の機密動画をアップロードしても安全ですか？',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'VideoQ はアクセス制御機能を備えており、共有リンクの発行範囲を制限できます。社内の機密情報を安全に管理できます。',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: '既存の LMS や社内システムと連携できますか？',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'OpenAI 互換 API を提供しており、既存の LMS・Slack bot・社内システムと簡単に統合できます。MCP サーバーにも対応しています。',
+      },
+    },
+  ],
+};
+
+export default function UseCaseCorporateTrainingPage() {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const currentUrl = locale === 'ja' ? JA_URL : EN_URL;
+
+  useEffect(() => {
+    // title
+    const prevTitle = document.title;
+    document.title = '社内研修動画をAI検索 | VideoQ 企業研修向け';
+
+    // meta description
+    const metaDesc = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+    const prevDesc = metaDesc?.getAttribute('content') ?? '';
+    metaDesc?.setAttribute(
+      'content',
+      'VideoQ は企業研修向け AI 動画プラットフォームです。社内研修動画を Whisper で文字起こしし、社員が AI チャットで必要な場面を即検索。新入社員研修・コンプライアンス・業務マニュアルに対応。',
+    );
+
+    // canonical
+    const canonicalEl = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    const prevCanonical = canonicalEl?.getAttribute('href') ?? '';
+    canonicalEl?.setAttribute('href', currentUrl);
+
+    // hreflang alternates
+    const hreflangEn = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="en"]');
+    const hreflangJa = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="ja"]');
+    const hreflangXDefault = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="x-default"]');
+    const prevHreflangEn = hreflangEn?.getAttribute('href') ?? '';
+    const prevHreflangJa = hreflangJa?.getAttribute('href') ?? '';
+    const prevHreflangXDefault = hreflangXDefault?.getAttribute('href') ?? '';
+    hreflangEn?.setAttribute('href', EN_URL);
+    hreflangJa?.setAttribute('href', JA_URL);
+    hreflangXDefault?.setAttribute('href', EN_URL);
+
+    // OGP
+    const ogTitle = document.querySelector<HTMLMetaElement>('meta[property="og:title"]');
+    const ogDesc = document.querySelector<HTMLMetaElement>('meta[property="og:description"]');
+    const ogUrl = document.querySelector<HTMLMetaElement>('meta[property="og:url"]');
+    const prevOgTitle = ogTitle?.getAttribute('content') ?? '';
+    const prevOgDesc = ogDesc?.getAttribute('content') ?? '';
+    const prevOgUrl = ogUrl?.getAttribute('content') ?? '';
+    ogTitle?.setAttribute('content', '社内研修動画をAI検索 | VideoQ 企業研修向け');
+    ogDesc?.setAttribute('content', 'VideoQ は企業研修向け AI 動画プラットフォームです。社内研修動画を Whisper で文字起こしし、社員が AI チャットで必要な場面を即検索できます。');
+    ogUrl?.setAttribute('content', currentUrl);
+
+    // FAQPage schema
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.id = 'faq-schema-corporate-training';
+    script.textContent = JSON.stringify(FAQ_SCHEMA);
+    document.head.appendChild(script);
+
+    return () => {
+      document.title = prevTitle;
+      metaDesc?.setAttribute('content', prevDesc);
+      canonicalEl?.setAttribute('href', prevCanonical);
+      hreflangEn?.setAttribute('href', prevHreflangEn);
+      hreflangJa?.setAttribute('href', prevHreflangJa);
+      hreflangXDefault?.setAttribute('href', prevHreflangXDefault);
+      ogTitle?.setAttribute('content', prevOgTitle);
+      ogDesc?.setAttribute('content', prevOgDesc);
+      ogUrl?.setAttribute('content', prevOgUrl);
+      document.getElementById('faq-schema-corporate-training')?.remove();
+    };
+  }, [currentUrl]);
+
+  return (
+    <AppPageShell isPublic contentClassName="w-full px-0">
+      {/* ── Hero ── */}
+      <section className="w-full bg-[#f8faf5] py-16 lg:py-24">
+        <div className={`${CONTAINER} text-center`}>
+          <span
+            className="inline-block mb-4 px-3 py-1 rounded-full text-xs font-semibold tracking-widest uppercase"
+            style={{ background: '#dcfce7', color: '#00652c' }}
+          >
+            Corporate Training
+          </span>
+          <h1 className="text-3xl lg:text-5xl font-extrabold text-[#191c19] leading-tight mb-5 max-w-3xl mx-auto">
+            {t('useCases.corporateTraining.hero.title')}
+          </h1>
+          <p className="text-base lg:text-lg text-[#3f493f] mb-8 max-w-2xl mx-auto leading-relaxed">
+            {t('useCases.corporateTraining.hero.subtitle')}
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              to="/signup"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-semibold text-white text-sm transition-opacity hover:opacity-90"
+              style={{
+                background: 'linear-gradient(145deg, #00652c 0%, #15803d 100%)',
+                boxShadow: '0 4px 16px rgba(0,101,44,0.25)',
+              }}
+            >
+              {t('useCases.corporateTraining.hero.ctaSignup')}
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+            <Link
+              to="/docs"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-semibold text-[#00652c] text-sm border-2 border-[#00652c] bg-transparent hover:bg-[#f0fdf4] transition-colors"
+            >
+              {t('useCases.corporateTraining.hero.ctaApiDocs')}
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Problems → Solutions ── */}
+      <section className="w-full py-16 lg:py-20 bg-white">
+        <div className={CONTAINER}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-[#191c19] text-center mb-12">
+            {t('useCases.corporateTraining.problems.title')}
+          </h2>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {(
+              [
+                'tooMany',
+                'noRecord',
+                'newHire',
+                'highCost',
+              ] as const
+            ).map((key) => (
+              <div
+                key={key}
+                className="rounded-2xl overflow-hidden"
+                style={{ boxShadow: '0 8px 24px rgba(25,28,25,0.06)' }}
+              >
+                <div className="bg-[#f8faf5] px-5 py-4">
+                  <p className="text-sm font-medium text-[#6f7a6e] leading-snug">
+                    {t(`useCases.corporateTraining.problems.${key}.problem`)}
+                  </p>
+                </div>
+                <div className="bg-white px-5 py-4 flex gap-3 items-start">
+                  <CheckCircle className="w-5 h-5 text-[#00652c] mt-0.5 shrink-0" />
+                  <p className="text-sm font-semibold text-[#191c19] leading-snug">
+                    {t(`useCases.corporateTraining.problems.${key}.solution`)}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Use Cases ── */}
+      <section className="w-full py-16 lg:py-20 bg-[#f8faf5]">
+        <div className={CONTAINER}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-[#191c19] text-center mb-12">
+            {t('useCases.corporateTraining.useCases.title')}
+          </h2>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {(
+              [
+                { key: 'onboarding', Icon: Users },
+                { key: 'compliance', Icon: ShieldCheck },
+                { key: 'manual', Icon: BookMarked },
+                { key: 'seminar', Icon: Archive },
+              ] as const
+            ).map(({ key, Icon }) => (
+              <div
+                key={key}
+                className="rounded-2xl bg-white p-6"
+                style={{ boxShadow: '0 8px 24px rgba(25,28,25,0.06)' }}
+              >
+                <div
+                  className="w-10 h-10 rounded-xl flex items-center justify-center mb-4"
+                  style={{ background: '#dcfce7' }}
+                >
+                  <Icon className="w-5 h-5 text-[#00652c]" />
+                </div>
+                <h3 className="font-bold text-[#191c19] mb-2">
+                  {t(`useCases.corporateTraining.useCases.${key}.title`)}
+                </h3>
+                <p className="text-sm text-[#6f7a6e] leading-relaxed">
+                  {t(`useCases.corporateTraining.useCases.${key}.description`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── API Integration ── */}
+      <section id="api" className="w-full py-16 lg:py-20 bg-white">
+        <div className={CONTAINER}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-[#191c19] text-center mb-12">
+            {t('useCases.corporateTraining.api.title')}
+          </h2>
+          <div className="grid gap-6 md:grid-cols-2 max-w-2xl mx-auto">
+            {(
+              [
+                { key: 'slack', Icon: Bot },
+                { key: 'mcp', Icon: Code2 },
+              ] as const
+            ).map(({ key, Icon }) => (
+              <div
+                key={key}
+                className="rounded-2xl bg-[#f8faf5] p-6"
+                style={{ boxShadow: '0 4px 16px rgba(25,28,25,0.04)' }}
+              >
+                <div
+                  className="w-10 h-10 rounded-xl flex items-center justify-center mb-4"
+                  style={{ background: '#00652c' }}
+                >
+                  <Icon className="w-5 h-5 text-white" />
+                </div>
+                <h3 className="font-bold text-[#191c19] mb-2">
+                  {t(`useCases.corporateTraining.api.${key}.title`)}
+                </h3>
+                <p className="text-sm text-[#6f7a6e] leading-relaxed">
+                  {t(`useCases.corporateTraining.api.${key}.description`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Bottom CTA ── */}
+      <section
+        className="w-full py-16 lg:py-20"
+        style={{ background: 'linear-gradient(145deg, #00652c 0%, #005b8c 100%)' }}
+      >
+        <div className={`${CONTAINER} text-center`}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-white mb-6">
+            {t('useCases.corporateTraining.cta.title')}
+          </h2>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              to="/signup"
+              className="inline-flex items-center gap-2 px-8 py-4 rounded-xl font-bold text-[#00652c] bg-white text-sm transition-opacity hover:opacity-90"
+              style={{ boxShadow: '0 4px 16px rgba(0,0,0,0.2)' }}
+            >
+              {t('useCases.corporateTraining.hero.ctaSignup')}
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+            <Link
+              to="/docs"
+              className="inline-flex items-center gap-2 px-8 py-4 rounded-xl font-bold text-white text-sm border-2 border-white bg-transparent hover:bg-white/10 transition-colors"
+            >
+              {t('useCases.corporateTraining.hero.ctaApiDocs')}
+            </Link>
+          </div>
+        </div>
+      </section>
+    </AppPageShell>
+  );
+}

--- a/frontend/src/pages/__tests__/UseCaseCorporateTrainingPage.test.tsx
+++ b/frontend/src/pages/__tests__/UseCaseCorporateTrainingPage.test.tsx
@@ -1,0 +1,214 @@
+import { render, screen } from '@testing-library/react'
+import UseCaseCorporateTrainingPage from '../UseCaseCorporateTrainingPage'
+
+describe('UseCaseCorporateTrainingPage', () => {
+  describe('Hero section', () => {
+    it('renders hero title', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'useCases.corporateTraining.hero.title'
+      )
+    })
+
+    it('renders hero subtitle', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.hero.subtitle')).toBeInTheDocument()
+    })
+
+    it('renders signup CTA link pointing to /signup', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      const signupLinks = screen.getAllByText('useCases.corporateTraining.hero.ctaSignup')
+      expect(signupLinks.length).toBeGreaterThan(0)
+      expect(signupLinks[0].closest('a')).toHaveAttribute('href', '/signup')
+    })
+
+    it('renders API docs CTA link pointing to /docs', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      const apiDocsLinks = screen.getAllByText('useCases.corporateTraining.hero.ctaApiDocs')
+      expect(apiDocsLinks.length).toBeGreaterThan(0)
+      expect(apiDocsLinks[0].closest('a')).toHaveAttribute('href', '/docs')
+    })
+  })
+
+  describe('Problems section', () => {
+    it('renders problems section title', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.problems.title')).toBeInTheDocument()
+    })
+
+    it('renders tooMany problem', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.problems.tooMany.problem')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.problems.tooMany.solution')).toBeInTheDocument()
+    })
+
+    it('renders noRecord problem', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.problems.noRecord.problem')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.problems.noRecord.solution')).toBeInTheDocument()
+    })
+
+    it('renders newHire problem', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.problems.newHire.problem')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.problems.newHire.solution')).toBeInTheDocument()
+    })
+
+    it('renders highCost problem', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.problems.highCost.problem')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.problems.highCost.solution')).toBeInTheDocument()
+    })
+  })
+
+  describe('Use cases section', () => {
+    it('renders use cases section title', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.useCases.title')).toBeInTheDocument()
+    })
+
+    it('renders onboarding use case', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.useCases.onboarding.title')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.useCases.onboarding.description')).toBeInTheDocument()
+    })
+
+    it('renders compliance use case', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.useCases.compliance.title')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.useCases.compliance.description')).toBeInTheDocument()
+    })
+
+    it('renders manual use case', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.useCases.manual.title')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.useCases.manual.description')).toBeInTheDocument()
+    })
+
+    it('renders seminar use case', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.useCases.seminar.title')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.useCases.seminar.description')).toBeInTheDocument()
+    })
+  })
+
+  describe('API integration section', () => {
+    it('renders API integration section title', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.api.title')).toBeInTheDocument()
+    })
+
+    it('renders slack integration', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.api.slack.title')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.api.slack.description')).toBeInTheDocument()
+    })
+
+    it('renders mcp integration', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.api.mcp.title')).toBeInTheDocument()
+      expect(screen.getByText('useCases.corporateTraining.api.mcp.description')).toBeInTheDocument()
+    })
+  })
+
+  describe('Bottom CTA section', () => {
+    it('renders bottom CTA title', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(screen.getByText('useCases.corporateTraining.cta.title')).toBeInTheDocument()
+    })
+
+    it('renders bottom signup CTA link', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      const signupLinks = screen.getAllByText('useCases.corporateTraining.hero.ctaSignup')
+      expect(signupLinks.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('renders bottom API docs CTA link', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      const apiDocsLinks = screen.getAllByText('useCases.corporateTraining.hero.ctaApiDocs')
+      expect(apiDocsLinks.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('SEO', () => {
+    it('sets document.title on mount', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      expect(document.title).toBe('社内研修動画をAI検索 | VideoQ 企業研修向け')
+    })
+
+    it('injects FAQPage schema on mount', () => {
+      render(<UseCaseCorporateTrainingPage />)
+      const script = document.getElementById('faq-schema-corporate-training')
+      expect(script).not.toBeNull()
+      expect(script?.getAttribute('type')).toBe('application/ld+json')
+      const json = JSON.parse(script?.textContent ?? '{}')
+      expect(json['@type']).toBe('FAQPage')
+      expect(json.mainEntity).toHaveLength(3)
+    })
+
+    it('restores document.title on unmount', () => {
+      document.title = 'original title'
+      const { unmount } = render(<UseCaseCorporateTrainingPage />)
+      unmount()
+      expect(document.title).toBe('original title')
+    })
+
+    it('sets canonical href to EN URL on mount (en locale)', () => {
+      const link = document.createElement('link')
+      link.rel = 'canonical'
+      link.href = 'https://videoq.jp/'
+      document.head.appendChild(link)
+
+      render(<UseCaseCorporateTrainingPage />)
+      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+        'https://videoq.jp/use-cases/corporate-training'
+      )
+
+      link.remove()
+    })
+
+    it('restores canonical href on unmount', () => {
+      const link = document.createElement('link')
+      link.rel = 'canonical'
+      link.href = 'https://videoq.jp/'
+      document.head.appendChild(link)
+
+      const { unmount } = render(<UseCaseCorporateTrainingPage />)
+      unmount()
+      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+        'https://videoq.jp/'
+      )
+
+      link.remove()
+    })
+
+    it('sets og:url to EN URL on mount', () => {
+      const meta = document.createElement('meta')
+      meta.setAttribute('property', 'og:url')
+      meta.setAttribute('content', 'https://videoq.jp/')
+      document.head.appendChild(meta)
+
+      render(<UseCaseCorporateTrainingPage />)
+      expect(
+        document.querySelector('meta[property="og:url"]')?.getAttribute('content')
+      ).toBe('https://videoq.jp/use-cases/corporate-training')
+
+      meta.remove()
+    })
+
+    it('restores og:url on unmount', () => {
+      const meta = document.createElement('meta')
+      meta.setAttribute('property', 'og:url')
+      meta.setAttribute('content', 'https://videoq.jp/')
+      document.head.appendChild(meta)
+
+      const { unmount } = render(<UseCaseCorporateTrainingPage />)
+      unmount()
+      expect(
+        document.querySelector('meta[property="og:url"]')?.getAttribute('content')
+      ).toBe('https://videoq.jp/')
+
+      meta.remove()
+    })
+  })
+})


### PR DESCRIPTION
## 概要
企業研修向けのユースケースランディングページ `/use-cases/corporate-training` を追加しました。
あわせて英語・日本語の文言、ルーティング、SEO 設定、サイトマップ、テストを追加しています。

## 変更内容
- `/use-cases/corporate-training` と `/ja/use-cases/corporate-training` に対応するページを追加
- `App.tsx` に企業研修向けユースケースページのルートを追加
- 英語 / 日本語の翻訳文言を追加
- ページ内に以下のセクションを実装
- Hero
- 課題と解決策
- ユースケース例
- API 連携
- CTA
- SEO 対応を追加
- title / meta description
- canonical
- hreflang
- OGP
- FAQ 構造化データ
- `sitemap.xml` に企業研修向けページを追加
- ページ表示と SEO の基本挙動を確認するテストを追加

## 変更ファイル
- `frontend/src/pages/UseCaseCorporateTrainingPage.tsx`
- `frontend/src/pages/__tests__/UseCaseCorporateTrainingPage.test.tsx`
- `frontend/src/App.tsx`
- `frontend/src/i18n/locales/ja/translation.json`
- `frontend/src/i18n/locales/en/translation.json`
- `frontend/public/sitemap.xml`

## 動作確認
- 企業研修向けユースケースページが表示されること
- `/use-cases/corporate-training`
- `/ja/use-cases/corporate-training`
- CTA が `/signup` と `/docs` に遷移すること
- title / canonical / og:url / FAQ schema が設定されること

## テスト
- `frontend/src/pages/__tests__/UseCaseCorporateTrainingPage.test.tsx` を追加