### PR TITLE
fix: VideoGroupDetailPage のレイアウト余白・チャットヘッダー整列を修正

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -262,10 +262,10 @@ export function ChatPanel({ groupId, onVideoPlay, shareToken, className }: ChatP
   return (
     <div className={containerClass}>
       {/* Header */}
-      <div className="p-4 border-b border-stone-100 shrink-0">
-        <h2 className="font-extrabold text-[#191c19]">{t('chat.title')}</h2>
+      <div className="px-4 py-3 border-b border-stone-100 shrink-0 flex items-center justify-between gap-4">
+        <h2 className="font-extrabold text-[#191c19] shrink-0">{t('chat.title')}</h2>
         {showTabs && (
-          <div className="flex gap-4 mt-3">
+          <div className="flex gap-4">
             <button
               onClick={() => setTab('chat')}
               className={`text-xs font-bold pb-1 transition-colors ${

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -681,7 +681,7 @@ export default function VideoGroupDetailPage() {
       </Dialog>
 
       {/* ── Main ─────────────────────────────────────────────────────────── */}
-      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-0 lg:h-[calc(100dvh-4rem)] lg:overflow-hidden">
+      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-4 lg:h-[calc(100dvh-4rem)] lg:overflow-hidden">
         {/* Share link panel */}
         <ShareLinkPanel
           shareSlug={group.share_slug ?? ''}


### PR DESCRIPTION
## Summary

- デスクトップ表示で動画プレイヤーカードの下端がビューポート端で切れていた問題を修正
- チャットパネルのヘッダーが他パネル（動画一覧・プレイヤー）より縦に長く、視覚的にずれて見えていた問題を修正

## Changes

### `VideoGroupDetailPage.tsx`
- `<main>` の `lg:pb-0` → `lg:pb-4` に変更
  - デスクトップの固定高さレイアウト（`lg:h-[calc(100dvh-4rem)]`）で下端パディングが 0 だったため、プレイヤーカードがビューポート端まで到達し切れて見えていた

### `ChatPanel.tsx`
- ヘッダーのタイトルとタブを縦積み → 横並び（`flex items-center justify-between`）に変更
- `p-4`（上下 16px）→ `px-4 py-3`（上下 12px）に変更
  - 動画一覧・プレイヤーのヘッダー高さ（約 52px）と揃え、3カラム間の視覚的な整列を改善

## Test plan

- [x] デスクトップ表示で `/ja/videos/groups/:id` を開き、プレイヤーカードの下端に適切な余白があることを確認
- [x] チャットパネルのヘッダー（チャット + タブ）が横一行で表示されることを確認
- [x] チャットパネルのヘッダー高さが動画一覧・プレイヤーのヘッダーと視覚的に揃っていることを確認
- [x] モバイル表示で崩れがないことを確認（`pb-16` のモバイル余白は変更なし）
- [x] チャットの新規相談・会話履歴タブの切り替えが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)