### PR TITLE
fix: GSC インデックス問題の修正 — legacy リダイレクト・/en/ 除去・robots.txt ja ルール追加

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -24,6 +24,15 @@ Disallow: /reset-password
 Disallow: /verify-email
 Disallow: /share/
 Disallow: /api/
+Disallow: /ja/videos
+Disallow: /ja/settings
+Disallow: /ja/billing
+Disallow: /ja/login
+Disallow: /ja/signup
+Disallow: /ja/forgot-password
+Disallow: /ja/reset-password
+Disallow: /ja/verify-email
+Disallow: /ja/share/
 Allow: /
 
 Sitemap: https://videoq.jp/sitemap.xml

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,12 @@ function LocaleGate() {
     return <Navigate to="/" replace />;
   }
 
+  // Strip redundant default-locale prefix (/en/foo → /foo).
+  if (locale === defaultLocale) {
+    const withoutLocale = location.pathname.replace(/^\/[^/]+(\/|$)/, '$1') || '/';
+    return <Navigate to={withoutLocale + location.search} replace />;
+  }
+
   // If user prefers non-default locale, redirect to /:locale/... automatically.
   if (!locale) {
     const preferred = getPreferredLocale();
@@ -93,6 +99,8 @@ export default function App() {
         </Route>
 
         {/* Legacy URL redirects */}
+        <Route path="legal/privacy" element={<Navigate to="/privacy" replace />} />
+        <Route path="legal/terms" element={<Navigate to="/terms" replace />} />
         <Route path="legal/commercial-disclosure" element={<Navigate to="/commercial-disclosure" replace />} />
         <Route path="ja/legal/commercial-disclosure" element={<Navigate to="/ja/commercial-disclosure" replace />} />
 


### PR DESCRIPTION
## Summary

- `/legal/privacy` と `/legal/terms` の legacy リダイレクトを追加（`*` フォールバックで `/` に飛んでいたのを正しい `/privacy`・`/terms` に修正）
- `LocaleGate` に `/en/foo → /foo` のリダイレクトを追加し、Google が `/en/` を「代替ページ」と誤認する問題を解消
- `robots.txt` に `/ja/login`、`/ja/signup` など `/ja/*` の認証ページ Disallow ルールを追加（これまで `/login` のみ禁止で `/ja/login` はクロール可能だった）

## Background

Google Search Console で以下の3つのインデックス問題が検出されたため対応:

| 問題 | 該当 URL | 原因 |
|------|----------|------|
| ページにリダイレクトがあります | `/legal/privacy`, `/legal/terms` | `*` フォールバックで `/` へ誤リダイレクト |
| 代替ページ（適切な canonical タグあり） | `/en/`, `/ja/login` など | `/en/` が separate URL として存在、`/ja/login` がクロールされていた |
| クロール済み - インデックス未登録 | `/ja/signup`, `/en/signup` など | robots.txt に locale prefix 付きルールがなかった |

## Test plan

- [ ] `/legal/privacy` にアクセス → `/privacy` にリダイレクトされることを確認
- [ ] `/legal/terms` にアクセス → `/terms` にリダイレクトされることを確認
- [ ] `/en/` にアクセス → `/` にリダイレクトされることを確認
- [ ] `/en/docs` にアクセス → `/docs` にリダイレクトされることを確認
- [ ] `/ja/login` が robots.txt で Disallow されていることを確認
- [ ] 日本語ユーザーが `/ja/docs` などの正規ページにアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)