### PR TITLE
フロントエンド SEO・ランディングページ改善 (develop → main)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VideoQ — あらゆるビデオを、最高の学びの体験へ</title>
-    <meta name="description" content="VideoQは動画をAIで検索・質問できる学習プラットフォームです。Whisperで自動文字起こし、RAGチャットで動画の内容に自然言語で質問できます。OpenAI互換API対応。" />
+    <title>動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ</title>
+    <meta name="description" content="VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修・セミナーを文字起こし。自然言語で即検索できます。無料で始められます。" />
     <link rel="canonical" href="https://videoq.jp/" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://videoq.jp/" />
-    <meta property="og:title" content="VideoQ — あらゆるビデオを、最高の学びの体験へ" />
-    <meta property="og:description" content="動画をアップロードしてAIで自動文字起こし。動画の内容にチャットで質問できる教育向けプラットフォーム。OpenAI互換API対応。" />
+    <meta property="og:title" content="動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ" />
+    <meta property="og:description" content="VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修・セミナーを文字起こし。自然言語で即検索できます。" />
     <meta property="og:site_name" content="VideoQ" />
     <meta property="og:locale" content="ja_JP" />
     <meta property="og:locale:alternate" content="en_US" />
@@ -18,8 +18,8 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="VideoQ — AI動画ナビゲーター" />
-    <meta name="twitter:description" content="動画をアップロードしてAIで自動文字起こし。動画の内容にチャットで質問できる教育向けプラットフォーム。" />
+    <meta name="twitter:title" content="動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ" />
+    <meta name="twitter:description" content="VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修を文字起こし。自然言語で即検索できます。" />
     <meta name="twitter:image" content="https://videoq.jp/og-image.png" />
     <link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/" />
     <link rel="alternate" hreflang="en" href="https://videoq.jp/" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,6 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.90.21",
-        "@tanstack/react-query-devtools": "^5.91.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -26,6 +25,7 @@
         "lucide-react": "^0.560.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-helmet-async": "^3.0.0",
         "react-hook-form": "^7.65.0",
         "react-i18next": "^15.2.2",
         "react-router-dom": "^7.1.3",
@@ -36,6 +36,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@tailwindcss/postcss": "^4.1.18",
+        "@tanstack/react-query-devtools": "^5.91.3",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
@@ -2793,6 +2794,7 @@
       "version": "5.93.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.93.0.tgz",
       "integrity": "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2819,6 +2821,7 @@
       "version": "5.91.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.3.tgz",
       "integrity": "sha512-nlahjMtd/J1h7IzOOfqeyDh5LNfG0eULwlltPEonYy0QL+nqrBB+nyzJfULV+moL7sZyxc2sHdNJki+vLA9BSA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-devtools": "5.93.0"
@@ -5235,6 +5238,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5366,7 +5378,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5777,6 +5788,18 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -6259,6 +6282,20 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
     },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.69.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.69.0.tgz",
@@ -6615,6 +6652,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "lucide-react": "^0.560.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-helmet-async": "^3.0.0",
     "react-hook-form": "^7.65.0",
     "react-i18next": "^15.2.2",
     "react-router-dom": "^7.1.3",
@@ -39,9 +40,9 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@tanstack/react-query-devtools": "^5.91.3",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/postcss": "^4.1.18",
+    "@tanstack/react-query-devtools": "^5.91.3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",

