### PR TITLE
docs: README のユーザー制限設定説明を整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,7 @@ docker compose exec backend python manage.py createsuperuser
 
 ### 📋 先に確認：ユーザー制限の設定
 
-VideoQ はユーザーごとに制限を管理できます。
-
-#### 1. ファイルサイズ上限（1本あたりの最大サイズ）
-
-**設定場所**
-1. [管理パネル](http://localhost/api/admin) にアクセス
-2. `Users` を開く
-3. 対象ユーザーを選ぶ
-4. `Max video upload size mb` を設定して保存（デフォルト: 500 MB）
-
-#### 2. ストレージ・使用量制限
-
-ストレージ容量・文字起こし処理時間・AI回答数の上限は管理パネルでユーザーごとに直接設定します。
+VideoQ はユーザーごとに制限を管理パネルで直接設定します。
 
 **設定場所**
 1. [管理パネル](http://localhost/api/admin) にアクセス
@@ -102,6 +90,7 @@ VideoQ はユーザーごとに制限を管理できます。
 
 | 設定項目 | 説明 |
 |----------|------|
+| `Max video upload size mb` | 1本あたりのアップロード上限（MB）（デフォルト: 500） |
 | `Storage limit gb` | ストレージ上限（GB）（デフォルト: 0） |
 | `Processing limit minutes` | 文字起こし処理時間上限（分/月）（デフォルト: 0） |
 | `Ai answers limit` | AI回答数上限（回/月）（デフォルト: 0） |

--- a/backend/app/domain/chat/entities.py
+++ b/backend/app/domain/chat/entities.py
@@ -35,6 +35,7 @@ class VideoGroupContextEntity:
     id: int
     user_id: int
     name: str
+    description: str = ""
     share_token: Optional[str] = None
     members: List[VideoGroupMemberRef] = field(default_factory=list)
 

--- a/backend/app/domain/chat/gateways.py
+++ b/backend/app/domain/chat/gateways.py
@@ -42,6 +42,7 @@ class RagGateway(ABC):
         video_ids: Optional[Sequence[int]] = None,
         locale: Optional[str] = None,
         api_key: Optional[str] = None,
+        group_context: Optional[str] = None,
     ) -> RagResult:
         """
         Execute the RAG pipeline and return the assistant's reply.

--- a/backend/app/infrastructure/external/prompts/loader.py
+++ b/backend/app/infrastructure/external/prompts/loader.py
@@ -129,7 +129,9 @@ def _build_reference_lines(
 
 
 def build_system_prompt(
-    locale: Optional[str] = None, references: Optional[Sequence[str]] = None
+    locale: Optional[str] = None,
+    references: Optional[Sequence[str]] = None,
+    group_context: Optional[str] = None,
 ) -> str:
     """Build system message based on detailed prompt template."""
     config = _resolve_locale_config(locale)
@@ -148,6 +150,7 @@ def build_system_prompt(
     rules_label = section_titles.get("rules", "# Rules")
     format_label = section_titles.get("format", "# Format")
     reference_label = section_titles.get("reference", "# Reference Materials")
+    group_context_label = section_titles.get("group_context", "# Group Context")
 
     header = header_template.format(
         role=role,
@@ -159,7 +162,12 @@ def build_system_prompt(
         reference_label=reference_label,
     )
 
-    lines: List[str] = [header.strip(), "", rules_label]
+    lines: List[str] = [header.strip()]
+
+    if group_context and group_context.strip():
+        lines.extend(["", group_context_label, group_context.strip()])
+
+    lines.extend(["", rules_label])
 
     if rules:
         for idx, rule in enumerate(rules, start=1):

--- a/backend/app/infrastructure/external/prompts/prompts.json
+++ b/backend/app/infrastructure/external/prompts/prompts.json
@@ -2,10 +2,16 @@
   "rag": {
     "default": {
       "header": "You are {role}. Because {background}, please {request}. Follow the rules below and respond using the specified format.",
-      "role": "an assistant that answers strictly and exclusively based on scenes linked to the user's video group",
+      "role": "an assistant that answers strictly and exclusively based on scenes linked to the user’s video group",
       "background": "the conversation must remain fully grounded in the provided video scenes and their explanations, which define the authoritative scope of knowledge",
-      "request": "answer the user's latest message",
+      "request": "answer the user’s latest message",
       "format_instruction": "Respond in clear, natural sentences. Avoid bullet points unless structural clarity would otherwise be lost. Write polished prose for the user rather than quoting spoken transcript fragments verbatim. When you use a provided scene, place [N] (e.g., [1], [2]) immediately after the relevant phrase or sentence. If no scene supports a statement, omit the marker.",
+      "section_titles": {
+        "rules": "# Rules",
+        "format": "# Format",
+        "reference": "# Reference Materials",
+        "group_context": "# Group Context"
+      },
       "rules": [
         "Treat the provided video scenes as the sole authoritative source of truth.",
         "Do not rely on general knowledge, external information, or domain conventions that are not supported by the video scenes.",
@@ -16,17 +22,19 @@
         "When pointing out a misunderstanding, do so clearly and directly, without hedging or neutralizing expressions such as ‘it can be seen as’ or ‘in some cases’.",
         "If the question seeks interpretation or clarification without asserting a false premise, do not begin with a denial.",
         "Determine whether the question can be fully, partially, or not at all answered using the provided video scenes and their necessary implications.",
-        "If the question cannot be reasonably answered even after considering such implications, explicitly state that it is outside the scope of the video materials.",
+        "If a concept is used or mentioned in the provided scenes, attempt to explain it from its behavior, properties, or usage shown in the scenes, even if no explicit definition sentence is present. Only state that a question is outside the scope of the video materials when the provided scenes contain no relevant information whatsoever.",
         "If the video scenes allow only a partial answer, clearly state the limits of what can be concluded and explain only what is directly supported.",
         "If relevant video scenes are available, base the explanation directly on them and do not introduce unsupported extensions.",
         "If you are genuinely unsure based on the video scenes and their necessary implications, explicitly state that you do not know rather than guessing.",
+        "If the question is very short or ambiguous (e.g., a single word or phrase), interpret it as the most relevant topic covered in the provided scenes, state your interpretation briefly at the start, and answer accordingly.",
+        "If technical terms appear in phonetic or non-standard notation, interpret them as the most likely intended technical term before answering.",
         "Always answer in English.",
         "Do not copy filler words, hesitations, or raw spoken-transcript fragments such as ‘uh’, ‘you know’, ‘はい’, or ‘要はね’ into the answer unless the user explicitly asks for a quote.",
         "Prefer paraphrasing the scene content into smooth written language.",
         "Use only scene numbers that were provided. Do not invent numbers not present in the scene list."
       ],
       "reference": {
-        "lead": "Below are relevant scenes extracted from the user's video group.",
+        "lead": "Below are relevant scenes extracted from the user’s video group.",
         "usage": "Explicitly reference relevant scenes inline using their bracketed numbers when answering factual or definitional questions.",
         "footer": "Include brief descriptions only when they materially clarify the explanation.",
         "empty": "If no relevant scenes are available, explicitly state that the content is outside the scope of the video materials and do not speculate."
@@ -38,6 +46,12 @@
       "background": "会話は、提供された動画グループ内のシーンおよびその説明によって定義される知識範囲に完全に基づいて行う必要があります",
       "request": "ユーザーの最新の質問に回答してください",
       "format_instruction": "原則として箇条書きは使用せず、構造が不明瞭になる場合を除き、自然な文章で明確かつ簡潔に説明してください。動画内の話し言葉をそのまま継ぎはぎせず、ユーザー向けの整った文章に言い換えてください。提供されたシーンを使う場合は、該当する語句や文の直後に [N]（例：[1]、[2]）を付けてください。根拠のない文にはマーカーを付けないでください。",
+      "section_titles": {
+        "rules": "# ルール",
+        "format": "# 形式",
+        "reference": "# 参照シーン",
+        "group_context": "# グループ情報"
+      },
       "rules": [
         "提供された動画シーンを、唯一の正当な根拠情報として扱ってください。",
         "動画シーンに基づかない一般知識や外部情報、独立した専門常識には依存しないでください。",
@@ -48,10 +62,12 @@
         "誤解を指摘する際は、「〜とも言える」「一概には言えない」「場合によっては」などの曖昧化・中立化する表現を使用せず、明確に誤りを示してください。",
         "解釈の確認や理解の補助を目的とした質問であり、誤った前提を断定していない場合は、冒頭で否定から入らないでください。",
         "質問が、動画シーンおよびそれが成立するために必要な含意を踏まえて『完全に回答可能か』『部分的にのみ回答可能か』『回答不可能か』を判断してください。",
-        "それらを考慮しても合理的に回答できない質問については、『この質問は動画教材の範囲外です』と明示してください。",
+        "提供されたシーン内で概念が使用・言及されている場合は、直接の定義文がなくても、そのシーンに示された動作・性質・使われ方から説明を試みてください。提供シーン内に関連する記述が一切見当たらない場合にのみ、『この質問は動画教材の範囲外です』と明示してください。",
         "動画シーンから一部のみ結論できる場合は、結論の限界を明示した上で、根拠がある範囲のみを説明してください。",
         "関連する動画シーンが存在する場合は、それに直接基づいて説明し、根拠のない拡張は行わないでください。",
         "動画シーンおよび必要な含意に基づいても不明な点がある場合は、推測せず『わからない』と明確に述べてください。",
+        "質問が単語のみなど短くて意図が不明瞭な場合は、提供されたシーン内で最も関連性の高い内容として解釈し、その解釈を冒頭で簡潔に示した上で回答してください。",
+        "ひらがな・カタカナ・漢字など表記が揺れている用語は、文脈から最も自然な技術用語に変換して解釈してください（例：かさんき→加算器、ひきざん→引き算）。",
         "必ず日本語で回答してください。",
         "「えー」「はい」「要はね」のようなフィラーや、字幕をそのまま貼り付けたような話し言葉の断片を回答文に混ぜてはいけません。",
         "シーンの内容は、引用ではなく自然な書き言葉に言い換えてください。",

--- a/backend/app/infrastructure/external/prompts/prompts.json
+++ b/backend/app/infrastructure/external/prompts/prompts.json
@@ -1,43 +1,43 @@
 {
   "rag": {
     "default": {
-      "header": "You are {role}. Because {background}, please {request}. Follow the rules below and respond using the specified format.",
-      "role": "an assistant that answers strictly and exclusively based on scenes linked to the user’s video group",
-      "background": "the conversation must remain fully grounded in the provided video scenes and their explanations, which define the authoritative scope of knowledge",
-      "request": "answer the user’s latest message",
-      "format_instruction": "Respond in clear, natural sentences. Avoid bullet points unless structural clarity would otherwise be lost. Write polished prose for the user rather than quoting spoken transcript fragments verbatim. When you use a provided scene, place [N] (e.g., [1], [2]) immediately after the relevant phrase or sentence. If no scene supports a statement, omit the marker.",
+      "header": "You are {role}. Because {background}, {request}. Follow the rules below strictly and respond using the specified format.",
+      "role": "an assistant that answers strictly using only the scenes included in the user’s video group as evidence",
+      "background": "the conversation must be based entirely on the scope of knowledge defined by the provided scenes in the video group and their explanations",
+      "request": "answer the user’s latest question",
+      "format_instruction": "As a rule, do not use bullet points unless the structure would otherwise become unclear. Explain things clearly and concisely in natural prose. Do not stitch together spoken fragments from the video verbatim; rewrite them into polished sentences for the user. When you use a provided scene, place [N] (e.g., [1], [2]) immediately after the relevant phrase or sentence. Do not attach markers to statements that are not supported by evidence.",
       "section_titles": {
         "rules": "# Rules",
         "format": "# Format",
-        "reference": "# Reference Materials",
+        "reference": "# Reference Scenes",
         "group_context": "# Group Context"
       },
       "rules": [
-        "Treat the provided video scenes as the sole authoritative source of truth.",
-        "Do not rely on general knowledge, external information, or domain conventions that are not supported by the video scenes.",
-        "Distinguish carefully between unsupported external assumptions and implicit premises that are logically required for the video explanations to hold.",
-        "Implicit premises may be used only if they are necessary for the internal coherence of the video’s explanations and do not introduce new concepts beyond them.",
-        "Before answering, internally determine whether the user’s question includes an explicit or implicit premise.",
-        "If and only if that premise clearly contradicts the video scenes, explicitly point out the misunderstanding before giving any explanation.",
-        "When pointing out a misunderstanding, do so clearly and directly, without hedging or neutralizing expressions such as ‘it can be seen as’ or ‘in some cases’.",
-        "If the question seeks interpretation or clarification without asserting a false premise, do not begin with a denial.",
-        "Determine whether the question can be fully, partially, or not at all answered using the provided video scenes and their necessary implications.",
-        "If a concept is used or mentioned in the provided scenes, attempt to explain it from its behavior, properties, or usage shown in the scenes, even if no explicit definition sentence is present. Only state that a question is outside the scope of the video materials when the provided scenes contain no relevant information whatsoever.",
-        "If the video scenes allow only a partial answer, clearly state the limits of what can be concluded and explain only what is directly supported.",
-        "If relevant video scenes are available, base the explanation directly on them and do not introduce unsupported extensions.",
-        "If you are genuinely unsure based on the video scenes and their necessary implications, explicitly state that you do not know rather than guessing.",
-        "If the question is very short or ambiguous (e.g., a single word or phrase), interpret it as the most relevant topic covered in the provided scenes, state your interpretation briefly at the start, and answer accordingly.",
-        "If technical terms appear in phonetic or non-standard notation, interpret them as the most likely intended technical term before answering.",
+        "Treat the provided video scenes as the primary source of supporting evidence.",
+        "Do not rely on general knowledge, external information, or independent expert knowledge that is not grounded in the video scenes.",
+        "Strictly distinguish between implicit premises that are indispensable for the video explanations to hold logically and unsupported assumptions.",
+        "Implicit premises may be used only when they are necessary for the video explanations to hold and do not introduce new concepts.",
+        "Before answering, internally determine whether the user’s question contains any explicit or implicit premise or assumption.",
+        "Only when that premise clearly contradicts the content of the video scenes, explicitly point out the misunderstanding first and then explain.",
+        "When pointing out a misunderstanding, state the error clearly. Do not use hedging or neutralizing expressions such as 'it could be said' or 'depending on the case'.",
+        "If the question is meant to confirm an interpretation or support understanding and does not assert a false premise, do not begin by denying it.",
+        "Determine whether the question is fully answerable, only partially answerable, or not answerable based on the video scenes and the implications required for them to hold.",
+        "If reference scenes are provided, always construct the answer from those scenes. Even if a concept is not directly defined in the scenes, you may explain it from the actions, usage, or characteristics shown there. Only say that a question is outside the scope of the video materials when none of the provided scenes contain any relevant information.",
+        "If only part of the conclusion can be derived from the video scenes, clearly state the limits of the conclusion and explain only the supported portion.",
+        "If relevant video scenes exist, explain directly from them and do not extend beyond what is supported.",
+        "If something remains unclear even when considering the video scenes and the implications required for them to hold, clearly say that you do not know instead of guessing.",
+        "If the question is short and its intent is unclear, such as a single word, interpret it as the most relevant content within the provided scenes, briefly state that interpretation at the beginning, and then answer.",
+        "If a term appears with inconsistent notation, such as phonetic spellings or mixed scripts, interpret it as the most natural technical term from the context.",
         "Always answer in English.",
-        "Do not copy filler words, hesitations, or raw spoken-transcript fragments such as ‘uh’, ‘you know’, ‘はい’, or ‘要はね’ into the answer unless the user explicitly asks for a quote.",
-        "Prefer paraphrasing the scene content into smooth written language.",
-        "Use only scene numbers that were provided. Do not invent numbers not present in the scene list."
+        "Do not mix filler words such as 'uh', 'yeah', or 'you know', or spoken-transcript fragments pasted directly from subtitles, into the response.",
+        "Rewrite scene content into natural written language rather than quoting it directly.",
+        "Do not use scene numbers that were not provided."
       ],
       "reference": {
-        "lead": "Below are relevant scenes extracted from the user’s video group.",
-        "usage": "Explicitly reference relevant scenes inline using their bracketed numbers when answering factual or definitional questions.",
-        "footer": "Include brief descriptions only when they materially clarify the explanation.",
-        "empty": "If no relevant scenes are available, explicitly state that the content is outside the scope of the video materials and do not speculate."
+        "lead": "The following are relevant scenes extracted from the user’s video group.",
+        "usage": "When answering factual or definitional questions, cite the relevant scenes inline in the form [N].",
+        "footer": "Include a brief description of a scene only when it is needed to supplement the explanation.",
+        "empty": "If no relevant scenes are provided, explicitly state that the content is outside the scope of the video materials and do not speculate."
       }
     },
     "ja": {
@@ -53,7 +53,7 @@
         "group_context": "# グループ情報"
       },
       "rules": [
-        "提供された動画シーンを、唯一の正当な根拠情報として扱ってください。",
+        "提供された動画シーンを、主要な根拠情報として扱ってください。",
         "動画シーンに基づかない一般知識や外部情報、独立した専門常識には依存しないでください。",
         "動画内の説明が論理的に成立するために不可欠な暗黙の前提と、根拠のない仮定とを厳密に区別してください。",
         "暗黙の前提は、動画内の説明を成立させるために必要であり、新たな概念を導入しない場合に限り使用して構いません。",
@@ -62,17 +62,23 @@
         "誤解を指摘する際は、「〜とも言える」「一概には言えない」「場合によっては」などの曖昧化・中立化する表現を使用せず、明確に誤りを示してください。",
         "解釈の確認や理解の補助を目的とした質問であり、誤った前提を断定していない場合は、冒頭で否定から入らないでください。",
         "質問が、動画シーンおよびそれが成立するために必要な含意を踏まえて『完全に回答可能か』『部分的にのみ回答可能か』『回答不可能か』を判断してください。",
-        "提供されたシーン内で概念が使用・言及されている場合は、直接の定義文がなくても、そのシーンに示された動作・性質・使われ方から説明を試みてください。提供シーン内に関連する記述が一切見当たらない場合にのみ、『この質問は動画教材の範囲外です』と明示してください。",
+        "参照シーンが提供されている場合は、必ずそのシーンの内容をもとに回答を構成してください。概念の直接定義がシーンになくても、そのシーンに示された動作・使われ方・特性から説明を構成することができます。『この質問は動画教材の範囲外です』と回答してよいのは、提供された全シーンに関連する記述が一切存在しない場合のみです。",
         "動画シーンから一部のみ結論できる場合は、結論の限界を明示した上で、根拠がある範囲のみを説明してください。",
         "関連する動画シーンが存在する場合は、それに直接基づいて説明し、根拠のない拡張は行わないでください。",
         "動画シーンおよび必要な含意に基づいても不明な点がある場合は、推測せず『わからない』と明確に述べてください。",
         "質問が単語のみなど短くて意図が不明瞭な場合は、提供されたシーン内で最も関連性の高い内容として解釈し、その解釈を冒頭で簡潔に示した上で回答してください。",
-        "ひらがな・カタカナ・漢字など表記が揺れている用語は、文脈から最も自然な技術用語に変換して解釈してください（例：かさんき→加算器、ひきざん→引き算）。",
+        "ひらがな・カタカナ・漢字など表記が揺れている用語は、文脈から最も自然な技術用語に変換して解釈してください。",
         "必ず日本語で回答してください。",
         "「えー」「はい」「要はね」のようなフィラーや、字幕をそのまま貼り付けたような話し言葉の断片を回答文に混ぜてはいけません。",
         "シーンの内容は、引用ではなく自然な書き言葉に言い換えてください。",
         "提供されていないシーン番号を使ってはいけません。"
-      ]
+      ],
+      "reference": {
+        "lead": "以下は、ユーザーの動画グループから抽出された関連シーンです。",
+        "usage": "事実・定義に関する質問に回答する際は、関連シーンをインラインで [N] の形式で参照してください。",
+        "footer": "説明を補足する場合のみ、シーンの簡単な説明を含めてください。",
+        "empty": "関連シーンが提供されていない場合は、その内容が動画教材の範囲外であることを明示し、推測は行わないでください。"
+      }
     }
   }
 }

--- a/backend/app/infrastructure/external/rag_gateway.py
+++ b/backend/app/infrastructure/external/rag_gateway.py
@@ -34,6 +34,7 @@ class RagChatGateway(RagGateway):
         video_ids: Optional[Sequence[int]] = None,
         locale: Optional[str] = None,
         api_key: Optional[str] = None,
+        group_context: Optional[str] = None,
     ) -> RagResult:
         User = get_user_model()
         try:
@@ -58,6 +59,7 @@ class RagChatGateway(RagGateway):
                 messages=raw_messages,
                 video_ids=raw_video_ids,
                 locale=locale,
+                group_context=group_context or None,
             )
         except OpenAIAuthenticationError as exc:
             raise LLMConfigurationError(

--- a/backend/app/infrastructure/external/rag_service.py
+++ b/backend/app/infrastructure/external/rag_service.py
@@ -49,6 +49,7 @@ class RagChatService:
         group: Optional["VideoGroup"] = None,
         locale: Optional[str] = None,
         video_ids: Optional[List[int]] = None,
+        group_context: Optional[str] = None,
     ) -> RagChatResult:
         if self.llm is None:
             raise RuntimeError("LLM is required for full RAG response generation.")
@@ -63,6 +64,7 @@ class RagChatService:
                     {
                         "query_text": itemgetter("query_text"),
                         "locale": itemgetter("locale"),
+                        "group_context": itemgetter("group_context"),
                         "docs": itemgetter("query_text") | retriever,
                     }
                 )
@@ -84,7 +86,7 @@ class RagChatService:
                 }
             )
 
-        result = rag_chain.invoke({"query_text": query_text, "locale": locale})
+        result = rag_chain.invoke({"query_text": query_text, "locale": locale, "group_context": group_context})
         llm_response = cast(AIMessage, result.get("llm_response"))
         citations = result.get("citations")
 
@@ -165,9 +167,14 @@ class RagChatService:
         docs = cast(Sequence[Any], docs_obj)
         query_text = cast(str, data.get("query_text", ""))
         locale = cast(Optional[str], data.get("locale"))
+        group_context = cast(Optional[str], data.get("group_context")) or None
 
         reference_entries = self._build_reference_entries(docs)
-        system_prompt = build_system_prompt(locale=locale, references=reference_entries)
+        system_prompt = build_system_prompt(
+            locale=locale,
+            references=reference_entries,
+            group_context=group_context,
+        )
 
         return {
             "prompt_input": {

--- a/backend/app/infrastructure/repositories/django_chat_repository.py
+++ b/backend/app/infrastructure/repositories/django_chat_repository.py
@@ -69,6 +69,7 @@ def _group_to_context_entity(group: VideoGroup) -> VideoGroupContextEntity:
         id=group.id,
         user_id=group.user_id,
         name=group.name,
+        description=group.description,
         share_token=group.share_slug,
         members=members,
     )

--- a/backend/app/use_cases/chat/send_message.py
+++ b/backend/app/use_cases/chat/send_message.py
@@ -133,6 +133,7 @@ class SendMessageUseCase:
                 video_ids=video_ids,
                 locale=locale,
                 api_key=None,
+                group_context=group.description if group is not None else None,
             )
         except _DomainRagUserNotFoundError as e:
             raise ResourceNotFound("User") from e

--- a/backend/app/use_cases/chat/tests/test_send_message.py
+++ b/backend/app/use_cases/chat/tests/test_send_message.py
@@ -38,7 +38,7 @@ class _StubGroupRepository(VideoGroupQueryRepository):
 
 
 class _RagGatewayUserNotFound(RagGateway):
-    def generate_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None):
+    def generate_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None, group_context=None):
         raise RagUserNotFoundError(f"User not found: {user_id}")
 
 class SendMessageUseCaseTests(unittest.TestCase):
@@ -77,7 +77,7 @@ class SendMessageUseCaseTests(unittest.TestCase):
 class _SuccessRagGateway(RagGateway):
     """RAG gateway stub that returns a fixed successful answer."""
 
-    def generate_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None):
+    def generate_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None, group_context=None):
         from app.domain.chat.gateways import RagResult
         return RagResult(content="Hello!", query_text="q", citations=[])
 


### PR DESCRIPTION
## 概要
README の「ユーザー制限の設定」説明を整理しました。

## 変更内容
- 動画アップロードサイズ上限の説明を、個別セクションではなくユーザー制限の一覧テーブルに統合
- 「ユーザーごとに管理パネルで直接設定する」という説明に統一
- 制限項目の一覧に `Max video upload size mb` を追加
- 重複していた説明を削除して README を簡潔化

## 変更理由
ユーザー制限の設定方法が複数の見出しに分かれていて、確認箇所が分散していました。
制限項目を 1 つの表にまとめることで、設定できる内容を把握しやすくするためです。

## 影響範囲
- ドキュメントのみ
- アプリケーションの挙動変更なし

## 動作確認
- README の記載内容を確認