### PR TITLE
トップページのコピーとCTAを教育・企業研修ペルソナ向けに最適化

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VideoQ — あらゆるビデオを、最高の学びの体験へ</title>
-    <meta name="description" content="VideoQは動画をAIで検索・質問できる学習プラットフォームです。Whisperで自動文字起こし、RAGチャットで動画の内容に自然言語で質問できます。OpenAI互換API対応。" />
+    <title>動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ</title>
+    <meta name="description" content="VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修・セミナーを文字起こし。自然言語で即検索できます。無料で始められます。" />
     <link rel="canonical" href="https://videoq.jp/" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://videoq.jp/" />
-    <meta property="og:title" content="VideoQ — あらゆるビデオを、最高の学びの体験へ" />
-    <meta property="og:description" content="動画をアップロードしてAIで自動文字起こし。動画の内容にチャットで質問できる教育向けプラットフォーム。OpenAI互換API対応。" />
+    <meta property="og:title" content="動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ" />
+    <meta property="og:description" content="VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修・セミナーを文字起こし。自然言語で即検索できます。" />
     <meta property="og:site_name" content="VideoQ" />
     <meta property="og:locale" content="ja_JP" />
     <meta property="og:locale:alternate" content="en_US" />
@@ -18,8 +18,8 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="VideoQ — AI動画ナビゲーター" />
-    <meta name="twitter:description" content="動画をアップロードしてAIで自動文字起こし。動画の内容にチャットで質問できる教育向けプラットフォーム。" />
+    <meta name="twitter:title" content="動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ" />
+    <meta name="twitter:description" content="VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修を文字起こし。自然言語で即検索できます。" />
     <meta name="twitter:image" content="https://videoq.jp/og-image.png" />
     <link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/" />
     <link rel="alternate" hreflang="en" href="https://videoq.jp/" />

--- a/frontend/src/components/layout/AppNav.tsx
+++ b/frontend/src/components/layout/AppNav.tsx
@@ -4,8 +4,9 @@ import { GraduationCap, LogOut, Menu, X, CreditCard, LogIn } from 'lucide-react'
 import { Link, useI18nNavigate } from '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '@/lib/api';
+import { apiClient, type User } from '@/lib/api';
 import { APP_CONTAINER_CLASS } from '@/components/layout/layoutTokens';
+import { queryKeys } from '@/lib/queryKeys';
 
 export type ActivePage = 'home' | 'videos' | 'groups' | 'docs' | 'settings' | 'billing';
 
@@ -14,11 +15,14 @@ interface AppNavProps {
   isPublic?: boolean;
 }
 
