### PR TITLE
Add missing public pages to sitemap.xml with changefreq/priority (#575)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,7 @@
         "@vitejs/plugin-react-swc": "^4.2.2",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.2",
+        "@xmldom/xmldom": "^0.9.9",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -3592,6 +3593,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
+      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/acorn": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "@vitejs/plugin-react-swc": "^4.2.2",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.2",
+    "@xmldom/xmldom": "^0.9.9",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <!-- LP (home) -->
   <url>
     <loc>https://videoq.jp/</loc>
     <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/"/>
     <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/"/>
@@ -11,111 +14,18 @@
   <url>
     <loc>https://videoq.jp/ja/</loc>
     <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/"/>
     <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/"/>
   </url>
-  <url>
-    <loc>https://videoq.jp/docs</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/ja/docs</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/docs/auth</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/auth"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/auth"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/auth"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/ja/docs/auth</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/auth"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/auth"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/auth"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/docs/videos</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/videos"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/videos"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/videos"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/ja/docs/videos</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/videos"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/videos"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/videos"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/docs/chat</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/chat"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/chat"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/chat"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/ja/docs/chat</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/chat"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/chat"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/chat"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/docs/openai</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/openai"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/openai"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/openai"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/ja/docs/openai</loc>
-    <lastmod>2026-03-22</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/openai"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/openai"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/openai"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/use-cases/education</loc>
-    <lastmod>2026-03-30</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/education"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/education"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/education"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/ja/use-cases/education</loc>
-    <lastmod>2026-03-30</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/education"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/education"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/education"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/use-cases/corporate-training</loc>
-    <lastmod>2026-03-30</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/corporate-training"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/corporate-training"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/corporate-training"/>
-  </url>
-  <url>
-    <loc>https://videoq.jp/ja/use-cases/corporate-training</loc>
-    <lastmod>2026-03-30</lastmod>
-    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/corporate-training"/>
-    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/corporate-training"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/corporate-training"/>
-  </url>
+  <!-- FAQ -->
   <url>
     <loc>https://videoq.jp/faq</loc>
     <lastmod>2026-03-31</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/faq"/>
     <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/faq"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/faq"/>
@@ -123,8 +33,193 @@
   <url>
     <loc>https://videoq.jp/ja/faq</loc>
     <lastmod>2026-03-31</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/faq"/>
     <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/faq"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/faq"/>
+  </url>
+  <!-- Use-case LPs -->
+  <url>
+    <loc>https://videoq.jp/use-cases/education</loc>
+    <lastmod>2026-03-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/education"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/education"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/education"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/use-cases/education</loc>
+    <lastmod>2026-03-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/education"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/education"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/education"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/use-cases/corporate-training</loc>
+    <lastmod>2026-03-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/corporate-training"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/corporate-training"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/corporate-training"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/use-cases/corporate-training</loc>
+    <lastmod>2026-03-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/use-cases/corporate-training"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/use-cases/corporate-training"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/use-cases/corporate-training"/>
+  </url>
+  <!-- Docs -->
+  <url>
+    <loc>https://videoq.jp/docs</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/docs</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/docs/auth</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/auth"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/auth"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/auth"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/docs/auth</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/auth"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/auth"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/auth"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/docs/videos</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/videos"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/videos"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/videos"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/docs/videos</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/videos"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/videos"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/videos"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/docs/chat</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/chat"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/chat"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/chat"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/docs/chat</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/chat"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/chat"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/chat"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/docs/openai</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/openai"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/openai"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/openai"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/docs/openai</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/docs/openai"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/docs/openai"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/docs/openai"/>
+  </url>
+  <!-- Legal pages (priority=0.3, changefreq=yearly) -->
+  <url>
+    <loc>https://videoq.jp/terms</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/terms"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/terms"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/terms"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/terms</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/terms"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/terms"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/terms"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/privacy</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/privacy"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/privacy"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/privacy"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/privacy</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/privacy"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/privacy"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/privacy"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/commercial-disclosure</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/commercial-disclosure"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/commercial-disclosure"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/commercial-disclosure"/>
+  </url>
+  <url>
+    <loc>https://videoq.jp/ja/commercial-disclosure</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://videoq.jp/commercial-disclosure"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://videoq.jp/ja/commercial-disclosure"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://videoq.jp/commercial-disclosure"/>
   </url>
 </urlset>

--- a/frontend/src/__tests__/sitemap.test.ts
+++ b/frontend/src/__tests__/sitemap.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment node
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { describe, it, expect, beforeAll } from 'vitest'
+import { DOMParser } from '@xmldom/xmldom'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const BASE = 'https://videoq.jp'
+
+const SITEMAP_NS = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+const XHTML_NS = 'http://www.w3.org/1999/xhtml'
+
+interface UrlEntry {
+  loc: string
+  lastmod: string | null
+  changefreq: string | null
+  priority: string | null
+  alternates: { hreflang: string; href: string }[]
+}
+
+function parseSitemap(xml: string): UrlEntry[] {
+  const doc = new DOMParser().parseFromString(xml, 'text/xml')
+  const urlNodes = doc.getElementsByTagNameNS(SITEMAP_NS, 'url')
+  const entries: UrlEntry[] = []
+
+  for (let i = 0; i < urlNodes.length; i++) {
+    const urlNode = urlNodes.item(i)!
+    const loc =
+      urlNode.getElementsByTagNameNS(SITEMAP_NS, 'loc').item(0)?.textContent ?? ''
+    const lastmod =
+      urlNode.getElementsByTagNameNS(SITEMAP_NS, 'lastmod').item(0)?.textContent ?? null
+    const changefreq =
+      urlNode.getElementsByTagNameNS(SITEMAP_NS, 'changefreq').item(0)?.textContent ?? null
+    const priority =
+      urlNode.getElementsByTagNameNS(SITEMAP_NS, 'priority').item(0)?.textContent ?? null
+
+    const linkNodes = urlNode.getElementsByTagNameNS(XHTML_NS, 'link')
+    const alternates: { hreflang: string; href: string }[] = []
+    for (let j = 0; j < linkNodes.length; j++) {
+      const linkNode = linkNodes.item(j)!
+      const hreflang = linkNode.getAttribute('hreflang') ?? ''
+      const href = linkNode.getAttribute('href') ?? ''
+      alternates.push({ hreflang, href })
+    }
+
+    entries.push({ loc, lastmod, changefreq, priority, alternates })
+  }
+
+  return entries
+}
+
+describe('sitemap.xml', () => {
+  let entries: UrlEntry[]
+  let locs: Set<string>
+
+  beforeAll(() => {
+    const xml = readFileSync(
+      resolve(__dirname, '../../public/sitemap.xml'),
+      'utf-8'
+    )
+    entries = parseSitemap(xml)
+    locs = new Set(entries.map((e) => e.loc))
+  })
+
+  // ── Required pages ──────────────────────────────────────────────────────────
+
+  const REQUIRED_PAGES: [string, string][] = [
+    // [en URL, ja URL]
+    [`${BASE}/`, `${BASE}/ja/`],
+    [`${BASE}/docs`, `${BASE}/ja/docs`],
+    [`${BASE}/docs/auth`, `${BASE}/ja/docs/auth`],
+    [`${BASE}/docs/videos`, `${BASE}/ja/docs/videos`],
+    [`${BASE}/docs/chat`, `${BASE}/ja/docs/chat`],
+    [`${BASE}/docs/openai`, `${BASE}/ja/docs/openai`],
+    [`${BASE}/faq`, `${BASE}/ja/faq`],
+    [`${BASE}/use-cases/education`, `${BASE}/ja/use-cases/education`],
+    [`${BASE}/use-cases/corporate-training`, `${BASE}/ja/use-cases/corporate-training`],
+    [`${BASE}/terms`, `${BASE}/ja/terms`],
+    [`${BASE}/privacy`, `${BASE}/ja/privacy`],
+    [`${BASE}/commercial-disclosure`, `${BASE}/ja/commercial-disclosure`],
+  ]
+
+  it.each(REQUIRED_PAGES)('contains %s', (enUrl) => {
+    expect(locs).toContain(enUrl)
+  })
+
+  it.each(REQUIRED_PAGES)('contains %s (ja)', (_enUrl, jaUrl) => {
+    expect(locs).toContain(jaUrl)
+  })
+
+  // ── changefreq and priority ─────────────────────────────────────────────────
+
+  const LP_FAQ_PAGES = [
+    `${BASE}/`,
+    `${BASE}/ja/`,
+    `${BASE}/faq`,
+    `${BASE}/ja/faq`,
+    `${BASE}/use-cases/education`,
+    `${BASE}/ja/use-cases/education`,
+    `${BASE}/use-cases/corporate-training`,
+    `${BASE}/ja/use-cases/corporate-training`,
+  ]
+
+  const LEGAL_PAGES = [
+    `${BASE}/terms`,
+    `${BASE}/ja/terms`,
+    `${BASE}/privacy`,
+    `${BASE}/ja/privacy`,
+    `${BASE}/commercial-disclosure`,
+    `${BASE}/ja/commercial-disclosure`,
+  ]
+
+  it.each(LP_FAQ_PAGES)('%s has changefreq=monthly', (url) => {
+    const entry = entries.find((e) => e.loc === url)
+    expect(entry?.changefreq).toBe('monthly')
+  })
+
+  it.each(LP_FAQ_PAGES)('%s has priority=0.8', (url) => {
+    const entry = entries.find((e) => e.loc === url)
+    expect(entry?.priority).toBe('0.8')
+  })
+
+  it.each(LEGAL_PAGES)('%s has changefreq=yearly', (url) => {
+    const entry = entries.find((e) => e.loc === url)
+    expect(entry?.changefreq).toBe('yearly')
+  })
+
+  it.each(LEGAL_PAGES)('%s has priority=0.3', (url) => {
+    const entry = entries.find((e) => e.loc === url)
+    expect(entry?.priority).toBe('0.3')
+  })
+
+  // ── hreflang alternates ─────────────────────────────────────────────────────
+
+  it.each(REQUIRED_PAGES)(
+    '%s has hreflang en/ja/x-default alternates',
+    (enUrl, jaUrl) => {
+      const entry = entries.find((e) => e.loc === enUrl)!
+      const hreflangs = entry.alternates.map((a) => a.hreflang)
+      expect(hreflangs).toContain('en')
+      expect(hreflangs).toContain('ja')
+      expect(hreflangs).toContain('x-default')
+
+      const enAlt = entry.alternates.find((a) => a.hreflang === 'en')
+      const jaAlt = entry.alternates.find((a) => a.hreflang === 'ja')
+      const defaultAlt = entry.alternates.find((a) => a.hreflang === 'x-default')
+
+      expect(enAlt?.href).toBe(enUrl)
+      expect(jaAlt?.href).toBe(jaUrl)
+      expect(defaultAlt?.href).toBe(enUrl)
+    }
+  )
+
+  // ── lastmod present ─────────────────────────────────────────────────────────
+
+  it('every url has a lastmod date', () => {
+    for (const entry of entries) {
+      expect(entry.lastmod).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    }
+  })
+
+  // ── no duplicates ───────────────────────────────────────────────────────────
+
+  it('has no duplicate locs', () => {
+    const locArray = entries.map((e) => e.loc)
+    expect(locArray.length).toBe(new Set(locArray).size)
+  })
+})


### PR DESCRIPTION
## Summary

- `frontend/public/sitemap.xml` に `/terms`, `/privacy`, `/commercial-disclosure`（en + ja）を追加
- 全エントリに `<changefreq>` と `<priority>` を追加（LP・FAQ=0.8/monthly、法的ページ=0.3/yearly）
- `@xmldom/xmldom` を追加し `sitemap.test.ts` で 66 件のテストを実装（TDD）

## Test plan

- [x] `npx vitest run src/__tests__/sitemap.test.ts` — 66 tests passed
- [x] 全必須 URL（24 件）の存在確認
- [x] `changefreq` / `priority` の値が仕様通りであることを確認
- [x] hreflang en/ja/x-default alternates が全 URL に設定されていることを確認
- [x] `robots.txt` の `Sitemap:` ディレクティブが正しいパスを指していることを確認
- [ ] Google Search Console でサイトマップ送信後にエラーが出ないことを確認（本番反映後）

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)