### PR TITLE
SEO: localized metadata, GSC indexing fixes, robots.txt ja rules

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -24,6 +24,15 @@ Disallow: /reset-password
 Disallow: /verify-email
 Disallow: /share/
 Disallow: /api/
+Disallow: /ja/videos
+Disallow: /ja/settings
+Disallow: /ja/billing
+Disallow: /ja/login
+Disallow: /ja/signup
+Disallow: /ja/forgot-password
+Disallow: /ja/reset-password
+Disallow: /ja/verify-email
+Disallow: /ja/share/
 Allow: /
 
 Sitemap: https://videoq.jp/sitemap.xml

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,12 @@ function LocaleGate() {
     return <Navigate to="/" replace />;
   }
 
+  // Strip redundant default-locale prefix (/en/foo → /foo).
+  if (locale === defaultLocale) {
+    const withoutLocale = location.pathname.replace(/^\/[^/]+(\/|$)/, '$1') || '/';
+    return <Navigate to={withoutLocale + location.search} replace />;
+  }
+
   // If user prefers non-default locale, redirect to /:locale/... automatically.
   if (!locale) {
     const preferred = getPreferredLocale();
@@ -93,6 +99,8 @@ export default function App() {
         </Route>
 
         {/* Legacy URL redirects */}
+        <Route path="legal/privacy" element={<Navigate to="/privacy" replace />} />
+        <Route path="legal/terms" element={<Navigate to="/terms" replace />} />
         <Route path="legal/commercial-disclosure" element={<Navigate to="/commercial-disclosure" replace />} />
         <Route path="ja/legal/commercial-disclosure" element={<Navigate to="/ja/commercial-disclosure" replace />} />
 


### PR DESCRIPTION
## Summary

- **ローカライズされたSEOメタデータの追加**: 全ページ（HomePage, LoginPage, SignupPage, BillingPage, VideoDetailPage, SharePage など）に `<title>` / `<meta name="description">` を i18n キー経由で設定。en/ja 翻訳ファイルに対応するキーを追加
- **GSCインデックス問題の修正**: `/en/` プレフィックスを自動的にデフォルトロケール（`/`）へリダイレクト（`/en/foo → /foo`）。`/legal/privacy` / `/legal/terms` のレガシーURLリダイレクトを追加
- **robots.txt の日本語ルール追加**: `/ja/` 配下の認証・プライベートルートを `Disallow` に追加し、クローラーが不要なページをインデックスしないよう設定

## Test plan

- [ ] 各ページで `<title>` が言語に応じて正しく表示されること（en/ja）
- [ ] `/en/foo` へアクセスすると `/foo` へリダイレクトされること
- [ ] `/legal/privacy` → `/privacy`、`/legal/terms` → `/terms` へリダイレクトされること
- [ ] `robots.txt` の `/ja/` Disallow ルールが正しく反映されていること
- [ ] フロントエンドのページテスト（`__tests__/`）が全てパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)