### PR TITLE
feat: increase RAG topk from 4 to 20 for better answer quality

### DIFF
--- a/backend/app/infrastructure/external/rag_service.py
+++ b/backend/app/infrastructure/external/rag_service.py
@@ -121,7 +121,7 @@ class RagChatService:
         vector_store = self._create_vector_store()
         return vector_store.as_retriever(
             search_kwargs={
-                "k": 4,
+                "k": 20,
                 "filter": {
                     "user_id": self.user.id,
                     "video_id": {"$in": group_video_ids},


### PR DESCRIPTION
# Pull Request: Increase RAG topk for Better Answer Quality

## Description
AIチャットの回答精度を向上させるため、RAG（検索拡張生成）におけるドキュメント取得件数（`topk`）を **4件から20件** に引き上げました。

### Rationale（変更の理由）
- **回答精度の向上:** 1件あたり最大200トークンのチャンクを4つだけ取得して回答を生成していましたが、これでは長い動画や複数のソースがある場合にコンテキストが不足し、情報が欠落するケースがありました。20件に増やすことで、LLMがより広範な情報を参照して詳細かつ正確な回答を生成できるようになります。
- **コストの持続性:** 使用している `gpt-4o-mini` は非常に安価なため、この変更によるコスト増は1クエリあたり約0.07円（推定0.1円→0.17円）と非常に軽微です。
- **プラン収益性の維持:** ユーザーがLiteやStandardプランのAI回答上限まで利用したとしても、依然として十分な利益率（粗利）を確保できることを確認済みです。

## Changes
- `backend/app/infrastructure/external/rag_service.py` のベクターストア・リトリーバー設定における `k` を **20** に更新しました。

## Cost Analysis (per query - GPT-4o-mini)
| パラメータ | 平均トークン数 | 推定コスト (JPY) |
| :--- | :--- | :--- |
| **Previous (k=4)** | ~2,600 | ~0.10 JPY |
| **New (k=20)** | ~5,800 | **~0.17 JPY** |

## Plan Impact (AI Answer Limit一杯まで使い切った場合)
| プラン | 月間AI回答上限 | 月間LLMコスト (k=4) | 月間LLMコスト (k=20) |
| :--- | :--- | :--- | :--- |
| **Lite (¥980)** | 3,000回 | ~300 JPY | **~510 JPY** |
| **Standard (¥2,980)** | 7,000回 | ~700 JPY | **~1,190 JPY** |

## Verification Results
- `git diff` により、変更箇所が意図したリトリーバー設定のみであることを確認。
- `gpt-4o-mini` のコンテキスト窓（128K tokens）に対して、入力サイズ（約6K tokens）が十分余裕があることを検証。
- `backend/app/domain/billing/entities.py` のプラン定義に基づき、採算性を確認。