### PR TITLE
feat: SeoHead に og:image サポートを追加する (#609)

### DIFF
--- a/frontend/src/components/seo/SeoHead.tsx
+++ b/frontend/src/components/seo/SeoHead.tsx
@@ -3,6 +3,7 @@ import { defaultLocale, locales, type Locale } from '@/i18n/config';
 import { useLocale } from '@/lib/i18n';
 
 const BASE_URL = 'https://videoq.jp';
+const DEFAULT_OG_IMAGE = 'https://videoq.jp/og-image.png';
 
 function normalizePath(path: string): string {
   if (!path) {
@@ -21,9 +22,10 @@ type SeoHeadProps = {
   title: string;
   description: string;
   path: string;
+  ogImage?: string;
 };
 
-export function SeoHead({ title, description, path }: SeoHeadProps) {
+export function SeoHead({ title, description, path, ogImage = DEFAULT_OG_IMAGE }: SeoHeadProps) {
   const locale = useLocale();
   const canonicalUrl = buildAbsoluteUrl(path, locale);
   const alternateUrls = Object.fromEntries(
@@ -49,6 +51,10 @@ export function SeoHead({ title, description, path }: SeoHeadProps) {
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:image" content={ogImage} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta name="twitter:image" content={ogImage} />
     </Helmet>
   );
 }

--- a/frontend/src/components/seo/__tests__/SeoHead.test.tsx
+++ b/frontend/src/components/seo/__tests__/SeoHead.test.tsx
@@ -1,0 +1,100 @@
+import { render } from '@testing-library/react'
+import { SeoHead } from '../SeoHead'
+
+const DEFAULT_OG_IMAGE = 'https://videoq.jp/og-image.png'
+
+describe('SeoHead', () => {
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
+  describe('og:image', () => {
+    it('outputs default og:image when ogImage prop is omitted', () => {
+      render(<SeoHead title="Test" description="Test desc" path="/test" />)
+      expect(
+        document.querySelector('meta[property="og:image"]')?.getAttribute('content')
+      ).toBe(DEFAULT_OG_IMAGE)
+    })
+
+    it('outputs custom og:image when ogImage prop is provided', () => {
+      render(
+        <SeoHead
+          title="Test"
+          description="Test desc"
+          path="/test"
+          ogImage="https://videoq.jp/custom.png"
+        />
+      )
+      expect(
+        document.querySelector('meta[property="og:image"]')?.getAttribute('content')
+      ).toBe('https://videoq.jp/custom.png')
+    })
+
+    it('outputs og:image:width as 1200', () => {
+      render(<SeoHead title="Test" description="Test desc" path="/test" />)
+      expect(
+        document.querySelector('meta[property="og:image:width"]')?.getAttribute('content')
+      ).toBe('1200')
+    })
+
+    it('outputs og:image:height as 630', () => {
+      render(<SeoHead title="Test" description="Test desc" path="/test" />)
+      expect(
+        document.querySelector('meta[property="og:image:height"]')?.getAttribute('content')
+      ).toBe('630')
+    })
+  })
+
+  describe('twitter:image', () => {
+    it('outputs default twitter:image when ogImage prop is omitted', () => {
+      render(<SeoHead title="Test" description="Test desc" path="/test" />)
+      expect(
+        document.querySelector('meta[name="twitter:image"]')?.getAttribute('content')
+      ).toBe(DEFAULT_OG_IMAGE)
+    })
+
+    it('outputs custom twitter:image when ogImage prop is provided', () => {
+      render(
+        <SeoHead
+          title="Test"
+          description="Test desc"
+          path="/test"
+          ogImage="https://videoq.jp/custom.png"
+        />
+      )
+      expect(
+        document.querySelector('meta[name="twitter:image"]')?.getAttribute('content')
+      ).toBe('https://videoq.jp/custom.png')
+    })
+  })
+
+  describe('existing meta tags still work', () => {
+    it('sets title', () => {
+      render(<SeoHead title="My Page | VideoQ" description="desc" path="/my-page" />)
+      expect(document.title).toBe('My Page | VideoQ')
+    })
+
+    it('sets og:title', () => {
+      render(<SeoHead title="My Page | VideoQ" description="desc" path="/my-page" />)
+      expect(
+        document.querySelector('meta[property="og:title"]')?.getAttribute('content')
+      ).toBe('My Page | VideoQ')
+    })
+
+    it('sets canonical for english locale', () => {
+      globalThis.__setMockLanguage('en')
+      render(<SeoHead title="Test" description="desc" path="/test" />)
+      expect(
+        document.querySelector('link[rel="canonical"]')?.getAttribute('href')
+      ).toBe('https://videoq.jp/test')
+    })
+
+    it('sets canonical for japanese locale', () => {
+      globalThis.__setMockLanguage('ja')
+      render(<SeoHead title="Test" description="desc" path="/test" />)
+      expect(
+        document.querySelector('link[rel="canonical"]')?.getAttribute('href')
+      ).toBe('https://videoq.jp/ja/test')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `SeoHead` コンポーネントに `ogImage` props を追加（省略時のデフォルト: `https://videoq.jp/og-image.png`）
- `og:image`、`og:image:width`（1200）、`og:image:height`（630）を `Helmet` で出力
- `twitter:image` を `Helmet` で出力
- `SeoHead` のユニットテストを新規追加（10テスト）

これにより FaqPage・TermsPage・UseCasePage などすべての動的ページで SNS シェア時に OGP 画像が表示されるようになります。各ページは `ogImage` を省略することでデフォルト画像が自動適用されます。

## Test plan

- [x] `SeoHead` 単体テスト 10件がすべてパス
- [x] 全フロントエンドテスト 628件がパス
- [ ] `og:image` prop なしでデフォルト画像 `https://videoq.jp/og-image.png` が出力されることを確認
- [ ] `og:image` prop ありでカスタム画像が出力されることを確認
- [ ] SNS シェアプレビュー（OGP checker 等）で画像が表示されることを確認

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)