### PR TITLE
fix: improve VideoGroupDetailPage layout spacing and chat header alignment

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -262,10 +262,10 @@ export function ChatPanel({ groupId, onVideoPlay, shareToken, className }: ChatP
   return (
     <div className={containerClass}>
       {/* Header */}
-      <div className="p-4 border-b border-stone-100 shrink-0">
-        <h2 className="font-extrabold text-[#191c19]">{t('chat.title')}</h2>
+      <div className="px-4 py-3 border-b border-stone-100 shrink-0 flex items-center justify-between gap-4">
+        <h2 className="font-extrabold text-[#191c19] shrink-0">{t('chat.title')}</h2>
         {showTabs && (
-          <div className="flex gap-4 mt-3">
+          <div className="flex gap-4">
             <button
               onClick={() => setTab('chat')}
               className={`text-xs font-bold pb-1 transition-colors ${

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -681,7 +681,7 @@ export default function VideoGroupDetailPage() {
       </Dialog>
 
       {/* ── Main ─────────────────────────────────────────────────────────── */}
-      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-0 lg:h-[calc(100dvh-4rem)] lg:overflow-hidden">
+      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-4 lg:h-[calc(100dvh-4rem)] lg:overflow-hidden">
         {/* Share link panel */}
         <ShareLinkPanel
           shareSlug={group.share_slug ?? ''}


### PR DESCRIPTION
## Summary

- `VideoGroupDetailPage`: `lg:pb-0` → `lg:pb-4` to add bottom padding on desktop
- `ChatPanel`: チャットヘッダーを `flex items-center justify-between` レイアウトに変更し、タイトルとタブを横並びに配置。パディングも `p-4` → `px-4 py-3` に調整

## Test plan

- [x] デスクトップ表示でビデオグループ詳細ページのレイアウト確認
- [x] チャットヘッダーのタイトルとタブが横並びに正しく表示されることを確認
- [x] モバイル表示での崩れがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)