### PR TITLE
Add FAQ page with SEO meta tags and OG tag coverage (#601)

### DIFF
--- a/frontend/src/pages/__tests__/FaqPage.test.tsx
+++ b/frontend/src/pages/__tests__/FaqPage.test.tsx
@@ -118,6 +118,34 @@ describe('FaqPage', () => {
       )
     })
 
+    it('sets OG tags for english', () => {
+      globalThis.__setMockLanguage('en')
+      render(<FaqPage />)
+      expect(
+        document.querySelector('meta[property="og:title"]')?.getAttribute('content')
+      ).toBe('FAQ | VideoQ')
+      expect(
+        document.querySelector('meta[property="og:description"]')?.getAttribute('content')
+      ).toBe('Frequently asked questions about VideoQ: pricing, features, security, and more.')
+      expect(
+        document.querySelector('meta[property="og:url"]')?.getAttribute('content')
+      ).toBe('https://videoq.jp/faq')
+    })
+
+    it('sets OG tags for japanese', () => {
+      globalThis.__setMockLanguage('ja')
+      render(<FaqPage />)
+      expect(
+        document.querySelector('meta[property="og:title"]')?.getAttribute('content')
+      ).toBe('よくある質問 | VideoQ')
+      expect(
+        document.querySelector('meta[property="og:description"]')?.getAttribute('content')
+      ).toBe('VideoQ のよくある質問。料金・機能・セキュリティ・API 連携などをまとめています。')
+      expect(
+        document.querySelector('meta[property="og:url"]')?.getAttribute('content')
+      ).toBe('https://videoq.jp/ja/faq')
+    })
+
     it('injects FAQPage JSON-LD schema with at least 10 entries', () => {
       render(<FaqPage />)
       const script = document.getElementById('faq-schema-faq')


### PR DESCRIPTION
## Summary

- `/faq` ページ (`FaqPage.tsx`) を作成し、5カテゴリ・11項目のFAQアコーディオンを実装
- `SeoHead` コンポーネントで `<title>`、`<meta name="description">`、canonical、OGタグ（og:title / og:description / og:url）を設定
- ja / en の i18n 対応（`seo.faq.title` / `seo.faq.description` 翻訳キー）
- FAQPage JSON-LD スキーママークアップを注入
- `App.tsx` に `/faq` ルートを追加（`/:locale/faq` も自動対応）
- TDD: OGタグのテストを追加し、19テスト全パス

## Test plan

- [x] `FaqPage.test.tsx` 19テスト全パス
  - ページ構造（h1、FAQ件数、カテゴリ見出し）
  - アコーディオン開閉動作
  - 英語・日本語メタタグ（title / description / canonical）
  - **OGタグ（og:title / og:description / og:url）← 今回追加**
  - FAQPage JSON-LD スキーマ（10件以上、@type 検証）
  - AppNav activePage prop

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)