-export function AppNav({ activePage, isPublic = false }: AppNavProps) {
+export function AppNav({ activePage }: AppNavProps) {
   const { t } = useTranslation();
   const navigate = useI18nNavigate();
   const queryClient = useQueryClient();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const cachedUser = queryClient.getQueryData<User | null>(queryKeys.auth.me);
+  const isAuthenticated = !!cachedUser;
 
   const logoutMutation = useMutation({
     mutationFn: async () => await apiClient.logout(),
@@ -37,14 +41,16 @@ export function AppNav({ activePage, isPublic = false }: AppNavProps) {
     }
   };
 
-  const navLinks: { href: string; label: string; key: ActivePage; icon?: React.ReactNode }[] = [
+  const allNavLinks: { href: string; label: string; key: ActivePage; icon?: React.ReactNode; authRequired?: boolean }[] = [
     { href: '/', label: t('navigation.home'), key: 'home' },
-    { href: '/videos', label: t('navigation.videosNav'), key: 'videos' },
-    { href: '/videos/groups', label: t('navigation.groupsNav'), key: 'groups' },
+    { href: '/videos', label: t('navigation.videosNav'), key: 'videos', authRequired: true },
+    { href: '/videos/groups', label: t('navigation.groupsNav'), key: 'groups', authRequired: true },
     { href: '/docs', label: t('navigation.docs'), key: 'docs' },
-    { href: '/settings', label: t('navigation.settings'), key: 'settings' },
-    { href: '/billing', label: t('billing.nav'), key: 'billing', icon: <CreditCard className="w-3.5 h-3.5" /> },
+    { href: '/settings', label: t('navigation.settings'), key: 'settings', authRequired: true },
+    { href: '/billing', label: t('billing.nav'), key: 'billing', icon: <CreditCard className="w-3.5 h-3.5" />, authRequired: true },
   ];
+
+  const navLinks = isAuthenticated ? allNavLinks : allNavLinks.filter((l) => !l.authRequired);
 
   return (
     <nav className="fixed top-0 w-full z-50 bg-white/80 backdrop-blur-xl border-b border-stone-200/60">
@@ -76,7 +82,7 @@ export function AppNav({ activePage, isPublic = false }: AppNavProps) {
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
-          {isPublic ? (
+          {!isAuthenticated ? (
             <Link
               href="/login"
               className="hidden md:flex items-center gap-1.5 text-sm font-semibold text-stone-600 hover:text-[#00652c] transition-colors px-2"
@@ -126,7 +132,7 @@ export function AppNav({ activePage, isPublic = false }: AppNavProps) {
               </Link>
             ))}
             <div className="border-t border-stone-200/60 mt-2 pt-2">
-              {isPublic ? (
+              {!isAuthenticated ? (
                 <Link
                   href="/login"
                   onClick={() => setIsMobileMenuOpen(false)}

--- a/frontend/src/components/layout/__tests__/AppNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppNav.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/queryKeys'
+
+// Unmock AppNav so we can test the real implementation
+vi.unmock('@/components/layout/AppNav')
+
+const { AppNav } = await vi.importActual<typeof import('../AppNav')>('../AppNav')
+
+// Helper: seeds the React Query cache with a user before rendering
+function SeedUser({ user }: { user: unknown }) {
+  const qc = useQueryClient()
+  qc.setQueryData(queryKeys.auth.me, user)
+  return null
+}
+
+function renderWithUser(ui: React.ReactElement) {
+  return render(
+    <>
+      <SeedUser user={{ id: '1', username: 'testuser' }} />
+      {ui}
+    </>
+  )
+}
+
+describe('AppNav - no authenticated user (empty cache)', () => {
+  it('highlights home link when activePage="home"', () => {
+    render(<AppNav activePage="home" />)
+    const homeLink = screen.getByText('navigation.home')
+    expect(homeLink.closest('a')).toHaveClass('border-b-2')
+  })
+
+  it('hides videos nav link', () => {
+    render(<AppNav />)
+    expect(screen.queryByText('navigation.videosNav')).not.toBeInTheDocument()
+  })
+
+  it('hides groups nav link', () => {
+    render(<AppNav />)
+    expect(screen.queryByText('navigation.groupsNav')).not.toBeInTheDocument()
+  })
+
+  it('hides billing nav link', () => {
+    render(<AppNav />)
+    expect(screen.queryByText('billing.nav')).not.toBeInTheDocument()
+  })
+
+  it('hides settings nav link', () => {
+    render(<AppNav />)
+    expect(screen.queryByText('navigation.settings')).not.toBeInTheDocument()
+  })
+
+  it('shows docs nav link', () => {
+    render(<AppNav />)
+    expect(screen.getByText('navigation.docs')).toBeInTheDocument()
+  })
+
+  it('shows login button', () => {
+    render(<AppNav />)
+    expect(screen.getByText('auth.login.submit')).toBeInTheDocument()
+  })
+})
+
+describe('AppNav - authenticated user (cache populated)', () => {
+  it('shows videos nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('navigation.videosNav')).toBeInTheDocument()
+  })
+
+  it('shows groups nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('navigation.groupsNav')).toBeInTheDocument()
+  })
+
+  it('shows billing nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('billing.nav')).toBeInTheDocument()
+  })
+
+  it('shows settings nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('navigation.settings')).toBeInTheDocument()
+  })
+
+  it('shows docs nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('navigation.docs')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1015,9 +1015,9 @@
   },
   "landing": {
     "hero": {
-      "title": "Turn Any Video Into the Ultimate Learning Experience",
-      "subtitle": "AI-Powered Video Learning Platform",
-      "description": "Upload videos for automatic transcription via OpenAI Whisper, then ask questions about the content using RAG chat.",
+      "title": "Just Upload Your Video. AI Transcribes & Instantly Searches Your Lessons & Training",
+      "subtitle": "AI Video Learning Platform for Education & Corporate Training",
+      "description": "Transcribe your lectures, training videos, and seminars with AI — then search any moment with natural language. Built for educators and training teams.",
       "ctaSignup": "Get Started for Free",
       "ctaDocs": "Developer Docs"
     },
@@ -1034,6 +1034,24 @@
       "api": {
         "title": "OpenAI-Compatible API",
         "description": "Use any OpenAI client or SDK with your video library"
+      }
+    },
+    "personas": {
+      "title": "Who It's For",
+      "educator": {
+        "title": "Educators & Instructors",
+        "description": "Turn recorded lessons into self-study materials. Students find answers with AI chat on their own.",
+        "ctaLink": "For Educational Institutions"
+      },
+      "corporateTrainer": {
+        "title": "Corporate Training Teams",
+        "description": "Transform training videos into an AI knowledge base. New hires find exactly what they need, any time.",
+        "ctaLink": "For Corporate Training"
+      },
+      "developer": {
+        "title": "Developers",
+        "description": "Embed video AI into your product with an OpenAI-compatible API. Works with any existing SDK.",
+        "ctaLink": "View API Docs"
       }
     }
   },

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1015,9 +1015,9 @@
   },
   "landing": {
     "hero": {
-      "title": "あらゆるビデオを、最高の学びの体験へ",
-      "subtitle": "AI動画学習プラットフォーム",
-      "description": "動画をアップロードしてOpenAI Whisperで自動文字起こし。RAGチャットで動画の内容に自然言語で質問できます。",
+      "title": "動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索",
+      "subtitle": "教育・企業研修向けAI動画学習プラットフォーム",
+      "description": "授業・研修・セミナーの動画をAIで文字起こし→自然言語で即検索。教育者・研修担当者が動画を最大活用できます。",
       "ctaSignup": "無料で始める",
       "ctaDocs": "開発者ドキュメント"
     },
@@ -1034,6 +1034,24 @@
       "api": {
         "title": "OpenAI互換API",
         "description": "既存のOpenAIクライアントやSDKでビデオライブラリを操作できます"
+      }
+    },
+    "personas": {
+      "title": "こんな方に",
+      "educator": {
+        "title": "教育者・講師",
+        "description": "授業録画を学生が自習できる教材に。AIチャットで学生が自力で答えを探せます。",
+        "ctaLink": "教育機関の方はこちら"
+      },
+      "corporateTrainer": {
+        "title": "企業の研修担当者",
+        "description": "研修動画をAIナレッジベースに。新入社員が必要な情報をいつでも自分で検索できます。",
+        "ctaLink": "企業研修の方はこちら"
+      },
+      "developer": {
+        "title": "開発者",
+        "description": "OpenAI互換APIで自社サービスに動画AIを組み込む。既存のSDKでそのまま使えます。",
+        "ctaLink": "APIドキュメントを見る"
       }
     }
   },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -632,6 +632,18 @@ class ApiClient {
     return this.request<User>('/auth/me');
   }
 
+  async getMeOrNull(): Promise<User | null> {
+    try {
+      const url = this.buildUrl('/auth/me');
+      const headers = this.buildHeaders();
+      const response = await fetch(url, { credentials: 'include', headers });
+      if (!response.ok) return null;
+      return await this.parseJsonResponse<User>(response);
+    } catch {
+      return null;
+    }
+  }
+
   async getIntegrationApiKeys(): Promise<IntegrationApiKey[]> {
     return this.request<IntegrationApiKey[]>('/auth/api-keys/');
   }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,9 +1,8 @@
 import { useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useI18nNavigate } from '@/lib/i18n';
-import { useAuth } from '@/hooks/useAuth';
-import { type User } from '@/lib/api';
+import { apiClient, type User } from '@/lib/api';
 import { useHomePageData } from '@/hooks/useHomePageData';
 import { useVideoStats } from '@/hooks/useVideoStats';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
@@ -15,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 import {
   Upload, Film, Users, ArrowRight, Lightbulb,
 } from 'lucide-react';
+import LandingPage from '@/pages/LandingPage';
 
 function ActionCard({ icon, iconBg, title, description, linkLabel, linkColor, onClick }: {
   icon: ReactNode;
@@ -46,11 +46,17 @@ export default function HomePage() {
   const navigate = useI18nNavigate();
   const queryClient = useQueryClient();
   const { t } = useTranslation();
-  const { user, isLoading } = useAuth();
+
+  const { data: user, isLoading } = useQuery<User | null>({
+    queryKey: queryKeys.auth.me,
+    queryFn: () => apiClient.getMeOrNull(),
+    retry: false,
+  });
+
   const cachedUser = queryClient.getQueryData<User | null>(queryKeys.auth.me) ?? null;
   const currentUser = user ?? cachedUser;
 
-  const { videos, groups, isLoading: isLoadingData } = useHomePageData({ userId: user?.id });
+  const { videos, groups, isLoading: isLoadingData } = useHomePageData({ userId: currentUser?.id });
   const videoStats = useVideoStats(videos);
 
   const recentVideos = useMemo(
@@ -61,7 +67,19 @@ export default function HomePage() {
     [videos],
   );
 
-  if (isLoading || !user || isLoadingData) {
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#f8faf5]">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (!currentUser) {
+    return <LandingPage />;
+  }
+
+  if (isLoadingData) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-[#f8faf5]">
         <LoadingSpinner />

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,232 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  GraduationCap,
+  Building2,
+  Code2,
+  Mic,
+  MessageSquare,
+  Plug,
+  ArrowRight,
+} from 'lucide-react';
+import { AppPageShell } from '@/components/layout/AppPageShell';
+import { Link } from '@/lib/i18n';
+
+const BASE_URL = 'https://videoq.jp';
+const CONTAINER = 'max-w-screen-xl mx-auto px-6 lg:px-8';
+
+export default function LandingPage() {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const prevTitle = document.title;
+    document.title = '動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ';
+
+    const metaDesc = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+    const prevDesc = metaDesc?.getAttribute('content') ?? '';
+    metaDesc?.setAttribute(
+      'content',
+      'VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修・セミナーを文字起こし。自然言語で即検索できます。無料で始められます。',
+    );
+
+    const canonicalEl = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    const prevCanonical = canonicalEl?.getAttribute('href') ?? '';
+    canonicalEl?.setAttribute('href', `${BASE_URL}/`);
+
+    return () => {
+      document.title = prevTitle;
+      metaDesc?.setAttribute('content', prevDesc);
+      canonicalEl?.setAttribute('href', prevCanonical);
+    };
+  }, []);
+
+  return (
+    <AppPageShell isPublic activePage="home" contentClassName="w-full px-0">
+      {/* ── Hero ── */}
+      <section className="w-full bg-[#f8faf5] py-16 lg:py-28">
+        <div className={`${CONTAINER} text-center`}>
+          <span
+            className="inline-block mb-4 px-3 py-1 rounded-full text-xs font-semibold tracking-widest uppercase"
+            style={{ background: '#dcfce7', color: '#00652c' }}
+          >
+            AI Video Platform
+          </span>
+          <h1 className="text-3xl lg:text-5xl font-extrabold text-[#191c19] leading-tight mb-5 max-w-3xl mx-auto">
+            {t('landing.hero.title')}
+          </h1>
+          <p className="text-base lg:text-lg text-[#3f493f] mb-4 max-w-2xl mx-auto leading-relaxed">
+            {t('landing.hero.subtitle')}
+          </p>
+          <p className="text-sm text-[#6f7a6e] mb-10 max-w-xl mx-auto leading-relaxed">
+            {t('landing.hero.description')}
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              to="/signup"
+              className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl font-semibold text-white text-sm transition-opacity hover:opacity-90"
+              style={{
+                background: 'linear-gradient(145deg, #00652c 0%, #15803d 100%)',
+                boxShadow: '0 4px 16px rgba(0,101,44,0.25)',
+              }}
+            >
+              {t('landing.hero.ctaSignup')}
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+            <Link
+              to="/docs"
+              className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl font-semibold text-[#00652c] text-sm border-2 border-[#00652c] bg-transparent hover:bg-[#f0fdf4] transition-colors"
+            >
+              {t('landing.hero.ctaDocs')}
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Personas (こんな方に) ── */}
+      <section className="w-full py-16 lg:py-20 bg-white">
+        <div className={CONTAINER}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-[#191c19] text-center mb-12">
+            {t('landing.personas.title')}
+          </h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {/* Educator */}
+            <div
+              className="rounded-2xl bg-[#f8faf5] p-7 flex flex-col"
+              style={{ boxShadow: '0 8px 24px rgba(25,28,25,0.06)' }}
+            >
+              <div
+                className="w-12 h-12 rounded-xl flex items-center justify-center mb-5"
+                style={{ background: '#dcfce7' }}
+              >
+                <GraduationCap className="w-6 h-6 text-[#00652c]" />
+              </div>
+              <h3 className="font-bold text-lg text-[#191c19] mb-3">
+                {t('landing.personas.educator.title')}
+              </h3>
+              <p className="text-sm text-[#6f7a6e] leading-relaxed mb-6 flex-1">
+                {t('landing.personas.educator.description')}
+              </p>
+              <Link
+                to="/use-cases/education"
+                className="inline-flex items-center gap-1 text-sm font-semibold text-[#00652c] hover:underline"
+              >
+                {t('landing.personas.educator.ctaLink')}
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+
+            {/* Corporate Trainer */}
+            <div
+              className="rounded-2xl bg-[#f8faf5] p-7 flex flex-col"
+              style={{ boxShadow: '0 8px 24px rgba(25,28,25,0.06)' }}
+            >
+              <div
+                className="w-12 h-12 rounded-xl flex items-center justify-center mb-5"
+                style={{ background: '#e0f2fe' }}
+              >
+                <Building2 className="w-6 h-6 text-[#005b8c]" />
+              </div>
+              <h3 className="font-bold text-lg text-[#191c19] mb-3">
+                {t('landing.personas.corporateTrainer.title')}
+              </h3>
+              <p className="text-sm text-[#6f7a6e] leading-relaxed mb-6 flex-1">
+                {t('landing.personas.corporateTrainer.description')}
+              </p>
+              <Link
+                to="/use-cases/corporate-training"
+                className="inline-flex items-center gap-1 text-sm font-semibold text-[#005b8c] hover:underline"
+              >
+                {t('landing.personas.corporateTrainer.ctaLink')}
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+
+            {/* Developer */}
+            <div
+              className="rounded-2xl bg-[#f8faf5] p-7 flex flex-col"
+              style={{ boxShadow: '0 8px 24px rgba(25,28,25,0.06)' }}
+            >
+              <div
+                className="w-12 h-12 rounded-xl flex items-center justify-center mb-5"
+                style={{ background: '#fef9c3' }}
+              >
+                <Code2 className="w-6 h-6 text-[#854d0e]" />
+              </div>
+              <h3 className="font-bold text-lg text-[#191c19] mb-3">
+                {t('landing.personas.developer.title')}
+              </h3>
+              <p className="text-sm text-[#6f7a6e] leading-relaxed mb-6 flex-1">
+                {t('landing.personas.developer.description')}
+              </p>
+              <Link
+                to="/docs"
+                className="inline-flex items-center gap-1 text-sm font-semibold text-[#854d0e] hover:underline"
+              >
+                {t('landing.personas.developer.ctaLink')}
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Features ── */}
+      <section className="w-full py-16 lg:py-20 bg-[#f8faf5]">
+        <div className={CONTAINER}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-[#191c19] text-center mb-12">
+            {t('landing.features.title')}
+          </h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {(
+              [
+                { key: 'transcription', Icon: Mic },
+                { key: 'chat', Icon: MessageSquare },
+                { key: 'api', Icon: Plug },
+              ] as const
+            ).map(({ key, Icon }) => (
+              <div
+                key={key}
+                className="rounded-2xl bg-white p-6"
+                style={{ boxShadow: '0 4px 16px rgba(25,28,25,0.04)' }}
+              >
+                <div
+                  className="w-10 h-10 rounded-xl flex items-center justify-center mb-4"
+                  style={{ background: '#00652c' }}
+                >
+                  <Icon className="w-5 h-5 text-white" />
+                </div>
+                <h3 className="font-bold text-[#191c19] mb-2">
+                  {t(`landing.features.${key}.title`)}
+                </h3>
+                <p className="text-sm text-[#6f7a6e] leading-relaxed">
+                  {t(`landing.features.${key}.description`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Bottom CTA ── */}
+      <section
+        className="w-full py-16 lg:py-20"
+        style={{ background: 'linear-gradient(145deg, #00652c 0%, #005b8c 100%)' }}
+      >
+        <div className={`${CONTAINER} text-center`}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-white mb-3">
+            {t('landing.hero.ctaSignup')}
+          </h2>
+          <p className="text-white/80 text-sm mb-8">{t('landing.hero.description')}</p>
+          <Link
+            to="/signup"
+            className="inline-flex items-center gap-2 px-8 py-4 rounded-xl font-bold text-[#00652c] bg-white text-sm transition-opacity hover:opacity-90"
+            style={{ boxShadow: '0 4px 16px rgba(0,0,0,0.2)' }}
+          >
+            {t('landing.hero.ctaSignup')}
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+      </section>
+    </AppPageShell>
+  );
+}

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -18,26 +18,11 @@ const mockGroups = [
   { id: 2, name: 'Group 2', video_count: 3 },
 ]
 
-vi.mock('@/lib/api', () => ({
-  apiClient: {
-    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
-    getVideos: vi.fn(),
-    getVideoGroups: vi.fn(),
-    getVideoUrl: vi.fn((url) => url),
-  },
-}))
-
-vi.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({
-    user: { id: 1, username: 'testuser' },
-    isLoading: false,
-  }),
-}))
-
-describe('HomePage', () => {
+describe('HomePage - authenticated', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockNavigate = useI18nNavigate() as ReturnType<typeof vi.fn>
+    ;(apiClient.getMeOrNull as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 1, username: 'testuser' })
     ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue(mockVideos)
     ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
   })
@@ -151,6 +136,7 @@ describe('HomePage', () => {
 describe('HomePage - Data Loading', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ;(apiClient.getMeOrNull as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 1, username: 'testuser' })
     ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue(mockVideos)
     ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
   })
@@ -164,6 +150,52 @@ describe('HomePage - Data Loading', () => {
     // Should still render the page (useHomePageData catches errors internally)
     await waitFor(() => {
       expect(screen.getByText('home.welcome.greeting {"username":"testuser"}')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('HomePage - unauthenticated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getMeOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+  })
+
+  it('should render landing page hero when user is not authenticated', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('landing.hero.title')
+    })
+  })
+
+  it('should render persona cards when user is not authenticated', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('landing.personas.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.educator.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.corporateTrainer.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.developer.title')).toBeInTheDocument()
+    })
+  })
+
+  it('should render use-case LP links when user is not authenticated', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      const educationLink = screen.getByText('landing.personas.educator.ctaLink')
+      expect(educationLink.closest('a')).toHaveAttribute('href', '/use-cases/education')
+
+      const trainingLink = screen.getByText('landing.personas.corporateTrainer.ctaLink')
+      expect(trainingLink.closest('a')).toHaveAttribute('href', '/use-cases/corporate-training')
+    })
+  })
+
+  it('should NOT render home dashboard when user is not authenticated', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/home\.welcome\.greeting/)).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/__tests__/LandingPage.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen } from '@testing-library/react'
+import LandingPage from '../LandingPage'
+
+describe('LandingPage', () => {
+  describe('Hero section', () => {
+    it('renders h1 with persona-focused copy', () => {
+      render(<LandingPage />)
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'landing.hero.title'
+      )
+    })
+
+    it('renders hero subtitle', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.hero.subtitle')).toBeInTheDocument()
+    })
+
+    it('renders signup CTA link pointing to /signup', () => {
+      render(<LandingPage />)
+      const signupLinks = screen.getAllByText('landing.hero.ctaSignup')
+      expect(signupLinks.length).toBeGreaterThan(0)
+      expect(signupLinks[0].closest('a')).toHaveAttribute('href', '/signup')
+    })
+
+    it('renders docs CTA link pointing to /docs', () => {
+      render(<LandingPage />)
+      const docsLink = screen.getByText('landing.hero.ctaDocs')
+      expect(docsLink.closest('a')).toHaveAttribute('href', '/docs')
+    })
+  })
+
+  describe('Personas section (こんな方に)', () => {
+    it('renders personas section title', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.personas.title')).toBeInTheDocument()
+    })
+
+    it('renders educator persona card', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.personas.educator.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.educator.description')).toBeInTheDocument()
+    })
+
+    it('renders educator CTA link pointing to /use-cases/education', () => {
+      render(<LandingPage />)
+      const link = screen.getByText('landing.personas.educator.ctaLink')
+      expect(link.closest('a')).toHaveAttribute('href', '/use-cases/education')
+    })
+
+    it('renders corporate trainer persona card', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.personas.corporateTrainer.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.corporateTrainer.description')).toBeInTheDocument()
+    })
+
+    it('renders corporate trainer CTA link pointing to /use-cases/corporate-training', () => {
+      render(<LandingPage />)
+      const link = screen.getByText('landing.personas.corporateTrainer.ctaLink')
+      expect(link.closest('a')).toHaveAttribute('href', '/use-cases/corporate-training')
+    })
+
+    it('renders developer persona card', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.personas.developer.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.developer.description')).toBeInTheDocument()
+    })
+
+    it('renders developer CTA link pointing to /docs', () => {
+      render(<LandingPage />)
+      const link = screen.getByText('landing.personas.developer.ctaLink')
+      expect(link.closest('a')).toHaveAttribute('href', '/docs')
+    })
+  })
+
+  describe('Features section', () => {
+    it('renders features section title', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.features.title')).toBeInTheDocument()
+    })
+
+    it('renders transcription feature', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.features.transcription.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.features.transcription.description')).toBeInTheDocument()
+    })
+
+    it('renders chat feature', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.features.chat.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.features.chat.description')).toBeInTheDocument()
+    })
+
+    it('renders API feature', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.features.api.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.features.api.description')).toBeInTheDocument()
+    })
+  })
+
+  describe('SEO', () => {
+    it('sets document.title on mount', () => {
+      render(<LandingPage />)
+      expect(document.title).toBe(
+        '動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ'
+      )
+    })
+
+    it('restores document.title on unmount', () => {
+      document.title = 'original title'
+      const { unmount } = render(<LandingPage />)
+      unmount()
+      expect(document.title).toBe('original title')
+    })
+
+    it('sets meta description on mount', () => {
+      const meta = document.createElement('meta')
+      meta.name = 'description'
+      meta.content = 'original description'
+      document.head.appendChild(meta)
+
+      render(<LandingPage />)
+      expect(
+        document.querySelector('meta[name="description"]')?.getAttribute('content')
+      ).toBe(
+        'VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修・セミナーを文字起こし。自然言語で即検索できます。無料で始められます。'
+      )
+
+      meta.remove()
+    })
+
+    it('restores meta description on unmount', () => {
+      const meta = document.createElement('meta')
+      meta.name = 'description'
+      meta.content = 'original description'
+      document.head.appendChild(meta)
+
+      const { unmount } = render(<LandingPage />)
+      unmount()
+      expect(
+        document.querySelector('meta[name="description"]')?.getAttribute('content')
+      ).toBe('original description')
+
+      meta.remove()
+    })
+
+    it('sets canonical href on mount', () => {
+      const link = document.createElement('link')
+      link.rel = 'canonical'
+      link.href = 'https://videoq.jp/old'
+      document.head.appendChild(link)
+
+      render(<LandingPage />)
+      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+        'https://videoq.jp/'
+      )
+
+      link.remove()
+    })
+
+    it('restores canonical href on unmount', () => {
+      const link = document.createElement('link')
+      link.rel = 'canonical'
+      link.href = 'https://videoq.jp/old'
+      document.head.appendChild(link)
+
+      const { unmount } = render(<LandingPage />)
+      unmount()
+      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+        'https://videoq.jp/old'
+      )
+
+      link.remove()
+    })
+  })
+})

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -180,6 +180,7 @@ vi.mock('@/lib/api', async (importOriginal) => {
   ...actual,
   apiClient: {
     getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
+    getMeOrNull: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     signup: vi.fn(() => Promise.resolve()),
     verifyEmail: vi.fn(() => Promise.resolve()),
     requestPasswordReset: vi.fn(() => Promise.resolve()),


### PR DESCRIPTION
## 概要
未ログイン時のトップページを、教育機関・企業研修・開発者それぞれに訴求するランディングページに刷新しました。
あわせて、未認証ユーザーには公開導線のみを表示するようナビゲーションを整理し、SEOメタ情報も教育・研修向けの訴求に更新しています。

## 変更内容
- 未ログイン時の `/` でダッシュボードではなく専用ランディングページを表示
- ヒーローコピーとCTAを教育・企業研修向けに最適化
- 「教育者・講師」「企業の研修担当者」「開発者」の3ペルソナ導線を追加
- `/use-cases/education` と `/use-cases/corporate-training` への遷移導線を追加
- 未認証時のグローバルナビから `Videos` `Groups` `Settings` `Billing` を非表示化
- 認証状態確認用に `getMeOrNull()` を追加し、未ログイン時も安全にトップ表示を切り替え
- `index.html` の title / description / OGP / Twitter card を教育・研修向けに更新
- ja/en 翻訳文言を更新
- LandingPage / HomePage / AppNav のテストを追加・更新

## 確認観点
- 未ログインで `/` にアクセスするとLPが表示される
- LPから `/signup` `/docs` 各ユースケースLPへ遷移できる
- ログイン時は従来どおりホームダッシュボードが表示される
- 未ログイン時は公開ナビのみ表示される
- ログイン時は `Videos` `Groups` `Settings` `Billing` が表示される
- トップページのSEOメタ情報が意図した内容になっている

## テスト
- `npm test -- --run src/pages/__tests__/HomePage.test.tsx src/pages/__tests__/LandingPage.test.tsx src/components/layout/__tests__/AppNav.test.tsx`
