### PR TITLE
feat: アプリ内ページのローカライズ済みSEOメタデータを追加

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1180,6 +1180,63 @@
     }
   },
   "seo": {
+    "app": {
+      "home": {
+        "title": "Home | VideoQ",
+        "description": "View your VideoQ dashboard, recent uploads, and quick actions for managing videos and groups."
+      },
+      "videos": {
+        "title": "Video Library | VideoQ",
+        "description": "Browse, search, and manage your uploaded videos in VideoQ."
+      },
+      "groups": {
+        "title": "Group Management | VideoQ",
+        "description": "Create and manage video groups for searchable AI chat and shared learning flows."
+      },
+      "videoDetail": {
+        "description": "Review the video, transcript, and metadata in your VideoQ library."
+      },
+      "groupDetail": {
+        "description": "View the video group, its playlist, and related AI chat workspace in VideoQ."
+      },
+      "settings": {
+        "title": "Settings | VideoQ",
+        "description": "Manage your VideoQ account, API keys, and integration settings."
+      },
+      "billing": {
+        "title": "Billing & Plans | VideoQ",
+        "description": "Review your current plan, usage, and billing options in VideoQ."
+      }
+    },
+    "auth": {
+      "login": {
+        "title": "Log In | VideoQ",
+        "description": "Log in to VideoQ to manage videos, search transcripts with AI, and access your learning workspace."
+      },
+      "checkEmail": {
+        "title": "Check Your Email | VideoQ",
+        "description": "Check your inbox to verify your email address and finish creating your VideoQ account."
+      },
+      "signup": {
+        "title": "Sign Up | VideoQ",
+        "description": "Create a VideoQ account to upload videos, transcribe them with AI, and start searchable learning workflows."
+      },
+      "forgotPassword": {
+        "title": "Reset Your Password | VideoQ",
+        "description": "Request a password reset email to regain access to your VideoQ account."
+      },
+      "resetPassword": {
+        "title": "Set a New Password | VideoQ",
+        "description": "Set a new password to restore access to your VideoQ account."
+      },
+      "verifyEmail": {
+        "title": "Verify Your Email | VideoQ",
+        "description": "Verify your email address to activate your VideoQ account."
+      }
+    },
+    "shared": {
+      "description": "Open the shared VideoQ group and browse videos with AI chat."
+    },
     "landing": {
       "title": "Upload Your Video. AI Transcription & Instant Search for Education & Training | VideoQ",
       "description": "VideoQ is an AI video learning platform for education and corporate training. Upload your video and AI transcribes lectures, training sessions, and seminars. Search instantly in natural language. Free to start."

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1180,6 +1180,63 @@
     }
   },
   "seo": {
+    "app": {
+      "home": {
+        "title": "ホーム | VideoQ",
+        "description": "VideoQ のダッシュボードで、最近のアップロード、動画管理、グループ管理へのクイック操作を確認できます。"
+      },
+      "videos": {
+        "title": "動画ライブラリ | VideoQ",
+        "description": "VideoQ にアップロードした動画を一覧・検索・管理できます。"
+      },
+      "groups": {
+        "title": "グループ管理 | VideoQ",
+        "description": "AI チャットや共有学習フローに使う動画グループを作成・管理できます。"
+      },
+      "videoDetail": {
+        "description": "VideoQ の動画詳細画面で、動画、文字起こし、メタデータを確認できます。"
+      },
+      "groupDetail": {
+        "description": "VideoQ のグループ詳細画面で、動画一覧、再生、AI チャット連携を確認できます。"
+      },
+      "settings": {
+        "title": "設定 | VideoQ",
+        "description": "VideoQ のアカウント、API キー、各種連携設定を管理できます。"
+      },
+      "billing": {
+        "title": "課金・プラン | VideoQ",
+        "description": "現在のプラン、使用量、課金オプションを VideoQ 上で確認できます。"
+      }
+    },
+    "auth": {
+      "login": {
+        "title": "ログイン | VideoQ",
+        "description": "VideoQ にログインして、動画管理、AI による文字起こし検索、学習ワークスペースにアクセスできます。"
+      },
+      "checkEmail": {
+        "title": "メールをご確認ください | VideoQ",
+        "description": "受信メールを確認して、メールアドレス認証を完了し、VideoQ アカウント登録を完了してください。"
+      },
+      "signup": {
+        "title": "新規登録 | VideoQ",
+        "description": "VideoQ アカウントを作成して、動画をアップロードし、AI 文字起こしと検索可能な学習フローを始めましょう。"
+      },
+      "forgotPassword": {
+        "title": "パスワード再設定 | VideoQ",
+        "description": "VideoQ アカウントに再度アクセスするためのパスワード再設定メールを送信します。"
+      },
+      "resetPassword": {
+        "title": "新しいパスワードを設定 | VideoQ",
+        "description": "VideoQ アカウントに再度アクセスするため、新しいパスワードを設定します。"
+      },
+      "verifyEmail": {
+        "title": "メールアドレス認証 | VideoQ",
+        "description": "VideoQ アカウントを有効化するため、メールアドレス認証を行います。"
+      }
+    },
+    "shared": {
+      "description": "共有された VideoQ グループを開き、動画一覧と AI チャットを利用できます。"
+    },
     "landing": {
       "title": "動画をアップロードするだけ。教育・研修動画をAIで文字起こし→即検索 | VideoQ",
       "description": "VideoQは教育・企業研修向けのAI動画学習プラットフォームです。動画をアップロードするだけでAIが授業・研修・セミナーを文字起こし。自然言語で即検索できます。無料で始められます。"

--- a/frontend/src/pages/BillingPage.tsx
+++ b/frontend/src/pages/BillingPage.tsx
@@ -7,6 +7,7 @@ import { queryKeys } from '@/lib/queryKeys';
 import { useAuth } from '@/hooks/useAuth';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { Button } from '@/components/ui/button';
 import { operatorConfig } from '@/lib/operatorConfig';
@@ -315,6 +316,11 @@ export default function BillingPage() {
   if (isError) {
     return (
       <AppPageShell activePage="billing">
+        <SeoHead
+          title={t('seo.app.billing.title')}
+          description={t('seo.app.billing.description')}
+          path="/billing"
+        />
         <AppPageHeader title={t('billing.title')} description={t('billing.subtitle')} />
         <div className="bg-red-50 border border-red-200 rounded-xl p-5 text-sm text-red-700">
           {subscriptionQuery.error instanceof Error
@@ -353,6 +359,11 @@ export default function BillingPage() {
 
   return (
     <AppPageShell activePage="billing">
+      <SeoHead
+        title={t('seo.app.billing.title')}
+        description={t('seo.app.billing.description')}
+        path="/billing"
+      />
       <AppPageHeader title={t('billing.title')} description={t('billing.subtitle')} />
 
       <div className="flex flex-col gap-6">

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -7,6 +7,7 @@ import { useRequestPasswordResetMutation } from '@/hooks/usePasswordRecovery';
 import { AuthLayout } from '@/components/layout/AuthLayout';
 import { AuthPageIntro } from '@/components/layout/AuthPageIntro';
 import { AuthPageFooter } from '@/components/layout/AuthPageFooter';
+import { SeoHead } from '@/components/seo/SeoHead';
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('');
@@ -36,6 +37,11 @@ export default function ForgotPasswordPage() {
 
   return (
     <AuthLayout>
+      <SeoHead
+        title={t('seo.auth.forgotPassword.title')}
+        description={t('seo.auth.forgotPassword.description')}
+        path="/forgot-password"
+      />
       {/* Back Link */}
       <Link
         href="/login"

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -10,6 +10,7 @@ import { VideoCard } from '@/components/video/VideoCard';
 import { queryKeys } from '@/lib/queryKeys';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { useTranslation } from 'react-i18next';
 import {
   Upload, Film, Users, ArrowRight, Lightbulb,
@@ -89,6 +90,11 @@ export default function HomePage() {
 
   return (
     <AppPageShell activePage="home">
+      <SeoHead
+        title={t('seo.app.home.title')}
+        description={t('seo.app.home.description')}
+        path="/"
+      />
       <AppPageHeader
         title={t('home.welcome.greeting', { username: currentUser?.username })}
         description={t('home.welcome.dailyMotivation')}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -8,6 +8,7 @@ import { InlineSpinner } from '@/components/common/InlineSpinner';
 import { AuthLayout } from '@/components/layout/AuthLayout';
 import { AuthPageIntro } from '@/components/layout/AuthPageIntro';
 import { AuthPageFooter } from '@/components/layout/AuthPageFooter';
+import { SeoHead } from '@/components/seo/SeoHead';
 
 export default function LoginPage() {
   const navigate = useI18nNavigate();
@@ -24,6 +25,11 @@ export default function LoginPage() {
 
   return (
     <AuthLayout>
+      <SeoHead
+        title={t('seo.auth.login.title')}
+        description={t('seo.auth.login.description')}
+        path="/login"
+      />
       <AuthPageIntro badge={t('auth.login.badge')} title={t('auth.login.title')} />
 
       {/* Error Message */}

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -8,6 +8,7 @@ import { AuthPageIntro } from '@/components/layout/AuthPageIntro';
 import { AuthPageFooter } from '@/components/layout/AuthPageFooter';
 import { InlineSpinner } from '@/components/common/InlineSpinner';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { useConfirmPasswordResetMutation } from '@/hooks/usePasswordRecovery';
 
 function ResetPasswordContent() {
@@ -57,6 +58,11 @@ function ResetPasswordContent() {
 
   return (
     <AuthLayout>
+      <SeoHead
+        title={t('seo.auth.resetPassword.title')}
+        description={t('seo.auth.resetPassword.description')}
+        path="/reset-password"
+      />
       <Link
         href="/login"
         className="inline-flex items-center text-[#00652c] font-bold text-sm mb-12 hover:opacity-80 transition-opacity"

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { apiClient, ApiError, type IntegrationApiKeyCreateResponse } from '@/lib
 import { queryKeys } from '@/lib/queryKeys';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { InlineSpinner } from '@/components/common/InlineSpinner';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { Input } from '@/components/ui/input';
@@ -231,6 +232,11 @@ export default function SettingsPage() {
 
   return (
     <AppPageShell activePage="settings">
+      <SeoHead
+        title={t('seo.app.settings.title')}
+        description={t('seo.app.settings.description')}
+        path="/settings"
+      />
       <AppPageHeader
         title={t('settings.title')}
         description={t('settings.subtitle')}

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -8,6 +8,7 @@ import {
 import { Link } from '@/lib/i18n';
 import { apiClient, type VideoInGroup } from '@/lib/api';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { ChatPanel } from '@/components/chat/ChatPanel';
 import { convertVideoInGroupToSelectedVideo, type SelectedVideo } from '@/lib/utils/videoConversion';
 import { useVideoPlayback } from '@/hooks/useVideoPlayback';
@@ -148,10 +149,16 @@ export default function SharePage() {
   // ── Main ───────────────────────────────────────────────────────────────────
 
   return (
-    <div
-      className="bg-[#f8faf5] flex flex-col"
-      style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
-    >
+    <>
+      <SeoHead
+        title={`${group.name} | VideoQ`}
+        description={group.description || t('seo.shared.description')}
+        path={`/share/${shareToken}`}
+      />
+      <div
+        className="bg-[#f8faf5] flex flex-col"
+        style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+      >
       {/* ── Fixed Header ────────────────────────────────────────────────── */}
       <header className="fixed top-0 w-full bg-white/80 backdrop-blur-xl border-b border-stone-200/60 z-50">
         <div className="max-w-screen-xl px-6 lg:px-8 mx-auto w-full flex justify-between items-center py-4">
@@ -302,6 +309,7 @@ export default function SharePage() {
           );
         })}
       </nav>
-    </div>
+      </div>
+    </>
   );
 }

--- a/frontend/src/pages/SignupCheckEmailPage.tsx
+++ b/frontend/src/pages/SignupCheckEmailPage.tsx
@@ -4,12 +4,18 @@ import { Mail } from 'lucide-react';
 import { AuthLayout } from '@/components/layout/AuthLayout';
 import { AuthPageIntro } from '@/components/layout/AuthPageIntro';
 import { AuthPageFooter } from '@/components/layout/AuthPageFooter';
+import { SeoHead } from '@/components/seo/SeoHead';
 
 export default function SignupCheckEmailPage() {
   const { t } = useTranslation();
 
   return (
     <AuthLayout>
+      <SeoHead
+        title={t('seo.auth.checkEmail.title')}
+        description={t('seo.auth.checkEmail.description')}
+        path="/signup/check-email"
+      />
       <div className="space-y-6">
         <AuthPageIntro
           badge={t('auth.checkEmail.badge')}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -8,6 +8,7 @@ import { InlineSpinner } from '@/components/common/InlineSpinner';
 import { AuthLayout } from '@/components/layout/AuthLayout';
 import { AuthPageIntro } from '@/components/layout/AuthPageIntro';
 import { AuthPageFooter } from '@/components/layout/AuthPageFooter';
+import { SeoHead } from '@/components/seo/SeoHead';
 
 export default function SignupPage() {
   const navigate = useI18nNavigate();
@@ -32,6 +33,11 @@ export default function SignupPage() {
 
   return (
     <AuthLayout>
+      <SeoHead
+        title={t('seo.auth.signup.title')}
+        description={t('seo.auth.signup.description')}
+        path="/signup"
+      />
       <AuthPageIntro badge={t('auth.signup.badge')} title={t('auth.signup.title')} />
 
       {/* Error Message */}

--- a/frontend/src/pages/VerifyEmailPage.tsx
+++ b/frontend/src/pages/VerifyEmailPage.tsx
@@ -8,6 +8,7 @@ import { AuthPageIntro } from '@/components/layout/AuthPageIntro';
 import { AuthPageFooter } from '@/components/layout/AuthPageFooter';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { InlineSpinner } from '@/components/common/InlineSpinner';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { useVerifyEmailQuery } from '@/hooks/useVerifyEmailData';
 
 type VerificationState = 'loading' | 'success' | 'error';
@@ -56,6 +57,11 @@ function VerifyEmailContent() {
 
   return (
     <AuthLayout>
+      <SeoHead
+        title={t('seo.auth.verifyEmail.title')}
+        description={t('seo.auth.verifyEmail.description')}
+        path="/verify-email"
+      />
       <Link
         href="/login"
         className="inline-flex items-center text-[#00652c] font-bold text-sm mb-12 hover:opacity-80 transition-opacity"

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -6,6 +6,7 @@ import { useVideo } from '@/hooks/useVideos';
 import { apiClient } from '@/lib/api';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { InlineSpinner } from '@/components/common/InlineSpinner';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { formatDate } from '@/lib/utils/video';
 import { TagSelector } from '@/components/video/TagSelector';
 import { TagCreateDialog } from '@/components/video/TagCreateDialog';
@@ -297,10 +298,16 @@ export default function VideoDetailPage() {
   const isPlainTextTranscript = video.transcript?.trim() && !isSRTFormat(video.transcript);
 
   return (
-    <div
-      className="bg-[#f8faf5] h-screen flex flex-col overflow-hidden"
-      style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
-    >
+    <>
+      <SeoHead
+        title={`${video.title} | VideoQ`}
+        description={video.description || t('seo.app.videoDetail.description')}
+        path={`/videos/${video.id}`}
+      />
+      <div
+        className="bg-[#f8faf5] h-screen flex flex-col overflow-hidden"
+        style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+      >
       {/* ── Header ───────────────────────────────────────────────────────── */}
       <header className="fixed top-0 w-full bg-white/80 backdrop-blur-xl border-b border-stone-200/60 z-50">
         <div className="max-w-screen-xl px-6 lg:px-8 mx-auto w-full flex justify-between items-center py-4">
@@ -592,6 +599,7 @@ export default function VideoDetailPage() {
         onClose={() => setIsCreateDialogOpen(false)}
         onCreate={handleCreateTag}
       />
-    </div>
+      </div>
+    </>
   );
 }

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -28,6 +28,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Checkbox } from '@/components/ui/checkbox';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { InlineSpinner } from '@/components/common/InlineSpinner';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { Link, useI18nNavigate } from '@/lib/i18n';
 import { handleAsyncError } from '@/lib/utils/errorHandling';
 import { convertVideoInGroupToSelectedVideo, type SelectedVideo } from '@/lib/utils/videoConversion';
@@ -570,10 +571,16 @@ export default function VideoGroupDetailPage() {
   };
 
   return (
-    <div
-      className="bg-[#f8faf5] flex flex-col"
-      style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
-    >
+    <>
+      <SeoHead
+        title={`${group.name} | VideoQ`}
+        description={group.description || t('seo.app.groupDetail.description')}
+        path={`/videos/groups/${group.id}`}
+      />
+      <div
+        className="bg-[#f8faf5] flex flex-col"
+        style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+      >
       {/* ── Fixed Header ─────────────────────────────────────────────────── */}
       <header className="fixed top-0 w-full bg-white/80 backdrop-blur-xl border-b border-stone-200/60 z-50">
         <div className="max-w-screen-xl px-6 lg:px-8 mx-auto w-full flex justify-between items-center py-4">
@@ -829,6 +836,7 @@ export default function VideoGroupDetailPage() {
         groupId={groupId}
         group={group}
       />
-    </div>
+      </div>
+    </>
   );
 }

--- a/frontend/src/pages/VideoGroupsPage.tsx
+++ b/frontend/src/pages/VideoGroupsPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useI18nNavigate } from '@/lib/i18n';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { useAuth } from '@/hooks/useAuth';
 import { useVideoGroups } from '@/hooks/useVideoGroups';
@@ -26,6 +27,11 @@ export default function VideoGroupsPage() {
 
   return (
     <AppPageShell activePage="groups">
+      <SeoHead
+        title={t('seo.app.groups.title')}
+        description={t('seo.app.groups.description')}
+        path="/videos/groups"
+      />
       <AppPageHeader
         title={t('videos.groups.title')}
         description={t('videos.groups.subtitle')}

--- a/frontend/src/pages/VideosPage.tsx
+++ b/frontend/src/pages/VideosPage.tsx
@@ -12,6 +12,7 @@ import { useI18nNavigate } from '@/lib/i18n';
 import { useTags } from '@/hooks/useTags';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
+import { SeoHead } from '@/components/seo/SeoHead';
 import { Plus, Search, Tag } from 'lucide-react';
 
 type StatusFilter = 'all' | 'completed' | 'processing' | 'error';
@@ -89,6 +90,11 @@ export default function VideosPage() {
 
   return (
     <AppPageShell activePage="videos">
+      <SeoHead
+        title={t('seo.app.videos.title')}
+        description={t('seo.app.videos.description')}
+        path="/videos"
+      />
       <AppPageHeader
         title={t('videos.list.title')}
         description={t('videos.list.managingCount', { count: stats.total })}

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -131,6 +131,36 @@ describe('HomePage - authenticated', () => {
       expect(apiClient.getVideoGroups).toHaveBeenCalled()
     })
   })
+
+  it('sets authenticated metadata in english', async () => {
+    globalThis.__setMockLanguage('en')
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('Home | VideoQ')
+    })
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'View your VideoQ dashboard, recent uploads, and quick actions for managing videos and groups.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/'
+    )
+  })
+
+  it('switches authenticated metadata for japanese locale', async () => {
+    globalThis.__setMockLanguage('ja')
+    render(<HomePage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('ホーム | VideoQ')
+    })
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ のダッシュボードで、最近のアップロード、動画管理、グループ管理へのクイック操作を確認できます。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/'
+    )
+  })
 })
 
 describe('HomePage - Data Loading', () => {
@@ -158,6 +188,10 @@ describe('HomePage - unauthenticated', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ;(apiClient.getMeOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+  })
+
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
   })
 
   it('should render landing page hero when user is not authenticated', async () => {

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -18,6 +18,10 @@ describe('LoginPage', () => {
     mockNavigate = useI18nNavigate() as ReturnType<typeof vi.fn>
   })
 
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   it('should render login form', () => {
     render(<LoginPage />)
 
@@ -54,7 +58,7 @@ describe('LoginPage', () => {
   })
 
   it('should call apiClient.login on submit', async () => {
-    ; (apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
+    ;(apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<LoginPage />)
 
@@ -73,7 +77,7 @@ describe('LoginPage', () => {
   })
 
   it('should navigate to home on successful login', async () => {
-    ; (apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
+    ;(apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<LoginPage />)
 
@@ -97,5 +101,31 @@ describe('LoginPage', () => {
     const container = screen.getByText('auth.login.title').closest('main')
     expect(container).toBeInTheDocument()
     expect(container).toHaveClass('flex', 'min-h-screen', 'flex-col')
+  })
+
+  it('sets english metadata', () => {
+    globalThis.__setMockLanguage('en')
+    render(<LoginPage />)
+
+    expect(document.title).toBe('Log In | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Log in to VideoQ to manage videos, search transcripts with AI, and access your learning workspace.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/login'
+    )
+  })
+
+  it('switches metadata for japanese locale', () => {
+    globalThis.__setMockLanguage('ja')
+    render(<LoginPage />)
+
+    expect(document.title).toBe('ログイン | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ にログインして、動画管理、AI による文字起こし検索、学習ワークスペースにアクセスできます。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/login'
+    )
   })
 })

--- a/frontend/src/pages/__tests__/ResetPasswordPage.test.tsx
+++ b/frontend/src/pages/__tests__/ResetPasswordPage.test.tsx
@@ -22,6 +22,10 @@ describe('ResetPasswordPage', () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   it('should render page title', () => {
     render(<ResetPasswordPage />)
 
@@ -56,6 +60,32 @@ describe('ResetPasswordPage', () => {
     render(<ResetPasswordPage />)
 
     expect(screen.getByText('auth.resetPassword.backToLogin')).toBeInTheDocument()
+  })
+
+  it('sets english metadata', () => {
+    globalThis.__setMockLanguage('en')
+    render(<ResetPasswordPage />)
+
+    expect(document.title).toBe('Set a New Password | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Set a new password to restore access to your VideoQ account.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/reset-password'
+    )
+  })
+
+  it('switches metadata for japanese locale', () => {
+    globalThis.__setMockLanguage('ja')
+    render(<ResetPasswordPage />)
+
+    expect(document.title).toBe('新しいパスワードを設定 | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ アカウントに再度アクセスするため、新しいパスワードを設定します。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/reset-password'
+    )
   })
 
   it('should call confirmPasswordReset on submit', async () => {

--- a/frontend/src/pages/__tests__/SharePage.test.tsx
+++ b/frontend/src/pages/__tests__/SharePage.test.tsx
@@ -38,6 +38,10 @@ describe('SharePage', () => {
       ; (apiClient.getSharedGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
   })
 
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   it('should render group name', async () => {
     render(<SharePage />)
 
@@ -114,6 +118,36 @@ describe('SharePage', () => {
       expect(iframe).not.toBeNull()
       expect(iframe?.getAttribute('src')).toBe('https://www.youtube.com/embed/dQw4w9WgXcQ')
     })
+  })
+
+  it('sets english metadata', async () => {
+    globalThis.__setMockLanguage('en')
+    render(<SharePage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('Shared Group | VideoQ')
+    })
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Shared Description'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/share/test-share-token'
+    )
+  })
+
+  it('switches metadata for japanese locale', async () => {
+    globalThis.__setMockLanguage('ja')
+    render(<SharePage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('Shared Group | VideoQ')
+    })
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Shared Description'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/share/test-share-token'
+    )
   })
 })
 

--- a/frontend/src/pages/__tests__/SignupCheckEmailPage.test.tsx
+++ b/frontend/src/pages/__tests__/SignupCheckEmailPage.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react'
 import SignupCheckEmailPage from '../SignupCheckEmailPage'
 
 describe('SignupCheckEmailPage', () => {
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   it('should render page title', () => {
     render(<SignupCheckEmailPage />)
 
@@ -37,5 +41,31 @@ describe('SignupCheckEmailPage', () => {
 
     const container = screen.getByText('auth.checkEmail.title').closest('div')
     expect(container).toBeInTheDocument()
+  })
+
+  it('sets english metadata', () => {
+    globalThis.__setMockLanguage('en')
+    render(<SignupCheckEmailPage />)
+
+    expect(document.title).toBe('Check Your Email | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Check your inbox to verify your email address and finish creating your VideoQ account.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/signup/check-email'
+    )
+  })
+
+  it('switches metadata for japanese locale', () => {
+    globalThis.__setMockLanguage('ja')
+    render(<SignupCheckEmailPage />)
+
+    expect(document.title).toBe('メールをご確認ください | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      '受信メールを確認して、メールアドレス認証を完了し、VideoQ アカウント登録を完了してください。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/signup/check-email'
+    )
   })
 })

--- a/frontend/src/pages/__tests__/VerifyEmailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VerifyEmailPage.test.tsx
@@ -22,6 +22,10 @@ describe('VerifyEmailPage', () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   it('should render page title', () => {
     ; (apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockImplementation(
       () => new Promise(() => { })
@@ -109,6 +113,40 @@ describe('VerifyEmailPage', () => {
       expect(screen.getByText('Invalid token')).toBeInTheDocument()
     }, { timeout: 3000 })
   }, 10000)
+
+  it('sets english metadata', () => {
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => { })
+    )
+    globalThis.__setMockLanguage('en')
+
+    render(<VerifyEmailPage />)
+
+    expect(document.title).toBe('Verify Your Email | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Verify your email address to activate your VideoQ account.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/verify-email'
+    )
+  })
+
+  it('switches metadata for japanese locale', () => {
+    ;(apiClient.verifyEmail as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => { })
+    )
+    globalThis.__setMockLanguage('ja')
+
+    render(<VerifyEmailPage />)
+
+    expect(document.title).toBe('メールアドレス認証 | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ アカウントを有効化するため、メールアドレス認証を行います。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/verify-email'
+    )
+  })
 })
 
 describe('VerifyEmailPage - API Calls', () => {

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -58,6 +58,10 @@ describe('VideoDetailPage', () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   it('should render video title', () => {
     render(<VideoDetailPage />)
 
@@ -115,6 +119,32 @@ describe('VideoDetailPage', () => {
     render(<VideoDetailPage />)
 
     expect(mockLoadVideo).not.toHaveBeenCalled()
+  })
+
+  it('sets english metadata', () => {
+    globalThis.__setMockLanguage('en')
+    render(<VideoDetailPage />)
+
+    expect(document.title).toBe('Test Video | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Test Description'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/videos/1'
+    )
+  })
+
+  it('switches metadata for japanese locale', () => {
+    globalThis.__setMockLanguage('ja')
+    render(<VideoDetailPage />)
+
+    expect(document.title).toBe('Test Video | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Test Description'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/videos/1'
+    )
   })
 })
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -62,6 +62,10 @@ describe('VideoGroupDetailPage', () => {
       ; (apiClient.getVideos as ReturnType<typeof vi.fn>).mockResolvedValue([])
   })
 
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   it('should render group name', async () => {
     render(<VideoGroupDetailPage />)
 
@@ -190,6 +194,36 @@ describe('VideoGroupDetailPage', () => {
       expect(iframe).not.toBeNull()
       expect(iframe?.getAttribute('src')).toBe('https://www.youtube.com/embed/dQw4w9WgXcQ')
     })
+  })
+
+  it('sets english metadata', async () => {
+    globalThis.__setMockLanguage('en')
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('Test Group | VideoQ')
+    })
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Test Description'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/videos/groups/1'
+    )
+  })
+
+  it('switches metadata for japanese locale', async () => {
+    globalThis.__setMockLanguage('ja')
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('Test Group | VideoQ')
+    })
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Test Description'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/videos/groups/1'
+    )
   })
 })
 

--- a/frontend/src/pages/__tests__/VideoGroupsPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupsPage.test.tsx
@@ -28,6 +28,10 @@ describe('VideoGroupsPage', () => {
       ; (apiClient.getVideoGroups as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroups)
   })
 
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   it('should render page title', async () => {
     render(<VideoGroupsPage />)
 
@@ -137,6 +141,36 @@ describe('VideoGroupsPage', () => {
     await waitFor(() => {
       expect(screen.queryByText('videos.groups.createTitle')).not.toBeInTheDocument()
     })
+  })
+
+  it('sets english metadata', async () => {
+    globalThis.__setMockLanguage('en')
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('Group Management | VideoQ')
+    })
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Create and manage video groups for searchable AI chat and shared learning flows.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/videos/groups'
+    )
+  })
+
+  it('switches metadata for japanese locale', async () => {
+    globalThis.__setMockLanguage('ja')
+    render(<VideoGroupsPage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('グループ管理 | VideoQ')
+    })
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'AI チャットや共有学習フローに使う動画グループを作成・管理できます。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/videos/groups'
+    )
   })
 })
 

--- a/frontend/src/pages/__tests__/VideosPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideosPage.test.tsx
@@ -67,6 +67,10 @@ describe('VideosPage', () => {
     mockLoadVideos.mockClear()
   })
 
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
   it('should render page title', () => {
     render(<VideosPage />)
 
@@ -140,6 +144,32 @@ describe('VideosPage', () => {
 
     const statCards = screen.getAllByText(/^\d+$/)
     expect(statCards.length).toBeGreaterThan(0)
+  })
+
+  it('sets english metadata', () => {
+    globalThis.__setMockLanguage('en')
+    render(<VideosPage />)
+
+    expect(document.title).toBe('Video Library | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Browse, search, and manage your uploaded videos in VideoQ.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/videos'
+    )
+  })
+
+  it('switches metadata for japanese locale', () => {
+    globalThis.__setMockLanguage('ja')
+    render(<VideosPage />)
+
+    expect(document.title).toBe('動画ライブラリ | VideoQ')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'VideoQ にアップロードした動画を一覧・検索・管理できます。'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://videoq.jp/ja/videos'
+    )
   })
 })
 


### PR DESCRIPTION
## 概要

`develop` から `main` への差分として、アプリ内の主要ページに `SeoHead` を追加し、英語・日本語のローカライズに対応した title / description / canonical を設定しました。

あわせて、各ページのメタデータが正しく切り替わることを確認するテストを追加しています。

## 変更内容

- 各アプリ内ページに `SeoHead` を追加
  - Home
  - Videos
  - Video Groups
  - Video Detail
  - Video Group Detail
  - Settings
  - Billing
  - Login
  - Signup
  - Signup Check Email
  - Forgot Password
  - Reset Password
  - Verify Email
  - Share
- `ja` / `en` の翻訳ファイルに SEO 用文言を追加
- 動的ページではページ固有の内容をメタデータへ反映
  - 動画詳細: 動画タイトル・説明
  - グループ詳細: グループ名・説明
  - 共有ページ: 共有グループ名・説明
- ロケールごとの canonical URL 切り替えをテストで検証
  - `en`: `https://videoq.jp/...`
  - `ja`: `https://videoq.jp/ja/...`

## 変更理由

- アプリ内ページでも検索エンジンやSNS共有時に適切なメタ情報を返せるようにするため
- 日本語・英語それぞれで自然な title / description を出し分けるため
- canonical をロケール付き URL に合わせて統一し、インデックスの整合性を高めるため

## 影響範囲

- フロントエンドのみ
- UI 表示への影響は限定的で、主に `<head>` 内のメタデータ更新
- 既存ページ構成や主要な画面操作フローへの機能影響はなし

## テスト

- ページごとの SEO メタデータ設定テストを追加
- `document.title`
- `meta[name="description"]`
- `link[rel="canonical"]`
- 英語 / 日本語ロケール切り替え時の動作

## 確認観点

- 各ページで title / description が意図通りに設定されること
- 日本語表示時に canonical が `/ja/...` になること
- 動的ページでタイトルや説明に対象データが反映されること
- 共有ページ・動画詳細・グループ詳細でフォールバック文言が正しく使われること