--- a/frontend/src/components/layout/AppFooter.tsx
+++ b/frontend/src/components/layout/AppFooter.tsx
@@ -17,9 +17,6 @@ export function AppFooter() {
           <span>VideoQ</span>
         </div>
         <div className="flex flex-wrap justify-center gap-x-6 gap-y-1">
-          <Link to="/use-cases/education" className="text-xs text-stone-500 hover:text-stone-700">
-            {t('useCases.education.footer.link')}
-          </Link>
           <Link to="/terms" className="text-xs text-stone-500 hover:text-stone-700">
             {t('legal.terms.title')}
           </Link>

--- a/frontend/src/components/layout/AppNav.tsx
+++ b/frontend/src/components/layout/AppNav.tsx
@@ -4,8 +4,9 @@ import { GraduationCap, LogOut, Menu, X, CreditCard, LogIn } from 'lucide-react'
 import { Link, useI18nNavigate } from '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '@/lib/api';
+import { apiClient, type User } from '@/lib/api';
 import { APP_CONTAINER_CLASS } from '@/components/layout/layoutTokens';
+import { queryKeys } from '@/lib/queryKeys';
 
 export type ActivePage = 'home' | 'videos' | 'groups' | 'docs' | 'settings' | 'billing';
 
@@ -14,11 +15,14 @@ interface AppNavProps {
   isPublic?: boolean;
 }
 
-export function AppNav({ activePage, isPublic = false }: AppNavProps) {
+export function AppNav({ activePage }: AppNavProps) {
   const { t } = useTranslation();
   const navigate = useI18nNavigate();
   const queryClient = useQueryClient();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const cachedUser = queryClient.getQueryData<User | null>(queryKeys.auth.me);
+  const isAuthenticated = !!cachedUser;
 
   const logoutMutation = useMutation({
     mutationFn: async () => await apiClient.logout(),
@@ -37,14 +41,16 @@ export function AppNav({ activePage, isPublic = false }: AppNavProps) {
     }
   };
 
-  const navLinks: { href: string; label: string; key: ActivePage; icon?: React.ReactNode }[] = [
+  const allNavLinks: { href: string; label: string; key: ActivePage; icon?: React.ReactNode; authRequired?: boolean }[] = [
     { href: '/', label: t('navigation.home'), key: 'home' },
-    { href: '/videos', label: t('navigation.videosNav'), key: 'videos' },
-    { href: '/videos/groups', label: t('navigation.groupsNav'), key: 'groups' },
+    { href: '/videos', label: t('navigation.videosNav'), key: 'videos', authRequired: true },
+    { href: '/videos/groups', label: t('navigation.groupsNav'), key: 'groups', authRequired: true },
     { href: '/docs', label: t('navigation.docs'), key: 'docs' },
-    { href: '/settings', label: t('navigation.settings'), key: 'settings' },
-    { href: '/billing', label: t('billing.nav'), key: 'billing', icon: <CreditCard className="w-3.5 h-3.5" /> },
+    { href: '/settings', label: t('navigation.settings'), key: 'settings', authRequired: true },
+    { href: '/billing', label: t('billing.nav'), key: 'billing', icon: <CreditCard className="w-3.5 h-3.5" />, authRequired: true },
   ];
+
+  const navLinks = isAuthenticated ? allNavLinks : allNavLinks.filter((l) => !l.authRequired);
 
   return (
     <nav className="fixed top-0 w-full z-50 bg-white/80 backdrop-blur-xl border-b border-stone-200/60">
@@ -76,7 +82,7 @@ export function AppNav({ activePage, isPublic = false }: AppNavProps) {
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
-          {isPublic ? (
+          {!isAuthenticated ? (
             <Link
               href="/login"
               className="hidden md:flex items-center gap-1.5 text-sm font-semibold text-stone-600 hover:text-[#00652c] transition-colors px-2"
@@ -126,7 +132,7 @@ export function AppNav({ activePage, isPublic = false }: AppNavProps) {
               </Link>
             ))}
             <div className="border-t border-stone-200/60 mt-2 pt-2">
-              {isPublic ? (
+              {!isAuthenticated ? (
                 <Link
                   href="/login"
                   onClick={() => setIsMobileMenuOpen(false)}

--- a/frontend/src/components/layout/__tests__/AppNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppNav.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/queryKeys'
+
+// Unmock AppNav so we can test the real implementation
+vi.unmock('@/components/layout/AppNav')
+
+const { AppNav } = await vi.importActual<typeof import('../AppNav')>('../AppNav')
+
+// Helper: seeds the React Query cache with a user before rendering
+function SeedUser({ user }: { user: unknown }) {
+  const qc = useQueryClient()
+  qc.setQueryData(queryKeys.auth.me, user)
+  return null
+}
+
+function renderWithUser(ui: React.ReactElement) {
+  return render(
+    <>
+      <SeedUser user={{ id: '1', username: 'testuser' }} />
+      {ui}
+    </>
+  )
+}
+
+describe('AppNav - no authenticated user (empty cache)', () => {
+  it('highlights home link when activePage="home"', () => {
+    render(<AppNav activePage="home" />)
+    const homeLink = screen.getByText('navigation.home')
+    expect(homeLink.closest('a')).toHaveClass('border-b-2')
+  })
+
+  it('hides videos nav link', () => {
+    render(<AppNav />)
+    expect(screen.queryByText('navigation.videosNav')).not.toBeInTheDocument()
+  })
+
+  it('hides groups nav link', () => {
+    render(<AppNav />)
+    expect(screen.queryByText('navigation.groupsNav')).not.toBeInTheDocument()
+  })
+
+  it('hides billing nav link', () => {
+    render(<AppNav />)
+    expect(screen.queryByText('billing.nav')).not.toBeInTheDocument()
+  })
+
+  it('hides settings nav link', () => {
+    render(<AppNav />)
+    expect(screen.queryByText('navigation.settings')).not.toBeInTheDocument()
+  })
+
+  it('shows docs nav link', () => {
+    render(<AppNav />)
+    expect(screen.getByText('navigation.docs')).toBeInTheDocument()
+  })
+
+  it('shows login button', () => {
+    render(<AppNav />)
+    expect(screen.getByText('auth.login.submit')).toBeInTheDocument()
+  })
+})
+
+describe('AppNav - authenticated user (cache populated)', () => {
+  it('shows videos nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('navigation.videosNav')).toBeInTheDocument()
+  })
+
+  it('shows groups nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('navigation.groupsNav')).toBeInTheDocument()
+  })
+
+  it('shows billing nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('billing.nav')).toBeInTheDocument()
+  })
+
+  it('shows settings nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('navigation.settings')).toBeInTheDocument()
+  })
+
+  it('shows docs nav link', () => {
+    renderWithUser(<AppNav />)
+    expect(screen.getByText('navigation.docs')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/seo/SeoHead.tsx
+++ b/frontend/src/components/seo/SeoHead.tsx
@@ -1,0 +1,54 @@
+import { Helmet } from 'react-helmet-async';
+import { defaultLocale, locales, type Locale } from '@/i18n/config';
+import { useLocale } from '@/lib/i18n';
+
+const BASE_URL = 'https://videoq.jp';
+
+function normalizePath(path: string): string {
+  if (!path) {
+    return '/';
+  }
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+function buildAbsoluteUrl(path: string, locale: Locale): string {
+  const normalizedPath = normalizePath(path);
+  const localizedPath = locale === defaultLocale ? normalizedPath : `/${locale}${normalizedPath}`;
+  return `${BASE_URL}${localizedPath === '/' ? '/' : localizedPath}`;
+}
+
+type SeoHeadProps = {
+  title: string;
+  description: string;
+  path: string;
+};
+
+export function SeoHead({ title, description, path }: SeoHeadProps) {
+  const locale = useLocale();
+  const canonicalUrl = buildAbsoluteUrl(path, locale);
+  const alternateUrls = Object.fromEntries(
+    locales.map((candidateLocale) => [candidateLocale, buildAbsoluteUrl(path, candidateLocale)]),
+  ) as Record<Locale, string>;
+
+  return (
+    <Helmet prioritizeSeoTags>
+      <html lang={locale} />
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonicalUrl} />
+      {locales.map((candidateLocale) => (
+        <link
+          key={candidateLocale}
+          rel="alternate"
+          hrefLang={candidateLocale}
+          href={alternateUrls[candidateLocale]}
+        />
+      ))}
+      <link rel="alternate" hrefLang="x-default" href={alternateUrls[defaultLocale]} />
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={canonicalUrl} />
+    </Helmet>
+  );
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1178,5 +1178,49 @@
         "link": "For Corporate Training"
       }
     }
+  },
+  "seo": {
+    "docs": {
+      "home": {
+        "title": "Developer Docs | VideoQ",
+        "description": "VideoQ API reference. Authentication, videos, chat, and OpenAI-compatible API docs."
+      },
+      "sections": {
+        "auth": {
+          "title": "Authentication API | VideoQ Developer Docs",
+          "description": "How to issue and use VideoQ API keys for server-to-server authentication."
+        },
+        "videos": {
+          "title": "Videos API | VideoQ Developer Docs",
+          "description": "Upload videos, monitor processing status, and manage video groups with the VideoQ API."
+        },
+        "chat": {
+          "title": "Chat API | VideoQ Developer Docs",
+          "description": "Run RAG chat against indexed video groups and retrieve analytics with the VideoQ API."
+        },
+        "openai": {
+          "title": "OpenAI-Compatible API | VideoQ Developer Docs",
+          "description": "Use the OpenAI SDK with VideoQ's OpenAI-compatible API for video RAG chat."
+        }
+      }
+    },
+    "terms": {
+      "title": "Terms of Service | VideoQ",
+      "description": "Read the VideoQ Terms of Service covering accounts, billing, acceptable use, and liability."
+    },
+    "privacy": {
+      "title": "Privacy Policy | VideoQ",
+      "description": "Read how VideoQ collects, uses, stores, and protects personal data and uploaded content."
+    },
+    "useCases": {
+      "education": {
+        "title": "Education Use Case | VideoQ",
+        "description": "VideoQ for education: transcribe lectures, let students search by natural language, and share class videos."
+      },
+      "corporateTraining": {
+        "title": "Corporate Training Use Case | VideoQ",
+        "description": "VideoQ for corporate training: transcribe training videos, power self-serve search, and integrate with internal tools."
+      }
+    }
   }
 }

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1015,9 +1015,9 @@
   },
   "landing": {
     "hero": {
-      "title": "Turn Any Video Into the Ultimate Learning Experience",
-      "subtitle": "AI-Powered Video Learning Platform",
-      "description": "Upload videos for automatic transcription via OpenAI Whisper, then ask questions about the content using RAG chat.",
+      "title": "Just Upload Your Video. AI Transcribes & Instantly Searches Your Lessons & Training",
+      "subtitle": "AI Video Learning Platform for Education & Corporate Training",
+      "description": "Transcribe your lectures, training videos, and seminars with AI — then search any moment with natural language. Built for educators and training teams.",
       "ctaSignup": "Get Started for Free",
       "ctaDocs": "Developer Docs"
     },
@@ -1034,6 +1034,24 @@
       "api": {
         "title": "OpenAI-Compatible API",
         "description": "Use any OpenAI client or SDK with your video library"
+      }
+    },
+    "personas": {
+      "title": "Who It's For",
+      "educator": {
+        "title": "Educators & Instructors",
+        "description": "Turn recorded lessons into self-study materials. Students find answers with AI chat on their own.",
+        "ctaLink": "For Educational Institutions"
+      },
+      "corporateTrainer": {
+        "title": "Corporate Training Teams",
+        "description": "Transform training videos into an AI knowledge base. New hires find exactly what they need, any time.",
+        "ctaLink": "For Corporate Training"
+      },
+      "developer": {
+        "title": "Developers",
+        "description": "Embed video AI into your product with an OpenAI-compatible API. Works with any existing SDK.",
+        "ctaLink": "View API Docs"
       }
     }
   },

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1178,5 +1178,49 @@
         "link": "企業研修向け"
       }
     }
+  },
+  "seo": {
+    "docs": {
+      "home": {
+        "title": "開発者ドキュメント | VideoQ",
+        "description": "VideoQ API リファレンス。認証、動画、チャット、OpenAI互換 API をまとめて確認できます。"
+      },
+      "sections": {
+        "auth": {
+          "title": "認証 API | VideoQ 開発者ドキュメント",
+          "description": "VideoQ の連携用 API キーを発行し、サーバー間認証で利用する方法。"
+        },
+        "videos": {
+          "title": "動画 API | VideoQ 開発者ドキュメント",
+          "description": "動画アップロード、処理状態の確認、動画グループ管理を行うための VideoQ API リファレンス。"
+        },
+        "chat": {
+          "title": "チャット API | VideoQ 開発者ドキュメント",
+          "description": "インデックス済み動画グループへの RAG チャット実行と分析取得のための VideoQ API リファレンス。"
+        },
+        "openai": {
+          "title": "OpenAI互換 API | VideoQ 開発者ドキュメント",
+          "description": "OpenAI SDK からそのまま使える VideoQ の OpenAI互換 API で動画 RAG チャットを実行できます。"
+        }
+      }
+    },
+    "terms": {
+      "title": "利用規約 | VideoQ",
+      "description": "VideoQ のアカウント、課金、禁止事項、免責事項などを定めた利用規約です。"
+    },
+    "privacy": {
+      "title": "プライバシーポリシー | VideoQ",
+      "description": "VideoQ が個人情報やアップロード動画をどのように収集・利用・保護するかを説明します。"
+    },
+    "useCases": {
+      "education": {
+        "title": "教育向け | VideoQ",
+        "description": "教育機関向け VideoQ。授業・講義動画を文字起こしし、学生が自然言語で検索・質問できます。"
+      },
+      "corporateTraining": {
+        "title": "企業研修向け | VideoQ",
+        "description": "企業研修向け VideoQ。社内研修動画を文字起こしし、社員が必要な場面を検索・質問できます。"
+      }
+    }
   }
 }

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1015,9 +1015,9 @@
   },
   "landing": {
     "hero": {
-      "title": "あらゆるビデオを、最高の学びの体験へ",
-      "subtitle": "AI動画学習プラットフォーム",
-      "description": "動画をアップロードしてOpenAI Whisperで自動文字起こし。RAGチャットで動画の内容に自然言語で質問できます。",
+      "title": "動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索",
+      "subtitle": "教育・企業研修向けAI動画学習プラットフォーム",
+      "description": "授業・研修・セミナーの動画をAIで文字起こし→自然言語で即検索。教育者・研修担当者が動画を最大活用できます。",
       "ctaSignup": "無料で始める",
       "ctaDocs": "開発者ドキュメント"
     },
@@ -1034,6 +1034,24 @@
       "api": {
         "title": "OpenAI互換API",
         "description": "既存のOpenAIクライアントやSDKでビデオライブラリを操作できます"
+      }
+    },
+    "personas": {
+      "title": "こんな方に",
+      "educator": {
+        "title": "教育者・講師",
+        "description": "授業録画を学生が自習できる教材に。AIチャットで学生が自力で答えを探せます。",
+        "ctaLink": "教育機関の方はこちら"
+      },
+      "corporateTrainer": {
+        "title": "企業の研修担当者",
+        "description": "研修動画をAIナレッジベースに。新入社員が必要な情報をいつでも自分で検索できます。",
+        "ctaLink": "企業研修の方はこちら"
+      },
+      "developer": {
+        "title": "開発者",
+        "description": "OpenAI互換APIで自社サービスに動画AIを組み込む。既存のSDKでそのまま使えます。",
+        "ctaLink": "APIドキュメントを見る"
       }
     }
   },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -632,6 +632,18 @@ class ApiClient {
     return this.request<User>('/auth/me');
   }
 
+  async getMeOrNull(): Promise<User | null> {
+    try {
+      const url = this.buildUrl('/auth/me');
+      const headers = this.buildHeaders();
+      const response = await fetch(url, { credentials: 'include', headers });
+      if (!response.ok) return null;
+      return await this.parseJsonResponse<User>(response);
+    } catch {
+      return null;
+    }
+  }
+
   async getIntegrationApiKeys(): Promise<IntegrationApiKey[]> {
     return this.request<IntegrationApiKey[]>('/auth/api-keys/');
   }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { I18nextProvider } from 'react-i18next'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { HelmetProvider } from 'react-helmet-async'
 import i18n from './i18n/config'
 import App from './App.tsx'
 import { appQueryClient } from './lib/queryClient'
@@ -13,10 +14,12 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
       <I18nextProvider i18n={i18n}>
-        <QueryClientProvider client={appQueryClient}>
-          <App />
-          {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
-        </QueryClientProvider>
+        <HelmetProvider>
+          <QueryClientProvider client={appQueryClient}>
+            <App />
+            {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+          </QueryClientProvider>
+        </HelmetProvider>
       </I18nextProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/frontend/src/pages/DeveloperDocsPage.tsx
+++ b/frontend/src/pages/DeveloperDocsPage.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from '@/lib/i18n';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { Lock, Video, MessageCircle, Sparkles, ArrowRight, FileCode2, KeyRound } from 'lucide-react';
 
 const sectionIds = ['auth', 'videos', 'chat', 'openai'] as const;
@@ -26,6 +27,11 @@ export default function DeveloperDocsPage() {
 
   return (
     <AppPageShell activePage="docs">
+      <SeoHead
+        title={t('seo.docs.home.title')}
+        description={t('seo.docs.home.description')}
+        path="/docs"
+      />
       <AppPageHeader
         title={t('docs.home.title')}
         description={t('docs.home.subtitle')}

--- a/frontend/src/pages/DeveloperDocsSectionPage.tsx
+++ b/frontend/src/pages/DeveloperDocsSectionPage.tsx
@@ -5,6 +5,7 @@ import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
 import { ApiEndpointList } from '@/components/docs/ApiEndpointList';
 import { OpenAiSdkExampleList } from '@/components/docs/OpenAiSdkExampleList';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { CheckCircle, ClipboardCheck, Braces } from 'lucide-react';
 
 const sectionIds = ['auth', 'videos', 'chat', 'openai'] as const;
@@ -31,6 +32,11 @@ export default function DeveloperDocsSectionPage() {
 
   return (
     <AppPageShell activePage="docs">
+      <SeoHead
+        title={t(`seo.docs.sections.${section}.title`)}
+        description={t(`seo.docs.sections.${section}.description`)}
+        path={`/docs/${section}`}
+      />
       <nav className="flex items-center gap-2 text-sm font-medium text-[#6f7a6e] mb-6">
         <Link href="/docs" className="hover:text-[#00652c] transition-colors">
           ← {t('docs.backToHome')}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,9 +1,8 @@
 import { useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useI18nNavigate } from '@/lib/i18n';
-import { useAuth } from '@/hooks/useAuth';
-import { type User } from '@/lib/api';
+import { apiClient, type User } from '@/lib/api';
 import { useHomePageData } from '@/hooks/useHomePageData';
 import { useVideoStats } from '@/hooks/useVideoStats';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
@@ -15,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 import {
   Upload, Film, Users, ArrowRight, Lightbulb,
 } from 'lucide-react';
+import LandingPage from '@/pages/LandingPage';
 
 function ActionCard({ icon, iconBg, title, description, linkLabel, linkColor, onClick }: {
   icon: ReactNode;
@@ -46,11 +46,17 @@ export default function HomePage() {
   const navigate = useI18nNavigate();
   const queryClient = useQueryClient();
   const { t } = useTranslation();
-  const { user, isLoading } = useAuth();
+
+  const { data: user, isLoading } = useQuery<User | null>({
+    queryKey: queryKeys.auth.me,
+    queryFn: () => apiClient.getMeOrNull(),
+    retry: false,
+  });
+
   const cachedUser = queryClient.getQueryData<User | null>(queryKeys.auth.me) ?? null;
   const currentUser = user ?? cachedUser;
 
-  const { videos, groups, isLoading: isLoadingData } = useHomePageData({ userId: user?.id });
+  const { videos, groups, isLoading: isLoadingData } = useHomePageData({ userId: currentUser?.id });
   const videoStats = useVideoStats(videos);
 
   const recentVideos = useMemo(
@@ -61,7 +67,19 @@ export default function HomePage() {
     [videos],
   );
 
-  if (isLoading || !user || isLoadingData) {
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#f8faf5]">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (!currentUser) {
+    return <LandingPage />;
+  }
+
+  if (isLoadingData) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-[#f8faf5]">
         <LoadingSpinner />

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,232 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  GraduationCap,
+  Building2,
+  Code2,
+  Mic,
+  MessageSquare,
+  Plug,
+  ArrowRight,
+} from 'lucide-react';
+import { AppPageShell } from '@/components/layout/AppPageShell';
+import { Link } from '@/lib/i18n';
+
+const BASE_URL = 'https://videoq.jp';
+const CONTAINER = 'max-w-screen-xl mx-auto px-6 lg:px-8';
+
+export default function LandingPage() {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const prevTitle = document.title;
+    document.title = '動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ';
+
+    const metaDesc = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+    const prevDesc = metaDesc?.getAttribute('content') ?? '';
+    metaDesc?.setAttribute(
+      'content',
+      'VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修・セミナーを文字起こし。自然言語で即検索できます。無料で始められます。',
+    );
+
+    const canonicalEl = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    const prevCanonical = canonicalEl?.getAttribute('href') ?? '';
+    canonicalEl?.setAttribute('href', `${BASE_URL}/`);
+
+    return () => {
+      document.title = prevTitle;
+      metaDesc?.setAttribute('content', prevDesc);
+      canonicalEl?.setAttribute('href', prevCanonical);
+    };
+  }, []);
+
+  return (
+    <AppPageShell isPublic activePage="home" contentClassName="w-full px-0">
+      {/* ── Hero ── */}
+      <section className="w-full bg-[#f8faf5] py-16 lg:py-28">
+        <div className={`${CONTAINER} text-center`}>
+          <span
+            className="inline-block mb-4 px-3 py-1 rounded-full text-xs font-semibold tracking-widest uppercase"
+            style={{ background: '#dcfce7', color: '#00652c' }}
+          >
+            AI Video Platform
+          </span>
+          <h1 className="text-3xl lg:text-5xl font-extrabold text-[#191c19] leading-tight mb-5 max-w-3xl mx-auto">
+            {t('landing.hero.title')}
+          </h1>
+          <p className="text-base lg:text-lg text-[#3f493f] mb-4 max-w-2xl mx-auto leading-relaxed">
+            {t('landing.hero.subtitle')}
+          </p>
+          <p className="text-sm text-[#6f7a6e] mb-10 max-w-xl mx-auto leading-relaxed">
+            {t('landing.hero.description')}
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              to="/signup"
+              className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl font-semibold text-white text-sm transition-opacity hover:opacity-90"
+              style={{
+                background: 'linear-gradient(145deg, #00652c 0%, #15803d 100%)',
+                boxShadow: '0 4px 16px rgba(0,101,44,0.25)',
+              }}
+            >
+              {t('landing.hero.ctaSignup')}
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+            <Link
+              to="/docs"
+              className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl font-semibold text-[#00652c] text-sm border-2 border-[#00652c] bg-transparent hover:bg-[#f0fdf4] transition-colors"
+            >
+              {t('landing.hero.ctaDocs')}
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Personas (こんな方に) ── */}
+      <section className="w-full py-16 lg:py-20 bg-white">
+        <div className={CONTAINER}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-[#191c19] text-center mb-12">
+            {t('landing.personas.title')}
+          </h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {/* Educator */}
+            <div
+              className="rounded-2xl bg-[#f8faf5] p-7 flex flex-col"
+              style={{ boxShadow: '0 8px 24px rgba(25,28,25,0.06)' }}
+            >
+              <div
+                className="w-12 h-12 rounded-xl flex items-center justify-center mb-5"
+                style={{ background: '#dcfce7' }}
+              >
+                <GraduationCap className="w-6 h-6 text-[#00652c]" />
+              </div>
+              <h3 className="font-bold text-lg text-[#191c19] mb-3">
+                {t('landing.personas.educator.title')}
+              </h3>
+              <p className="text-sm text-[#6f7a6e] leading-relaxed mb-6 flex-1">
+                {t('landing.personas.educator.description')}
+              </p>
+              <Link
+                to="/use-cases/education"
+                className="inline-flex items-center gap-1 text-sm font-semibold text-[#00652c] hover:underline"
+              >
+                {t('landing.personas.educator.ctaLink')}
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+
+            {/* Corporate Trainer */}
+            <div
+              className="rounded-2xl bg-[#f8faf5] p-7 flex flex-col"
+              style={{ boxShadow: '0 8px 24px rgba(25,28,25,0.06)' }}
+            >
+              <div
+                className="w-12 h-12 rounded-xl flex items-center justify-center mb-5"
+                style={{ background: '#e0f2fe' }}
+              >
+                <Building2 className="w-6 h-6 text-[#005b8c]" />
+              </div>
+              <h3 className="font-bold text-lg text-[#191c19] mb-3">
+                {t('landing.personas.corporateTrainer.title')}
+              </h3>
+              <p className="text-sm text-[#6f7a6e] leading-relaxed mb-6 flex-1">
+                {t('landing.personas.corporateTrainer.description')}
+              </p>
+              <Link
+                to="/use-cases/corporate-training"
+                className="inline-flex items-center gap-1 text-sm font-semibold text-[#005b8c] hover:underline"
+              >
+                {t('landing.personas.corporateTrainer.ctaLink')}
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+
+            {/* Developer */}
+            <div
+              className="rounded-2xl bg-[#f8faf5] p-7 flex flex-col"
+              style={{ boxShadow: '0 8px 24px rgba(25,28,25,0.06)' }}
+            >
+              <div
+                className="w-12 h-12 rounded-xl flex items-center justify-center mb-5"
+                style={{ background: '#fef9c3' }}
+              >
+                <Code2 className="w-6 h-6 text-[#854d0e]" />
+              </div>
+              <h3 className="font-bold text-lg text-[#191c19] mb-3">
+                {t('landing.personas.developer.title')}
+              </h3>
+              <p className="text-sm text-[#6f7a6e] leading-relaxed mb-6 flex-1">
+                {t('landing.personas.developer.description')}
+              </p>
+              <Link
+                to="/docs"
+                className="inline-flex items-center gap-1 text-sm font-semibold text-[#854d0e] hover:underline"
+              >
+                {t('landing.personas.developer.ctaLink')}
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Features ── */}
+      <section className="w-full py-16 lg:py-20 bg-[#f8faf5]">
+        <div className={CONTAINER}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-[#191c19] text-center mb-12">
+            {t('landing.features.title')}
+          </h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {(
+              [
+                { key: 'transcription', Icon: Mic },
+                { key: 'chat', Icon: MessageSquare },
+                { key: 'api', Icon: Plug },
+              ] as const
+            ).map(({ key, Icon }) => (
+              <div
+                key={key}
+                className="rounded-2xl bg-white p-6"
+                style={{ boxShadow: '0 4px 16px rgba(25,28,25,0.04)' }}
+              >
+                <div
+                  className="w-10 h-10 rounded-xl flex items-center justify-center mb-4"
+                  style={{ background: '#00652c' }}
+                >
+                  <Icon className="w-5 h-5 text-white" />
+                </div>
+                <h3 className="font-bold text-[#191c19] mb-2">
+                  {t(`landing.features.${key}.title`)}
+                </h3>
+                <p className="text-sm text-[#6f7a6e] leading-relaxed">
+                  {t(`landing.features.${key}.description`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Bottom CTA ── */}
+      <section
+        className="w-full py-16 lg:py-20"
+        style={{ background: 'linear-gradient(145deg, #00652c 0%, #005b8c 100%)' }}
+      >
+        <div className={`${CONTAINER} text-center`}>
+          <h2 className="text-2xl lg:text-3xl font-extrabold text-white mb-3">
+            {t('landing.hero.ctaSignup')}
+          </h2>
+          <p className="text-white/80 text-sm mb-8">{t('landing.hero.description')}</p>
+          <Link
+            to="/signup"
+            className="inline-flex items-center gap-2 px-8 py-4 rounded-xl font-bold text-[#00652c] bg-white text-sm transition-opacity hover:opacity-90"
+            style={{ boxShadow: '0 4px 16px rgba(0,0,0,0.2)' }}
+          >
+            {t('landing.hero.ctaSignup')}
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+      </section>
+    </AppPageShell>
+  );
+}

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { operatorConfig } from '@/lib/operatorConfig';
 
 const sections = [
@@ -18,6 +19,11 @@ export default function PrivacyPolicyPage() {
 
   return (
     <AppPageShell isPublic>
+      <SeoHead
+        title={t('seo.privacy.title')}
+        description={t('seo.privacy.description')}
+        path="/privacy"
+      />
       <AppPageHeader title={t('legal.privacy.title')} />
       <div className="space-y-8 rounded-xl border border-stone-200 bg-white p-6 sm:p-8">
         {sections.map((section) => (

--- a/frontend/src/pages/TermsPage.tsx
+++ b/frontend/src/pages/TermsPage.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { operatorConfig } from '@/lib/operatorConfig';
 
 const sections = [
@@ -22,6 +23,11 @@ export default function TermsPage() {
 
   return (
     <AppPageShell isPublic>
+      <SeoHead
+        title={t('seo.terms.title')}
+        description={t('seo.terms.description')}
+        path="/terms"
+      />
       <AppPageHeader title={t('legal.terms.title')} />
       <div className="space-y-8 rounded-xl border border-stone-200 bg-white p-6 sm:p-8">
         {sections.map((section) => (

--- a/frontend/src/pages/UseCaseCorporateTrainingPage.tsx
+++ b/frontend/src/pages/UseCaseCorporateTrainingPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Helmet } from 'react-helmet-async';
 import {
   Archive,
   ShieldCheck,
@@ -11,11 +11,8 @@ import {
   CheckCircle,
 } from 'lucide-react';
 import { AppPageShell } from '@/components/layout/AppPageShell';
-import { Link, useLocale } from '@/lib/i18n';
-
-const BASE_URL = 'https://videoq.jp';
-const EN_URL = `${BASE_URL}/use-cases/corporate-training`;
-const JA_URL = `${BASE_URL}/ja/use-cases/corporate-training`;
+import { Link } from '@/lib/i18n';
+import { SeoHead } from '@/components/seo/SeoHead';
 
 const CONTAINER = 'max-w-screen-xl mx-auto px-6 lg:px-8';
 
@@ -52,72 +49,19 @@ const FAQ_SCHEMA = {
 
 export default function UseCaseCorporateTrainingPage() {
   const { t } = useTranslation();
-  const locale = useLocale();
-  const currentUrl = locale === 'ja' ? JA_URL : EN_URL;
-
-  useEffect(() => {
-    // title
-    const prevTitle = document.title;
-    document.title = '社内研修動画をAI検索 | VideoQ 企業研修向け';
-
-    // meta description
-    const metaDesc = document.querySelector<HTMLMetaElement>('meta[name="description"]');
-    const prevDesc = metaDesc?.getAttribute('content') ?? '';
-    metaDesc?.setAttribute(
-      'content',
-      'VideoQ は企業研修向け AI 動画プラットフォームです。社内研修動画を Whisper で文字起こしし、社員が AI チャットで必要な場面を即検索。新入社員研修・コンプライアンス・業務マニュアルに対応。',
-    );
-
-    // canonical
-    const canonicalEl = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
-    const prevCanonical = canonicalEl?.getAttribute('href') ?? '';
-    canonicalEl?.setAttribute('href', currentUrl);
-
-    // hreflang alternates
-    const hreflangEn = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="en"]');
-    const hreflangJa = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="ja"]');
-    const hreflangXDefault = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="x-default"]');
-    const prevHreflangEn = hreflangEn?.getAttribute('href') ?? '';
-    const prevHreflangJa = hreflangJa?.getAttribute('href') ?? '';
-    const prevHreflangXDefault = hreflangXDefault?.getAttribute('href') ?? '';
-    hreflangEn?.setAttribute('href', EN_URL);
-    hreflangJa?.setAttribute('href', JA_URL);
-    hreflangXDefault?.setAttribute('href', EN_URL);
-
-    // OGP
-    const ogTitle = document.querySelector<HTMLMetaElement>('meta[property="og:title"]');
-    const ogDesc = document.querySelector<HTMLMetaElement>('meta[property="og:description"]');
-    const ogUrl = document.querySelector<HTMLMetaElement>('meta[property="og:url"]');
-    const prevOgTitle = ogTitle?.getAttribute('content') ?? '';
-    const prevOgDesc = ogDesc?.getAttribute('content') ?? '';
-    const prevOgUrl = ogUrl?.getAttribute('content') ?? '';
-    ogTitle?.setAttribute('content', '社内研修動画をAI検索 | VideoQ 企業研修向け');
-    ogDesc?.setAttribute('content', 'VideoQ は企業研修向け AI 動画プラットフォームです。社内研修動画を Whisper で文字起こしし、社員が AI チャットで必要な場面を即検索できます。');
-    ogUrl?.setAttribute('content', currentUrl);
-
-    // FAQPage schema
-    const script = document.createElement('script');
-    script.type = 'application/ld+json';
-    script.id = 'faq-schema-corporate-training';
-    script.textContent = JSON.stringify(FAQ_SCHEMA);
-    document.head.appendChild(script);
-
-    return () => {
-      document.title = prevTitle;
-      metaDesc?.setAttribute('content', prevDesc);
-      canonicalEl?.setAttribute('href', prevCanonical);
-      hreflangEn?.setAttribute('href', prevHreflangEn);
-      hreflangJa?.setAttribute('href', prevHreflangJa);
-      hreflangXDefault?.setAttribute('href', prevHreflangXDefault);
-      ogTitle?.setAttribute('content', prevOgTitle);
-      ogDesc?.setAttribute('content', prevOgDesc);
-      ogUrl?.setAttribute('content', prevOgUrl);
-      document.getElementById('faq-schema-corporate-training')?.remove();
-    };
-  }, [currentUrl]);
 
   return (
-    <AppPageShell isPublic contentClassName="w-full px-0">
+    <AppPageShell activePage="home" isPublic contentClassName="w-full px-0">
+      <SeoHead
+        title={t('seo.useCases.corporateTraining.title')}
+        description={t('seo.useCases.corporateTraining.description')}
+        path="/use-cases/corporate-training"
+      />
+      <Helmet>
+        <script id="faq-schema-corporate-training" type="application/ld+json">
+          {JSON.stringify(FAQ_SCHEMA)}
+        </script>
+      </Helmet>
       {/* ── Hero ── */}
       <section className="w-full bg-[#f8faf5] py-16 lg:py-24">
         <div className={`${CONTAINER} text-center`}>

--- a/frontend/src/pages/UseCaseEducationPage.tsx
+++ b/frontend/src/pages/UseCaseEducationPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Helmet } from 'react-helmet-async';
 import {
   BookOpen,
   School,
@@ -11,11 +11,8 @@ import {
   CheckCircle,
 } from 'lucide-react';
 import { AppPageShell } from '@/components/layout/AppPageShell';
-import { Link, useLocale } from '@/lib/i18n';
-
-const BASE_URL = 'https://videoq.jp';
-const EN_URL = `${BASE_URL}/use-cases/education`;
-const JA_URL = `${BASE_URL}/ja/use-cases/education`;
+import { Link } from '@/lib/i18n';
+import { SeoHead } from '@/components/seo/SeoHead';
 
 const CONTAINER = 'max-w-screen-xl mx-auto px-6 lg:px-8';
 
@@ -52,72 +49,19 @@ const FAQ_SCHEMA = {
 
 export default function UseCaseEducationPage() {
   const { t } = useTranslation();
-  const locale = useLocale();
-  const currentUrl = locale === 'ja' ? JA_URL : EN_URL;
-
-  useEffect(() => {
-    // title
-    const prevTitle = document.title;
-    document.title = '授業・講義動画を AI 検索 | VideoQ 教育向け';
-
-    // meta description
-    const metaDesc = document.querySelector<HTMLMetaElement>('meta[name="description"]');
-    const prevDesc = metaDesc?.getAttribute('content') ?? '';
-    metaDesc?.setAttribute(
-      'content',
-      'VideoQ は教育機関向けの AI 動画学習プラットフォームです。授業・講義動画を Whisper で文字起こしし、学生が自然言語で質問・検索できます。大学・高校・反転授業に対応。無料で始められます。',
-    );
-
-    // canonical
-    const canonicalEl = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
-    const prevCanonical = canonicalEl?.getAttribute('href') ?? '';
-    canonicalEl?.setAttribute('href', currentUrl);
-
-    // hreflang alternates
-    const hreflangEn = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="en"]');
-    const hreflangJa = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="ja"]');
-    const hreflangXDefault = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="x-default"]');
-    const prevHreflangEn = hreflangEn?.getAttribute('href') ?? '';
-    const prevHreflangJa = hreflangJa?.getAttribute('href') ?? '';
-    const prevHreflangXDefault = hreflangXDefault?.getAttribute('href') ?? '';
-    hreflangEn?.setAttribute('href', EN_URL);
-    hreflangJa?.setAttribute('href', JA_URL);
-    hreflangXDefault?.setAttribute('href', EN_URL);
-
-    // OGP
-    const ogTitle = document.querySelector<HTMLMetaElement>('meta[property="og:title"]');
-    const ogDesc = document.querySelector<HTMLMetaElement>('meta[property="og:description"]');
-    const ogUrl = document.querySelector<HTMLMetaElement>('meta[property="og:url"]');
-    const prevOgTitle = ogTitle?.getAttribute('content') ?? '';
-    const prevOgDesc = ogDesc?.getAttribute('content') ?? '';
-    const prevOgUrl = ogUrl?.getAttribute('content') ?? '';
-    ogTitle?.setAttribute('content', '授業・講義動画を AI 検索 | VideoQ 教育向け');
-    ogDesc?.setAttribute('content', 'VideoQ は教育機関向けの AI 動画学習プラットフォームです。授業・講義動画を Whisper で文字起こしし、学生が自然言語で質問・検索できます。');
-    ogUrl?.setAttribute('content', currentUrl);
-
-    // FAQPage schema
-    const script = document.createElement('script');
-    script.type = 'application/ld+json';
-    script.id = 'faq-schema-education';
-    script.textContent = JSON.stringify(FAQ_SCHEMA);
-    document.head.appendChild(script);
-
-    return () => {
-      document.title = prevTitle;
-      metaDesc?.setAttribute('content', prevDesc);
-      canonicalEl?.setAttribute('href', prevCanonical);
-      hreflangEn?.setAttribute('href', prevHreflangEn);
-      hreflangJa?.setAttribute('href', prevHreflangJa);
-      hreflangXDefault?.setAttribute('href', prevHreflangXDefault);
-      ogTitle?.setAttribute('content', prevOgTitle);
-      ogDesc?.setAttribute('content', prevOgDesc);
-      ogUrl?.setAttribute('content', prevOgUrl);
-      document.getElementById('faq-schema-education')?.remove();
-    };
-  }, [currentUrl]);
 
   return (
-    <AppPageShell isPublic contentClassName="w-full px-0">
+    <AppPageShell activePage="home" isPublic contentClassName="w-full px-0">
+      <SeoHead
+        title={t('seo.useCases.education.title')}
+        description={t('seo.useCases.education.description')}
+        path="/use-cases/education"
+      />
+      <Helmet>
+        <script id="faq-schema-education" type="application/ld+json">
+          {JSON.stringify(FAQ_SCHEMA)}
+        </script>
+      </Helmet>
       {/* ── Hero ── */}
       <section className="w-full bg-[#f8faf5] py-16 lg:py-24">
         <div className={`${CONTAINER} text-center`}>

--- a/frontend/src/pages/__tests__/DeveloperDocsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DeveloperDocsPage.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react'
+import DeveloperDocsPage from '../DeveloperDocsPage'
+
+describe('DeveloperDocsPage SEO', () => {
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
+  it('sets english title, description, canonical, and og tags', () => {
+    globalThis.__setMockLanguage('en')
+    render(<DeveloperDocsPage />)
+
+    expect(document.title).toBe('Developer Docs | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ API reference. Authentication, videos, chat, and OpenAI-compatible API docs.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/docs'
+    )
+    expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(
+      'Developer Docs | VideoQ'
+    )
+    expect(document.querySelector('meta[property="og:description"]')?.getAttribute('content')).toBe(
+      'VideoQ API reference. Authentication, videos, chat, and OpenAI-compatible API docs.'
+    )
+    expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content')).toBe(
+      'https://videoq.jp/docs'
+    )
+  })
+
+  it('switches title and canonical for japanese locale', () => {
+    globalThis.__setMockLanguage('ja')
+    render(<DeveloperDocsPage />)
+
+    expect(document.title).toBe('開発者ドキュメント | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ API リファレンス。認証、動画、チャット、OpenAI互換 API をまとめて確認できます。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/docs'
+    )
+    expect(document.querySelector('link[rel="alternate"][hreflang="en"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/docs'
+    )
+    expect(document.querySelector('link[rel="alternate"][hreflang="ja"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/docs'
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/DeveloperDocsSectionPage.test.tsx
+++ b/frontend/src/pages/__tests__/DeveloperDocsSectionPage.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+import DeveloperDocsSectionPage from '../DeveloperDocsSectionPage'
+
+vi.mock('@/components/docs/ApiEndpointList', () => ({
+  ApiEndpointList: () => null,
+}))
+
+vi.mock('@/components/docs/OpenAiSdkExampleList', () => ({
+  OpenAiSdkExampleList: () => null,
+}))
+
+vi.mock('react-router-dom', () => {
+  return {
+    Navigate: () => null,
+    useParams: () => ({ section: 'auth' }),
+    Link: ({ children, to, ...props }: { children?: React.ReactNode; to?: string } & Record<string, unknown>) =>
+      React.createElement('a', { href: to ?? '', ...props }, children),
+  }
+})
+
+describe('DeveloperDocsSectionPage SEO', () => {
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
+  it('sets english metadata for the auth section', () => {
+    globalThis.__setMockLanguage('en')
+    render(<DeveloperDocsSectionPage />)
+
+    expect(document.title).toBe('Authentication API | VideoQ Developer Docs')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'How to issue and use VideoQ API keys for server-to-server authentication.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/docs/auth'
+    )
+    expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content')).toBe(
+      'https://videoq.jp/docs/auth'
+    )
+  })
+
+  it('switches metadata for japanese locale', () => {
+    globalThis.__setMockLanguage('ja')
+    render(<DeveloperDocsSectionPage />)
+
+    expect(document.title).toBe('認証 API | VideoQ 開発者ドキュメント')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ の連携用 API キーを発行し、サーバー間認証で利用する方法。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/docs/auth'
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -18,26 +18,11 @@ const mockGroups = [
   { id: 2, name: 'Group 2', video_count: 3 },
 ]
 
-vi.mock('@/lib/api', () => ({
-  apiClient: {
-    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
-    getVideos: vi.fn(),
-    getVideoGroups: vi.fn(),
-    getVideoUrl: vi.fn((url) => url),
-  },
-}))
-
-vi.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({
-    user: { id: 1, username: 'testuser' },
-    isLoading: false,
-  }),
-}))
-
-describe('HomePage', () => {
+describe('HomePage - authenticated', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockNavigate = useI18nNavigate() as ReturnType<typeof vi.fn>
+    ;(apiClient.getMeOrNull as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 1, username: 'testuser' })
     ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue(mockVideos)
     ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
   })
@@ -151,6 +136,7 @@ describe('HomePage', () => {
 describe('HomePage - Data Loading', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    ;(apiClient.getMeOrNull as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 1, username: 'testuser' })
     ;(apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue(mockVideos)
     ;(apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
   })
@@ -164,6 +150,52 @@ describe('HomePage - Data Loading', () => {
     // Should still render the page (useHomePageData catches errors internally)
     await waitFor(() => {
       expect(screen.getByText('home.welcome.greeting {"username":"testuser"}')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('HomePage - unauthenticated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getMeOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+  })
+
+  it('should render landing page hero when user is not authenticated', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('landing.hero.title')
+    })
+  })
+
+  it('should render persona cards when user is not authenticated', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('landing.personas.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.educator.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.corporateTrainer.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.developer.title')).toBeInTheDocument()
+    })
+  })
+
+  it('should render use-case LP links when user is not authenticated', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      const educationLink = screen.getByText('landing.personas.educator.ctaLink')
+      expect(educationLink.closest('a')).toHaveAttribute('href', '/use-cases/education')
+
+      const trainingLink = screen.getByText('landing.personas.corporateTrainer.ctaLink')
+      expect(trainingLink.closest('a')).toHaveAttribute('href', '/use-cases/corporate-training')
+    })
+  })
+
+  it('should NOT render home dashboard when user is not authenticated', async () => {
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/home\.welcome\.greeting/)).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/__tests__/LandingPage.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen } from '@testing-library/react'
+import LandingPage from '../LandingPage'
+
+describe('LandingPage', () => {
+  describe('Hero section', () => {
+    it('renders h1 with persona-focused copy', () => {
+      render(<LandingPage />)
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'landing.hero.title'
+      )
+    })
+
+    it('renders hero subtitle', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.hero.subtitle')).toBeInTheDocument()
+    })
+
+    it('renders signup CTA link pointing to /signup', () => {
+      render(<LandingPage />)
+      const signupLinks = screen.getAllByText('landing.hero.ctaSignup')
+      expect(signupLinks.length).toBeGreaterThan(0)
+      expect(signupLinks[0].closest('a')).toHaveAttribute('href', '/signup')
+    })
+
+    it('renders docs CTA link pointing to /docs', () => {
+      render(<LandingPage />)
+      const docsLink = screen.getByText('landing.hero.ctaDocs')
+      expect(docsLink.closest('a')).toHaveAttribute('href', '/docs')
+    })
+  })
+
+  describe('Personas section (こんな方に)', () => {
+    it('renders personas section title', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.personas.title')).toBeInTheDocument()
+    })
+
+    it('renders educator persona card', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.personas.educator.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.educator.description')).toBeInTheDocument()
+    })
+
+    it('renders educator CTA link pointing to /use-cases/education', () => {
+      render(<LandingPage />)
+      const link = screen.getByText('landing.personas.educator.ctaLink')
+      expect(link.closest('a')).toHaveAttribute('href', '/use-cases/education')
+    })
+
+    it('renders corporate trainer persona card', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.personas.corporateTrainer.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.corporateTrainer.description')).toBeInTheDocument()
+    })
+
+    it('renders corporate trainer CTA link pointing to /use-cases/corporate-training', () => {
+      render(<LandingPage />)
+      const link = screen.getByText('landing.personas.corporateTrainer.ctaLink')
+      expect(link.closest('a')).toHaveAttribute('href', '/use-cases/corporate-training')
+    })
+
+    it('renders developer persona card', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.personas.developer.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.personas.developer.description')).toBeInTheDocument()
+    })
+
+    it('renders developer CTA link pointing to /docs', () => {
+      render(<LandingPage />)
+      const link = screen.getByText('landing.personas.developer.ctaLink')
+      expect(link.closest('a')).toHaveAttribute('href', '/docs')
+    })
+  })
+
+  describe('Features section', () => {
+    it('renders features section title', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.features.title')).toBeInTheDocument()
+    })
+
+    it('renders transcription feature', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.features.transcription.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.features.transcription.description')).toBeInTheDocument()
+    })
+
+    it('renders chat feature', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.features.chat.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.features.chat.description')).toBeInTheDocument()
+    })
+
+    it('renders API feature', () => {
+      render(<LandingPage />)
+      expect(screen.getByText('landing.features.api.title')).toBeInTheDocument()
+      expect(screen.getByText('landing.features.api.description')).toBeInTheDocument()
+    })
+  })
+
+  describe('SEO', () => {
+    it('sets document.title on mount', () => {
+      render(<LandingPage />)
+      expect(document.title).toBe(
+        '動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ'
+      )
+    })
+
+    it('restores document.title on unmount', () => {
+      document.title = 'original title'
+      const { unmount } = render(<LandingPage />)
+      unmount()
+      expect(document.title).toBe('original title')
+    })
+
+    it('sets meta description on mount', () => {
+      const meta = document.createElement('meta')
+      meta.name = 'description'
+      meta.content = 'original description'
+      document.head.appendChild(meta)
+
+      render(<LandingPage />)
+      expect(
+        document.querySelector('meta[name="description"]')?.getAttribute('content')
+      ).toBe(
+        'VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修・セミナーを文字起こし。自然言語で即検索できます。無料で始められます。'
+      )
+
+      meta.remove()
+    })
+
+    it('restores meta description on unmount', () => {
+      const meta = document.createElement('meta')
+      meta.name = 'description'
+      meta.content = 'original description'
+      document.head.appendChild(meta)
+
+      const { unmount } = render(<LandingPage />)
+      unmount()
+      expect(
+        document.querySelector('meta[name="description"]')?.getAttribute('content')
+      ).toBe('original description')
+
+      meta.remove()
+    })
+
+    it('sets canonical href on mount', () => {
+      const link = document.createElement('link')
+      link.rel = 'canonical'
+      link.href = 'https://videoq.jp/old'
+      document.head.appendChild(link)
+
+      render(<LandingPage />)
+      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+        'https://videoq.jp/'
+      )
+
+      link.remove()
+    })
+
+    it('restores canonical href on unmount', () => {
+      const link = document.createElement('link')
+      link.rel = 'canonical'
+      link.href = 'https://videoq.jp/old'
+      document.head.appendChild(link)
+
+      const { unmount } = render(<LandingPage />)
+      unmount()
+      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+        'https://videoq.jp/old'
+      )
+
+      link.remove()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/PrivacyPolicyPage.test.tsx
+++ b/frontend/src/pages/__tests__/PrivacyPolicyPage.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react'
+import PrivacyPolicyPage from '../PrivacyPolicyPage'
+
+describe('PrivacyPolicyPage SEO', () => {
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
+  it('sets english metadata', () => {
+    globalThis.__setMockLanguage('en')
+    render(<PrivacyPolicyPage />)
+
+    expect(document.title).toBe('Privacy Policy | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Read how VideoQ collects, uses, stores, and protects personal data and uploaded content.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/privacy'
+    )
+  })
+
+  it('switches metadata for japanese locale', () => {
+    globalThis.__setMockLanguage('ja')
+    render(<PrivacyPolicyPage />)
+
+    expect(document.title).toBe('プライバシーポリシー | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ が個人情報やアップロード動画をどのように収集・利用・保護するかを説明します。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/privacy'
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/TermsPage.test.tsx
+++ b/frontend/src/pages/__tests__/TermsPage.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react'
+import TermsPage from '../TermsPage'
+
+describe('TermsPage SEO', () => {
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
+  it('sets english metadata', () => {
+    globalThis.__setMockLanguage('en')
+    render(<TermsPage />)
+
+    expect(document.title).toBe('Terms of Service | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Read the VideoQ Terms of Service covering accounts, billing, acceptable use, and liability.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/terms'
+    )
+  })
+
+  it('switches metadata for japanese locale', () => {
+    globalThis.__setMockLanguage('ja')
+    render(<TermsPage />)
+
+    expect(document.title).toBe('利用規約 | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ のアカウント、課金、禁止事項、免責事項などを定めた利用規約です。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/terms'
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/UseCaseCorporateTrainingPage.test.tsx
+++ b/frontend/src/pages/__tests__/UseCaseCorporateTrainingPage.test.tsx
@@ -1,7 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import UseCaseCorporateTrainingPage from '../UseCaseCorporateTrainingPage'
+import { AppNav } from '@/components/layout/AppNav'
+
+vi.mock('@/components/layout/AppNav', () => ({
+  AppNav: vi.fn(() => null),
+}))
 
 describe('UseCaseCorporateTrainingPage', () => {
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   describe('Hero section', () => {
     it('renders hero title', () => {
       render(<UseCaseCorporateTrainingPage />)
@@ -130,10 +139,24 @@ describe('UseCaseCorporateTrainingPage', () => {
     })
   })
 
-  describe('SEO', () => {
-    it('sets document.title on mount', () => {
+  describe('Navbar', () => {
+    it('passes activePage="home" to AppNav', () => {
       render(<UseCaseCorporateTrainingPage />)
-      expect(document.title).toBe('社内研修動画をAI検索 | VideoQ 企業研修向け')
+      expect(vi.mocked(AppNav)).toHaveBeenCalledWith(
+        expect.objectContaining({ activePage: 'home' }),
+        undefined,
+      )
+    })
+  })
+
+  describe('SEO', () => {
+    it('sets english metadata on mount', () => {
+      globalThis.__setMockLanguage('en')
+      render(<UseCaseCorporateTrainingPage />)
+      expect(document.title).toBe('Corporate Training Use Case | VideoQ')
+      expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+        'VideoQ for corporate training: transcribe training videos, power self-serve search, and integrate with internal tools.'
+      )
     })
 
     it('injects FAQPage schema on mount', () => {
@@ -154,61 +177,35 @@ describe('UseCaseCorporateTrainingPage', () => {
     })
 
     it('sets canonical href to EN URL on mount (en locale)', () => {
-      const link = document.createElement('link')
-      link.rel = 'canonical'
-      link.href = 'https://videoq.jp/'
-      document.head.appendChild(link)
-
+      globalThis.__setMockLanguage('en')
       render(<UseCaseCorporateTrainingPage />)
       expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
         'https://videoq.jp/use-cases/corporate-training'
       )
-
-      link.remove()
-    })
-
-    it('restores canonical href on unmount', () => {
-      const link = document.createElement('link')
-      link.rel = 'canonical'
-      link.href = 'https://videoq.jp/'
-      document.head.appendChild(link)
-
-      const { unmount } = render(<UseCaseCorporateTrainingPage />)
-      unmount()
-      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
-        'https://videoq.jp/'
-      )
-
-      link.remove()
     })
 
     it('sets og:url to EN URL on mount', () => {
-      const meta = document.createElement('meta')
-      meta.setAttribute('property', 'og:url')
-      meta.setAttribute('content', 'https://videoq.jp/')
-      document.head.appendChild(meta)
-
+      globalThis.__setMockLanguage('en')
       render(<UseCaseCorporateTrainingPage />)
       expect(
         document.querySelector('meta[property="og:url"]')?.getAttribute('content')
       ).toBe('https://videoq.jp/use-cases/corporate-training')
-
-      meta.remove()
     })
 
-    it('restores og:url on unmount', () => {
-      const meta = document.createElement('meta')
-      meta.setAttribute('property', 'og:url')
-      meta.setAttribute('content', 'https://videoq.jp/')
-      document.head.appendChild(meta)
+    it('switches metadata for japanese locale', () => {
+      globalThis.__setMockLanguage('ja')
+      render(<UseCaseCorporateTrainingPage />)
 
-      const { unmount } = render(<UseCaseCorporateTrainingPage />)
-      unmount()
+      expect(document.title).toBe('企業研修向け | VideoQ')
+      expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+        '企業研修向け VideoQ。社内研修動画を文字起こしし、社員が必要な場面を検索・質問できます。'
+      )
+      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+        'https://videoq.jp/ja/use-cases/corporate-training'
+      )
       expect(
         document.querySelector('meta[property="og:url"]')?.getAttribute('content')
-      ).toBe('https://videoq.jp/')
-
-      meta.remove()
+      ).toBe('https://videoq.jp/ja/use-cases/corporate-training')
     })
   })
 })

--- a/frontend/src/pages/__tests__/UseCaseEducationPage.test.tsx
+++ b/frontend/src/pages/__tests__/UseCaseEducationPage.test.tsx
@@ -1,7 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import UseCaseEducationPage from '../UseCaseEducationPage'
+import { AppNav } from '@/components/layout/AppNav'
+
+vi.mock('@/components/layout/AppNav', () => ({
+  AppNav: vi.fn(() => null),
+}))
 
 describe('UseCaseEducationPage', () => {
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   describe('Hero section', () => {
     it('renders hero title', () => {
       render(<UseCaseEducationPage />)
@@ -117,10 +126,24 @@ describe('UseCaseEducationPage', () => {
     })
   })
 
-  describe('SEO', () => {
-    it('sets document.title on mount', () => {
+  describe('Navbar', () => {
+    it('passes activePage="home" to AppNav', () => {
       render(<UseCaseEducationPage />)
-      expect(document.title).toBe('授業・講義動画を AI 検索 | VideoQ 教育向け')
+      expect(vi.mocked(AppNav)).toHaveBeenCalledWith(
+        expect.objectContaining({ activePage: 'home' }),
+        undefined,
+      )
+    })
+  })
+
+  describe('SEO', () => {
+    it('sets english metadata on mount', () => {
+      globalThis.__setMockLanguage('en')
+      render(<UseCaseEducationPage />)
+      expect(document.title).toBe('Education Use Case | VideoQ')
+      expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+        'VideoQ for education: transcribe lectures, let students search by natural language, and share class videos.'
+      )
     })
 
     it('injects FAQPage schema on mount', () => {
@@ -141,61 +164,35 @@ describe('UseCaseEducationPage', () => {
     })
 
     it('sets canonical href to EN URL on mount (en locale)', () => {
-      const link = document.createElement('link')
-      link.rel = 'canonical'
-      link.href = 'https://videoq.jp/'
-      document.head.appendChild(link)
-
+      globalThis.__setMockLanguage('en')
       render(<UseCaseEducationPage />)
       expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
         'https://videoq.jp/use-cases/education'
       )
-
-      link.remove()
-    })
-
-    it('restores canonical href on unmount', () => {
-      const link = document.createElement('link')
-      link.rel = 'canonical'
-      link.href = 'https://videoq.jp/'
-      document.head.appendChild(link)
-
-      const { unmount } = render(<UseCaseEducationPage />)
-      unmount()
-      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
-        'https://videoq.jp/'
-      )
-
-      link.remove()
     })
 
     it('sets og:url to EN URL on mount', () => {
-      const meta = document.createElement('meta')
-      meta.setAttribute('property', 'og:url')
-      meta.setAttribute('content', 'https://videoq.jp/')
-      document.head.appendChild(meta)
-
+      globalThis.__setMockLanguage('en')
       render(<UseCaseEducationPage />)
       expect(
         document.querySelector('meta[property="og:url"]')?.getAttribute('content')
       ).toBe('https://videoq.jp/use-cases/education')
-
-      meta.remove()
     })
 
-    it('restores og:url on unmount', () => {
-      const meta = document.createElement('meta')
-      meta.setAttribute('property', 'og:url')
-      meta.setAttribute('content', 'https://videoq.jp/')
-      document.head.appendChild(meta)
+    it('switches metadata for japanese locale', () => {
+      globalThis.__setMockLanguage('ja')
+      render(<UseCaseEducationPage />)
 
-      const { unmount } = render(<UseCaseEducationPage />)
-      unmount()
+      expect(document.title).toBe('教育向け | VideoQ')
+      expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+        '教育機関向け VideoQ。授業・講義動画を文字起こしし、学生が自然言語で検索・質問できます。'
+      )
+      expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+        'https://videoq.jp/ja/use-cases/education'
+      )
       expect(
         document.querySelector('meta[property="og:url"]')?.getAttribute('content')
-      ).toBe('https://videoq.jp/')
-
-      meta.remove()
+      ).toBe('https://videoq.jp/ja/use-cases/education')
     })
   })
 })

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -180,6 +180,7 @@ vi.mock('@/lib/api', async (importOriginal) => {
   ...actual,
   apiClient: {
     getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
+    getMeOrNull: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     signup: vi.fn(() => Promise.resolve()),
     verifyEmail: vi.fn(() => Promise.resolve()),
     requestPasswordReset: vi.fn(() => Promise.resolve()),

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -3,7 +3,10 @@ import { cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import React from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
+import { HelmetProvider } from 'react-helmet-async'
 import { createAppQueryClient } from './src/lib/queryClient'
+import enTranslation from './src/i18n/locales/en/translation.json'
+import jaTranslation from './src/i18n/locales/ja/translation.json'
 
 vi.mock('@testing-library/react', async () => {
   const actual = await vi.importActual<typeof import('@testing-library/react')>('@testing-library/react')
@@ -11,7 +14,11 @@ vi.mock('@testing-library/react', async () => {
   const createWrapper = (UserWrapper?: React.ComponentType<any>) => {
     const TestQueryWrapper = ({ children, ...props }: { children?: React.ReactNode } & Record<string, unknown>) => {
       const [queryClient] = React.useState(() => createAppQueryClient())
-      const content = React.createElement(QueryClientProvider, { client: queryClient }, children)
+      const content = React.createElement(
+        HelmetProvider,
+        {},
+        React.createElement(QueryClientProvider, { client: queryClient }, children),
+      )
       if (!UserWrapper) {
         return content
       }
@@ -41,6 +48,7 @@ vi.mock('@testing-library/react', async () => {
 declare global {
   interface GlobalThis {
     __setMockPathname: (pathname: string) => void
+    __setMockLanguage: (language: 'en' | 'ja') => void
   }
 }
 
@@ -84,10 +92,35 @@ const mockLocation: {
   state: unknown
   key: string
 } = { pathname: '/', search: '', hash: '', state: null, key: 'default' }
+let mockLanguage: 'en' | 'ja' = 'en'
+
+const seoTranslations = {
+  en: enTranslation.seo,
+  ja: jaTranslation.seo,
+} as const
+
+const lookupSeoTranslation = (language: 'en' | 'ja', key: string): string | undefined => {
+  if (!key.startsWith('seo.')) {
+    return undefined
+  }
+
+  let current: unknown = seoTranslations[language]
+  for (const segment of key.split('.').slice(1)) {
+    if (!current || typeof current !== 'object' || !(segment in current)) {
+      return undefined
+    }
+    current = (current as Record<string, unknown>)[segment]
+  }
+
+  return typeof current === 'string' ? current : undefined
+}
 
 // Allow tests to control the (de-localized) pathname returned by useLocation/useI18nLocation
 globalThis.__setMockPathname = (pathname: string) => {
   mockLocation.pathname = pathname
+}
+globalThis.__setMockLanguage = (language: 'en' | 'ja') => {
+  mockLanguage = language
 }
 
 vi.mock('react-router-dom', async () => {
@@ -109,12 +142,23 @@ vi.mock('react-router-dom', async () => {
 
 // Mock react-i18next
 vi.mock('react-i18next', () => ({
+  initReactI18next: {
+    type: '3rdParty',
+    init: () => undefined,
+  },
   useTranslation: () => ({
     t: (key: string, optionsOrDefault?: string | Record<string, unknown>) => {
+      const resolved = lookupSeoTranslation(mockLanguage, key)
+      if (resolved) {
+        return resolved
+      }
       if (typeof optionsOrDefault === 'string') {
         return key
       }
       if (optionsOrDefault && typeof optionsOrDefault === 'object') {
+        if ('returnObjects' in optionsOrDefault && key.endsWith('.bullets')) {
+          return [`${key}.0`, `${key}.1`]
+        }
         const rest = Object.fromEntries(
           Object.entries(optionsOrDefault as Record<string, unknown>).filter(([k]) => k !== 'defaultValue')
         )
@@ -126,7 +170,7 @@ vi.mock('react-i18next', () => ({
       return key
     },
     i18n: {
-      language: 'en',
+      language: mockLanguage,
       changeLanguage: vi.fn(),
     },
   }),
@@ -145,7 +189,7 @@ vi.mock('@/lib/i18n', () => ({
   useI18nLocation: () => mockLocation,
   removeLocalePrefix: (pathname: string) => pathname,
   addLocalePrefix: (pathname: string) => pathname,
-  useLocale: () => 'en',
+  useLocale: () => mockLanguage,
   Link: ({ children, to, href, ...props }: { children?: React.ReactNode; to?: unknown; href?: string } & Record<string, unknown>) =>
     React.createElement('a', { href: href || (typeof to === 'string' ? to : ''), ...props }, children),
   i18nConfig: {


### PR DESCRIPTION
## 概要

- **ランディングページのコピー・CTA最適化**: 教育・企業研修ペルソナ向けにランディングページのメッセージとCTAを改善
- **ナビバー修正**: ホームのアクティブ状態を修正、ユースケースページのフッター教育リンクを削除
- **ページ別SEOメタタグ**: `react-helmet-async` を使った `SeoHead` コンポーネントを追加し、各ルートで動的に `<title>` と `<meta name="description">` を設定
- **テスト追加**: `LandingPage`、`DeveloperDocsPage`、`DeveloperDocsSectionPage`、`PrivacyPolicyPage`、`TermsPage` のテストを新規追加、既存のページ・ナビテストを更新

## 変更内容

| 対象 | 詳細 |
|------|------|
| `SeoHead` コンポーネント | ページ別タイトル・ディスクリプションを設定する再利用可能なSEOヘッドコンポーネントを新規追加 |
| `react-helmet-async` | 依存関係に追加、`HelmetProvider` を `main.tsx` に組み込み |
| `LandingPage` | 教育・企業研修向けに最適化した新しい専用ランディングページ |
| `AppNav` | ホームアクティブ状態の修正、ユースケースページからフッターの教育リンクを削除 |
| i18n | SEO関連の翻訳キーを追加（日英） |
| テスト | ページとナビの動作をカバーする7ファイルを新規追加・更新 |

## テスト手順

- [x] ナビゲーション時にページタイトルが正しく更新されることを確認
- [x] 各ルートでメタディスクリプションが描画されることを確認
- [x] ホームルートでナビバーのアクティブ状態を確認
- [x] フロントエンドテストを実行: `frontend/` で `npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)