### PR TITLE
Improve chat streaming delivery and OpenAPI docs

### DIFF
--- a/backend/app/domain/chat/gateways.py
+++ b/backend/app/domain/chat/gateways.py
@@ -5,7 +5,7 @@ Abstract contracts for external services used by chat use cases.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Optional, Sequence
+from typing import Iterator, Optional, Sequence
 
 from app.domain.chat.dtos import ChatMessageDTO, CitationDTO
 
@@ -29,6 +29,20 @@ class RagResult:
     content: str
     query_text: str
     citations: Optional[Sequence[CitationDTO]] = field(default=None)
+
+
+@dataclass
+class RagStreamChunk:
+    """A single chunk emitted during streaming from the RAG gateway.
+
+    Content chunks have ``text`` set.
+    The final chunk has ``is_final=True`` and carries ``citations`` / ``query_text``.
+    """
+
+    text: Optional[str] = None
+    citations: Optional[Sequence[CitationDTO]] = field(default=None)
+    query_text: Optional[str] = None
+    is_final: bool = False
 
 
 class RagGateway(ABC):
@@ -62,3 +76,25 @@ class RagGateway(ABC):
             LLMProviderError: If the LLM provider returns an error.
         """
         ...
+
+    def stream_reply(
+        self,
+        messages: Sequence[ChatMessageDTO],
+        user_id: int,
+        video_ids: Optional[Sequence[int]] = None,
+        locale: Optional[str] = None,
+        api_key: Optional[str] = None,
+        group_context: Optional[str] = None,
+    ) -> Iterator[RagStreamChunk]:
+        """Stream the RAG reply token by token.
+
+        Yields ``RagStreamChunk`` objects:
+        - Content chunks have ``text`` set (non-empty string).
+        - The final chunk has ``is_final=True`` and carries ``citations`` / ``query_text``.
+
+        Raises:
+            RagUserNotFoundError: If the user context does not exist.
+            LLMConfigurationError: If the LLM cannot be initialised.
+            LLMProviderError: If the LLM provider returns an error during generation.
+        """
+        raise NotImplementedError("stream_reply is not implemented for this gateway")

--- a/backend/app/infrastructure/external/rag_gateway.py
+++ b/backend/app/infrastructure/external/rag_gateway.py
@@ -4,7 +4,7 @@ Wraps RagChatService (LangChain) for use case consumption.
 """
 
 import logging
-from typing import Optional, Sequence
+from typing import Iterator, Optional, Sequence
 
 from django.contrib.auth import get_user_model
 from openai import AuthenticationError as OpenAIAuthenticationError
@@ -14,11 +14,12 @@ from app.domain.chat.gateways import (
     LLMProviderError,
     RagGateway,
     RagResult,
+    RagStreamChunk,
     RagUserNotFoundError,
 )
 from app.domain.chat.dtos import ChatMessageDTO, CitationDTO
 from app.infrastructure.external.llm import get_langchain_llm
-from app.infrastructure.external.rag_service import RagChatService
+from app.infrastructure.external.rag_service import RagChatService, _RagServiceStreamEnd
 from app.domain.shared.exceptions import LLMConfigError
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,18 @@ logger = logging.getLogger(__name__)
 
 class RagChatGateway(RagGateway):
     """Implements RagGateway by delegating to RagChatService."""
+
+    @staticmethod
+    def _iter_text_units(text: str) -> Iterator[str]:
+        """Yield the smallest display units for streaming updates.
+
+        Upstream LLM providers may coalesce multiple characters into a single
+        streamed chunk. Split those chunks here so the downstream SSE contract
+        can update incrementally even when the provider batches output.
+        """
+        for unit in text:
+            if unit:
+                yield unit
 
     def generate_reply(
         self,
@@ -89,3 +102,67 @@ class RagChatGateway(RagGateway):
             query_text=result.query_text,
             citations=citations,
         )
+
+    def stream_reply(
+        self,
+        messages: Sequence[ChatMessageDTO],
+        user_id: int,
+        video_ids: Optional[Sequence[int]] = None,
+        locale: Optional[str] = None,
+        api_key: Optional[str] = None,
+        group_context: Optional[str] = None,
+    ) -> Iterator[RagStreamChunk]:
+        User = get_user_model()
+        try:
+            user = User.objects.get(pk=user_id)
+        except User.DoesNotExist as exc:
+            raise RagUserNotFoundError(f"User not found: {user_id}") from exc
+
+        try:
+            llm = get_langchain_llm(api_key=api_key)
+        except LLMConfigError as e:
+            raise LLMConfigurationError(str(e)) from e
+
+        service = RagChatService(user=user, llm=llm, api_key=api_key)
+        raw_messages = [
+            {"role": message.role, "content": message.content}
+            for message in messages
+        ]
+        raw_video_ids = list(video_ids) if video_ids is not None else None
+
+        try:
+            for item in service.stream(
+                messages=raw_messages,
+                video_ids=raw_video_ids,
+                locale=locale,
+                group_context=group_context or None,
+            ):
+                if isinstance(item, _RagServiceStreamEnd):
+                    citations = None
+                    if item.citations:
+                        citations = [
+                            CitationDTO(
+                                video_id=int(raw_video.get("video_id", 0) or 0),
+                                title=str(raw_video.get("title", "")),
+                                start_time=raw_video.get("start_time"),
+                                end_time=raw_video.get("end_time"),
+                            )
+                            for raw_video in item.citations
+                        ]
+                    yield RagStreamChunk(
+                        is_final=True,
+                        citations=citations,
+                        query_text=item.query_text,
+                    )
+                else:
+                    for unit in self._iter_text_units(item):
+                        yield RagStreamChunk(text=unit)
+        except OpenAIAuthenticationError as exc:
+            raise LLMConfigurationError(
+                "Invalid OpenAI API key. Please check your API key in Settings."
+            ) from exc
+        except (RagUserNotFoundError, LLMConfigurationError):
+            raise
+        except Exception as exc:
+            logger.exception("RAG stream_reply failed: %s", exc)
+            raise LLMProviderError(str(exc)) from exc

--- a/backend/app/infrastructure/external/rag_service.py
+++ b/backend/app/infrastructure/external/rag_service.py
@@ -5,7 +5,7 @@ Moved from app/chat/services/rag_chat.py.
 
 from dataclasses import dataclass
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Sequence, Union, cast
 
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import ChatPromptTemplate
@@ -27,6 +27,14 @@ class RagChatResult:
     llm_response: AIMessage
     query_text: str
     citations: Optional[List[Dict[str, str]]]
+
+
+@dataclass
+class _RagServiceStreamEnd:
+    """Sentinel yielded at the end of RagChatService.stream() carrying metadata."""
+
+    citations: Optional[List[Dict[str, str]]]
+    query_text: str
 
 
 class RagChatService:
@@ -95,6 +103,44 @@ class RagChatService:
             query_text=query_text,
             citations=citations,
         )
+
+    def stream(
+        self,
+        messages: Sequence[Dict[str, str]],
+        group: Optional["VideoGroup"] = None,
+        locale: Optional[str] = None,
+        video_ids: Optional[List[int]] = None,
+        group_context: Optional[str] = None,
+    ) -> Iterator[Union[str, _RagServiceStreamEnd]]:
+        """Stream LLM response token by token.
+
+        Yields:
+            - ``str`` for each content token from the LLM.
+            - ``_RagServiceStreamEnd`` as the final sentinel with citations + query_text.
+        """
+        if self.llm is None:
+            raise RuntimeError("LLM is required for streaming.")
+
+        query_text = self._extract_latest_user_query(messages)
+        retriever = self._get_retriever(group, video_ids=video_ids)
+
+        docs = retriever.invoke(query_text) if retriever is not None else []
+
+        payload = self._build_prompt_payload({
+            "docs": docs,
+            "query_text": query_text,
+            "locale": locale,
+            "group_context": group_context,
+        })
+        citations = payload["citations"]
+        prompt_messages = self.prompt.invoke(payload["prompt_input"])
+
+        for chunk in self.llm.stream(prompt_messages):
+            content = chunk.content
+            if isinstance(content, str) and content:
+                yield content
+
+        yield _RagServiceStreamEnd(citations=citations, query_text=query_text)
 
     def _extract_latest_user_query(self, messages: Sequence[Dict[str, str]]) -> str:
         for msg in reversed(messages):

--- a/backend/app/infrastructure/external/tests/test_rag_chat.py
+++ b/backend/app/infrastructure/external/tests/test_rag_chat.py
@@ -105,6 +105,124 @@ class RagChatServiceTests(TestCase):
         self.assertEqual(entries[1], "[2] Video B 00:01:00 - 00:01:10\nSecond scene")
 
 
+class RagChatGatewayStreamingTests(TestCase):
+    """Tests for RagChatGateway.stream_reply()."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="stream_testuser",
+            email="stream_test@example.com",
+            password="testpass123",
+        )
+
+    @patch("app.infrastructure.external.rag_gateway.get_langchain_llm")
+    @patch("app.infrastructure.external.rag_gateway.RagChatService")
+    @override_settings(LLM_PROVIDER="openai")
+    def test_stream_reply_yields_content_chunks(self, mock_service_cls, mock_get_llm):
+        mock_get_llm.return_value = MagicMock()
+        mock_service = MagicMock()
+
+        def _fake_stream(**kwargs):
+            yield "Hello "
+            yield "World"
+            from app.infrastructure.external.rag_service import _RagServiceStreamEnd
+            yield _RagServiceStreamEnd(citations=None, query_text="test")
+
+        mock_service.stream.side_effect = _fake_stream
+        mock_service_cls.return_value = mock_service
+
+        gateway = RagChatGateway()
+        messages = [ChatMessageDTO(role="user", content="hello")]
+
+        chunks = list(gateway.stream_reply(messages=messages, user_id=self.user.id))
+
+        content_chunks = [c for c in chunks if c.text is not None]
+        self.assertEqual("".join(chunk.text for chunk in content_chunks), "Hello World")
+        self.assertEqual(content_chunks[0].text, "H")
+        self.assertEqual(content_chunks[-1].text, "d")
+
+    @patch("app.infrastructure.external.rag_gateway.get_langchain_llm")
+    @patch("app.infrastructure.external.rag_gateway.RagChatService")
+    @override_settings(LLM_PROVIDER="openai")
+    def test_stream_reply_splits_batched_service_chunks_into_single_units(self, mock_service_cls, mock_get_llm):
+        mock_get_llm.return_value = MagicMock()
+        mock_service = MagicMock()
+
+        def _fake_stream(**kwargs):
+            yield "AB"
+            from app.infrastructure.external.rag_service import _RagServiceStreamEnd
+            yield _RagServiceStreamEnd(citations=None, query_text="test")
+
+        mock_service.stream.side_effect = _fake_stream
+        mock_service_cls.return_value = mock_service
+
+        gateway = RagChatGateway()
+        messages = [ChatMessageDTO(role="user", content="hello")]
+
+        chunks = list(gateway.stream_reply(messages=messages, user_id=self.user.id))
+
+        content_chunks = [c.text for c in chunks if c.text is not None]
+        self.assertEqual(content_chunks, ["A", "B"])
+
+    @patch("app.infrastructure.external.rag_gateway.get_langchain_llm")
+    @patch("app.infrastructure.external.rag_gateway.RagChatService")
+    @override_settings(LLM_PROVIDER="openai")
+    def test_stream_reply_yields_final_chunk(self, mock_service_cls, mock_get_llm):
+        from app.domain.chat.gateways import RagStreamChunk
+
+        mock_get_llm.return_value = MagicMock()
+        mock_service = MagicMock()
+
+        def _fake_stream(**kwargs):
+            yield "Hello"
+            from app.infrastructure.external.rag_service import _RagServiceStreamEnd
+            yield _RagServiceStreamEnd(citations=None, query_text="q")
+
+        mock_service.stream.side_effect = _fake_stream
+        mock_service_cls.return_value = mock_service
+
+        gateway = RagChatGateway()
+        messages = [ChatMessageDTO(role="user", content="hello")]
+
+        chunks = list(gateway.stream_reply(messages=messages, user_id=self.user.id))
+
+        final_chunks = [c for c in chunks if c.is_final]
+        self.assertEqual(len(final_chunks), 1)
+        self.assertEqual(final_chunks[0].query_text, "q")
+
+    @patch("app.infrastructure.external.rag_gateway.get_langchain_llm")
+    @patch("app.infrastructure.external.rag_gateway.RagChatService")
+    @override_settings(LLM_PROVIDER="openai")
+    def test_stream_reply_wraps_runtime_errors_as_llm_provider_error(self, mock_service_cls, mock_get_llm):
+        from app.domain.chat.gateways import LLMProviderError
+
+        mock_get_llm.return_value = MagicMock()
+        mock_service = MagicMock()
+
+        def _fake_stream(**kwargs):
+            yield "partial"
+            raise RuntimeError("LLM failed mid-stream")
+
+        mock_service.stream.side_effect = _fake_stream
+        mock_service_cls.return_value = mock_service
+
+        gateway = RagChatGateway()
+        messages = [ChatMessageDTO(role="user", content="hello")]
+
+        with self.assertRaises(LLMProviderError):
+            list(gateway.stream_reply(messages=messages, user_id=self.user.id))
+
+    @patch("app.infrastructure.external.rag_gateway.get_langchain_llm")
+    def test_stream_reply_raises_rag_user_not_found_for_missing_user(self, mock_get_llm):
+        from app.domain.chat.gateways import RagUserNotFoundError
+
+        gateway = RagChatGateway()
+        messages = [ChatMessageDTO(role="user", content="hello")]
+
+        with self.assertRaises(RagUserNotFoundError):
+            list(gateway.stream_reply(messages=messages, user_id=999999))
+
+
 class RagChatGatewayExceptionTests(TestCase):
     """Verify RagChatGateway exception classification."""
 
@@ -162,4 +280,3 @@ class RagChatGatewayExceptionTests(TestCase):
 
         with self.assertRaises(RagUserNotFoundError):
             gateway.generate_reply(messages=messages, user_id=999999)
-

--- a/backend/app/infrastructure/external/tests/test_rag_chat.py
+++ b/backend/app/infrastructure/external/tests/test_rag_chat.py
@@ -168,8 +168,6 @@ class RagChatGatewayStreamingTests(TestCase):
     @patch("app.infrastructure.external.rag_gateway.RagChatService")
     @override_settings(LLM_PROVIDER="openai")
     def test_stream_reply_yields_final_chunk(self, mock_service_cls, mock_get_llm):
-        from app.domain.chat.gateways import RagStreamChunk
-
         mock_get_llm.return_value = MagicMock()
         mock_service = MagicMock()
 

--- a/backend/app/presentation/chat/tests/test_streaming_view.py
+++ b/backend/app/presentation/chat/tests/test_streaming_view.py
@@ -1,0 +1,185 @@
+"""
+Tests for StreamChatView (SSE streaming endpoint).
+"""
+
+import json
+import secrets
+from unittest.mock import patch
+
+from django.apps import apps
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from app.domain.chat.gateways import LLMConfigurationError, RagStreamChunk
+from app.use_cases.billing.exceptions import AiAnswersLimitExceeded, OverQuotaError
+from app.use_cases.chat.exceptions import LLMProviderError
+
+User = get_user_model()
+Video = apps.get_model("app", "Video")
+VideoGroup = apps.get_model("app", "VideoGroup")
+VideoGroupMember = apps.get_model("app", "VideoGroupMember")
+
+
+def _parse_sse_events(raw: str) -> list[dict]:
+    """Parse SSE text into a list of event dicts."""
+    events = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("data:"):
+            data = line[len("data:"):].strip()
+            if data:
+                events.append(json.loads(data))
+    return events
+
+
+def _fake_stream_reply(chunks=None, citations=None):
+    """Return a function that patches stream_reply to yield given chunks."""
+    def _side_effect(self_or_gateway, messages, user_id, video_ids=None, locale=None, api_key=None, group_context=None):
+        for text in (chunks or ["Hello ", "World"]):
+            yield RagStreamChunk(text=text)
+        yield RagStreamChunk(is_final=True, citations=citations, query_text="test")
+    return _side_effect
+
+
+class StreamChatViewTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="streamer",
+            email="stream@example.com",
+            password="testpass123",
+        )
+        self.user.ai_answers_limit = 1000
+        self.user.save()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Stream Video",
+            description="desc",
+            status="completed",
+        )
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="Stream Group",
+            description="desc",
+            share_slug=secrets.token_urlsafe(32),
+        )
+        VideoGroupMember.objects.create(group=self.group, video=self.video, order=0)
+
+    def _post_stream(self, data):
+        url = reverse("chat-messages-stream")
+        return self.client.post(url, data, format="json")
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.stream_reply", _fake_stream_reply())
+    def test_returns_event_stream_content_type(self):
+        response = self._post_stream({
+            "messages": [{"role": "user", "content": "Hello"}],
+            "group_id": self.group.id,
+        })
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("text/event-stream", response.get("Content-Type", ""))
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.stream_reply", _fake_stream_reply())
+    def test_yields_content_chunk_events(self):
+        response = self._post_stream({
+            "messages": [{"role": "user", "content": "Hello"}],
+            "group_id": self.group.id,
+        })
+        content = b"".join(response.streaming_content).decode()
+        events = _parse_sse_events(content)
+        content_events = [e for e in events if e.get("type") == "content_chunk"]
+        self.assertEqual(len(content_events), 2)
+        self.assertEqual(content_events[0]["text"], "Hello ")
+        self.assertEqual(content_events[1]["text"], "World")
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.stream_reply", _fake_stream_reply())
+    def test_yields_done_event_at_end(self):
+        response = self._post_stream({
+            "messages": [{"role": "user", "content": "Hello"}],
+            "group_id": self.group.id,
+        })
+        content = b"".join(response.streaming_content).decode()
+        events = _parse_sse_events(content)
+        done_events = [e for e in events if e.get("type") == "done"]
+        self.assertEqual(len(done_events), 1)
+        done = done_events[0]
+        self.assertIn("chat_log_id", done)
+        self.assertIn("feedback", done)
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.stream_reply", _fake_stream_reply())
+    def test_done_event_is_last(self):
+        response = self._post_stream({
+            "messages": [{"role": "user", "content": "Hello"}],
+        })
+        content = b"".join(response.streaming_content).decode()
+        events = _parse_sse_events(content)
+        self.assertEqual(events[-1]["type"], "done")
+
+    def test_returns_400_on_empty_messages(self):
+        response = self._post_stream({"messages": []})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_400_on_missing_messages(self):
+        response = self._post_stream({})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.stream_reply")
+    def test_yields_error_event_on_llm_config_error(self, mock_stream):
+        mock_stream.side_effect = LLMConfigurationError("Invalid API key")
+
+        response = self._post_stream({
+            "messages": [{"role": "user", "content": "Hello"}],
+            "group_id": self.group.id,
+        })
+        content = b"".join(response.streaming_content).decode()
+        events = _parse_sse_events(content)
+        error_events = [e for e in events if e.get("type") == "error"]
+        self.assertEqual(len(error_events), 1)
+        self.assertEqual(error_events[0]["code"], "LLM_CONFIGURATION_ERROR")
+
+    @patch("app.infrastructure.external.rag_gateway.RagChatGateway.stream_reply")
+    def test_yields_error_event_on_llm_provider_error(self, mock_stream):
+        mock_stream.side_effect = LLMProviderError("provider exploded")
+
+        response = self._post_stream({
+            "messages": [{"role": "user", "content": "Hello"}],
+            "group_id": self.group.id,
+        })
+        content = b"".join(response.streaming_content).decode()
+        events = _parse_sse_events(content)
+        error_events = [e for e in events if e.get("type") == "error"]
+        self.assertEqual(len(error_events), 1)
+        self.assertEqual(error_events[0]["code"], "LLM_PROVIDER_ERROR")
+        # Must not expose internal error details
+        self.assertNotIn("provider exploded", error_events[0].get("message", ""))
+
+    @patch("app.use_cases.billing.check_ai_answers_limit.CheckAiAnswersLimitUseCase.execute")
+    def test_yields_error_event_on_over_quota(self, mock_check):
+        mock_check.side_effect = OverQuotaError("Over quota")
+
+        response = self._post_stream({
+            "messages": [{"role": "user", "content": "Hello"}],
+            "group_id": self.group.id,
+        })
+        content = b"".join(response.streaming_content).decode()
+        events = _parse_sse_events(content)
+        error_events = [e for e in events if e.get("type") == "error"]
+        self.assertEqual(len(error_events), 1)
+        self.assertEqual(error_events[0]["code"], "OVER_QUOTA")
+
+    @patch("app.use_cases.billing.check_ai_answers_limit.CheckAiAnswersLimitUseCase.execute")
+    def test_yields_error_event_on_ai_answers_limit_exceeded(self, mock_check):
+        mock_check.side_effect = AiAnswersLimitExceeded("AI answers limit exceeded")
+
+        response = self._post_stream({
+            "messages": [{"role": "user", "content": "Hello"}],
+            "group_id": self.group.id,
+        })
+        content = b"".join(response.streaming_content).decode()
+        events = _parse_sse_events(content)
+        error_events = [e for e in events if e.get("type") == "error"]
+        self.assertEqual(len(error_events), 1)
+        self.assertEqual(error_events[0]["code"], "AI_ANSWERS_LIMIT_EXCEEDED")

--- a/backend/app/presentation/chat/urls.py
+++ b/backend/app/presentation/chat/urls.py
@@ -7,6 +7,7 @@ from .views import (
     ChatFeedbackView,
     ChatHistoryView,
     ChatView,
+    StreamChatView,
 )
 
 urlpatterns = [
@@ -14,6 +15,11 @@ urlpatterns = [
         "messages/",
         ChatView.as_view(send_message_use_case=chat_dependencies.get_send_message_use_case),
         name="chat-messages",
+    ),
+    path(
+        "messages/stream/",
+        StreamChatView.as_view(send_message_use_case=chat_dependencies.get_send_message_use_case),
+        name="chat-messages-stream",
     ),
     path(
         "history/",

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -4,6 +4,7 @@ Views are thin HTTP adapters that delegate to use cases.
 """
 
 import csv
+import json
 import time
 import uuid
 
@@ -16,7 +17,7 @@ from rest_framework.views import APIView
 
 from app.presentation.common.authentication import APIKeyAuthentication, BearerAPIKeyAuthentication, CookieJWTAuthentication
 from app.use_cases.billing.exceptions import AiAnswersLimitExceeded, OverQuotaError
-from app.use_cases.chat.dto import ChatMessageInput
+from app.use_cases.chat.dto import ChatMessageInput, StreamContentChunk, StreamDoneEvent
 from app.presentation.common.mixins import DependencyResolverMixin
 from app.presentation.common.permissions import (
     ApiKeyScopePermission,
@@ -37,7 +38,7 @@ from app.use_cases.chat.exceptions import (
     LLMProviderError,
 )
 from app.use_cases.shared.exceptions import PermissionDenied, ResourceNotFound
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 
 from .exporters import write_chat_history_csv
 from .serializers import (
@@ -319,6 +320,102 @@ class ChatAnalyticsView(DependencyResolverMixin, APIView):
                 for item in dto.keywords
             ],
         })
+
+
+def _sse_event(data: dict) -> str:
+    return f"data: {json.dumps(data)}\n\n"
+
+
+class StreamChatView(DependencyResolverMixin, APIView):
+    """Streaming chat endpoint using Server-Sent Events (SSE).
+
+    Returns ``text/event-stream`` response with the following event types:
+    - ``{"type": "content_chunk", "text": "..."}`` — incremental LLM tokens
+    - ``{"type": "done", "chat_log_id": ..., "feedback": ..., "citations": [...]}`` — final
+    - ``{"type": "error", "code": "...", "message": "..."}`` — on error
+    """
+
+    authentication_classes = [
+        APIKeyAuthentication,
+        CookieJWTAuthentication,
+        ShareTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticatedOrSharedAccess, ApiKeyScopePermission]
+    required_scope = "chat_write"
+    throttle_classes = [
+        ShareTokenIPThrottle,
+        AuthenticatedChatThrottle,
+    ]
+    send_message_use_case = None
+
+    def post(self, request):
+        share_slug = _get_share_slug(request)
+        is_shared = share_slug is not None
+
+        serializer = ChatRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {"error": {"code": "VALIDATION_ERROR", "message": serializer.errors}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        group_id = serializer.validated_data.get("group_id")
+        user_id = getattr(request.user, "id", None)
+        validated_messages = serializer.validated_data.get("messages", [])
+
+        if not validated_messages:
+            return Response(
+                {"error": {"code": "INVALID_REQUEST", "message": "Messages are empty."}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        message_dtos = [
+            ChatMessageInput(role=m["role"], content=m["content"])
+            for m in validated_messages
+        ]
+
+        use_case = self.resolve_dependency(self.send_message_use_case)
+
+        def event_stream():
+            try:
+                for event in use_case.stream_execute(
+                    user_id=user_id,
+                    messages=message_dtos,
+                    group_id=group_id,
+                    share_token=share_slug,
+                    is_shared=is_shared,
+                    locale=_get_locale(request),
+                ):
+                    if isinstance(event, StreamContentChunk):
+                        yield _sse_event({"type": "content_chunk", "text": event.text})
+                    elif isinstance(event, StreamDoneEvent):
+                        done_data: dict = {
+                            "type": "done",
+                            "chat_log_id": event.chat_log_id,
+                            "feedback": event.feedback,
+                        }
+                        if group_id is not None and event.citations:
+                            done_data["citations"] = _serialize_citations(event.citations)
+                        yield _sse_event(done_data)
+            except InvalidChatRequestError as e:
+                yield _sse_event({"type": "error", "code": "INVALID_REQUEST", "message": str(e)})
+            except ResourceNotFound as e:
+                yield _sse_event({"type": "error", "code": "NOT_FOUND", "message": str(e)})
+            except PermissionDenied as e:
+                yield _sse_event({"type": "error", "code": "PERMISSION_DENIED", "message": str(e)})
+            except OverQuotaError as e:
+                yield _sse_event({"type": "error", "code": "OVER_QUOTA", "message": str(e)})
+            except AiAnswersLimitExceeded as e:
+                yield _sse_event({"type": "error", "code": "AI_ANSWERS_LIMIT_EXCEEDED", "message": str(e)})
+            except LLMConfigurationError as e:
+                yield _sse_event({"type": "error", "code": "LLM_CONFIGURATION_ERROR", "message": str(e)})
+            except LLMProviderError:
+                yield _sse_event({"type": "error", "code": "LLM_PROVIDER_ERROR", "message": "An internal server error occurred."})
+
+        response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+        response["Cache-Control"] = "no-cache"
+        response["X-Accel-Buffering"] = "no"
+        return response
 
 
 class OpenAIChatCompletionsView(DependencyResolverMixin, APIView):

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -85,6 +85,15 @@ class ChatView(DependencyResolverMixin, APIView):
 
     @extend_schema(
         request=ChatRequestSerializer,
+        parameters=[
+            OpenApiParameter(
+                "share_slug",
+                str,
+                OpenApiParameter.QUERY,
+                required=False,
+                description="Optional share link token for shared-access chat.",
+            ),
+        ],
         responses={200: ChatResponseSerializer},
         summary="Send chat message",
         description="Send a chat message and get AI response. Supports RAG when group_id is provided.",
@@ -348,6 +357,32 @@ class StreamChatView(DependencyResolverMixin, APIView):
     ]
     send_message_use_case = None
 
+    @extend_schema(
+        request=ChatRequestSerializer,
+        parameters=[
+            OpenApiParameter(
+                "share_slug",
+                str,
+                OpenApiParameter.QUERY,
+                required=False,
+                description="Optional share link token for shared-access chat.",
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(
+                response=OpenApiTypes.STR,
+                description=(
+                    "Server-Sent Events stream (`text/event-stream`). "
+                    "Emits `content_chunk`, `done`, and `error` events as JSON in SSE `data:` frames."
+                ),
+            )
+        },
+        summary="Send chat message (streaming)",
+        description=(
+            "Send a chat message and receive the assistant response as Server-Sent Events. "
+            "Supports RAG when `group_id` is provided."
+        ),
+    )
     def post(self, request):
         share_slug = _get_share_slug(request)
         is_shared = share_slug is not None

--- a/backend/app/use_cases/chat/dto.py
+++ b/backend/app/use_cases/chat/dto.py
@@ -129,3 +129,20 @@ class KeywordCountDTO:
 
     word: str
     count: int
+
+
+@dataclass(frozen=True)
+class StreamContentChunk:
+    """A single content token emitted by stream_execute()."""
+
+    text: str
+
+
+@dataclass
+class StreamDoneEvent:
+    """Final event from stream_execute() carrying full result metadata."""
+
+    content: str
+    citations: Optional[Sequence[CitationResponseDTO]]
+    chat_log_id: Optional[int]
+    feedback: Optional[str]

--- a/backend/app/use_cases/chat/send_message.py
+++ b/backend/app/use_cases/chat/send_message.py
@@ -1,7 +1,7 @@
 """Use case: Send a chat message with optional RAG context."""
 
 import logging
-from typing import Generator, Iterator, List, Optional, Union
+from typing import Generator, List, Optional, Union
 
 from app.domain.chat.dtos import ChatMessageDTO
 from app.domain.chat.gateways import LLMConfigurationError as _DomainLLMConfigError

--- a/backend/app/use_cases/chat/send_message.py
+++ b/backend/app/use_cases/chat/send_message.py
@@ -1,7 +1,7 @@
 """Use case: Send a chat message with optional RAG context."""
 
 import logging
-from typing import List, Optional
+from typing import Generator, Iterator, List, Optional, Union
 
 from app.domain.chat.dtos import ChatMessageDTO
 from app.domain.chat.gateways import LLMConfigurationError as _DomainLLMConfigError
@@ -20,6 +20,8 @@ from app.use_cases.chat.dto import (
     ChatMessageInput,
     CitationResponseDTO,
     SendMessageResultDTO,
+    StreamContentChunk,
+    StreamDoneEvent,
 )
 from app.use_cases.chat.exceptions import (
     InvalidChatRequestError,
@@ -188,3 +190,135 @@ class SendMessageUseCase:
                 )
 
         return result
+
+    def stream_execute(
+        self,
+        user_id: Optional[int],
+        messages: List[ChatMessageInput],
+        group_id: Optional[int] = None,
+        share_token: Optional[str] = None,
+        is_shared: bool = False,
+        locale: Optional[str] = None,
+    ) -> Generator[Union[StreamContentChunk, StreamDoneEvent], None, None]:
+        """Streaming variant of execute().
+
+        Yields:
+            ``StreamContentChunk`` for each token from the LLM.
+            ``StreamDoneEvent`` as the final item with full metadata.
+
+        Raises the same exceptions as ``execute()`` for setup failures
+        (validation, resource resolution) before any yielding occurs.
+        LLM errors during generation are re-raised and propagate through the generator.
+        """
+        policy = ChatRequestPolicy(
+            is_shared=is_shared,
+            authenticated_user_id=user_id,
+            share_token=share_token,
+            group_id=group_id,
+        )
+        try:
+            policy.validate_send_message_preconditions(messages_count=len(messages))
+        except _DomainInvalidSendMessageRequest as e:
+            raise InvalidChatRequestError(str(e)) from e
+
+        domain_messages = [ChatMessageDTO(role=m.role, content=m.content) for m in messages]
+
+        group = None
+        if group_id is not None:
+            if is_shared and share_token:
+                group_candidate = self.group_query_repo.get_with_members(
+                    group_id=group_id,
+                    share_token=share_token,
+                )
+            else:
+                group_candidate = self.group_query_repo.get_with_members(
+                    group_id=group_id,
+                    user_id=user_id,
+                )
+            try:
+                group = require_group_context(group_candidate)
+            except _DomainGroupContextNotFound:
+                raise ResourceNotFound("Group")
+
+        try:
+            owner_user_id = policy.resolve_owner_user_id(
+                group_user_id=group.user_id if group is not None else None
+            )
+        except _DomainOwnerUserResolutionError as e:
+            raise PermissionDenied(str(e)) from e
+
+        if self._ai_answer_limit_check_use_case is not None and owner_user_id is not None:
+            self._ai_answer_limit_check_use_case.execute(owner_user_id)
+
+        video_ids = group.member_video_ids if group else None
+
+        full_content = ""
+        final_citations = None
+        query_text = ""
+
+        try:
+            for chunk in self.rag_gateway.stream_reply(
+                messages=domain_messages,
+                user_id=owner_user_id,
+                video_ids=video_ids,
+                locale=locale,
+                api_key=None,
+                group_context=group.description if group is not None else None,
+            ):
+                if chunk.is_final:
+                    final_citations = chunk.citations
+                    query_text = chunk.query_text or ""
+                elif chunk.text is not None:
+                    full_content += chunk.text
+                    yield StreamContentChunk(text=chunk.text)
+        except _DomainRagUserNotFoundError as e:
+            raise ResourceNotFound("User") from e
+        except _DomainLLMConfigError as e:
+            raise LLMConfigurationError(str(e)) from e
+        except _DomainLLMProviderError as e:
+            raise LLMProviderError(str(e)) from e
+
+        chat_log_id: Optional[int] = None
+        feedback: Optional[str] = None
+
+        if group is not None:
+            chat_log = self.chat_repo.create_log(
+                user_id=owner_user_id,
+                group_id=group.id,
+                question=query_text,
+                answer=full_content,
+                citations=final_citations,
+                is_shared=is_shared,
+            )
+            chat_log_id = chat_log.id
+            feedback = chat_log.feedback
+
+        yield StreamDoneEvent(
+            content=full_content,
+            citations=(
+                [
+                    CitationResponseDTO(
+                        id=index,
+                        video_id=v.video_id,
+                        title=v.title,
+                        start_time=v.start_time,
+                        end_time=v.end_time,
+                    )
+                    for index, v in enumerate(final_citations or [], start=1)
+                ]
+                if group_id is not None
+                else None
+            ),
+            chat_log_id=chat_log_id,
+            feedback=feedback,
+        )
+
+        if self._ai_answer_record_use_case is not None and owner_user_id is not None:
+            try:
+                self._ai_answer_record_use_case.execute(owner_user_id)
+            except Exception:
+                logger.warning(
+                    "Failed to record AI answer usage for user %s",
+                    owner_user_id,
+                    exc_info=True,
+                )

--- a/backend/app/use_cases/chat/tests/test_stream_message.py
+++ b/backend/app/use_cases/chat/tests/test_stream_message.py
@@ -1,0 +1,196 @@
+"""Tests for SendMessageUseCase.stream_execute() (streaming path)."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from app.domain.chat.gateways import LLMProviderError as DomainLLMProviderError
+from app.domain.chat.gateways import RagGateway, RagStreamChunk, RagUserNotFoundError
+from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
+from app.use_cases.chat.dto import ChatMessageInput, StreamContentChunk, StreamDoneEvent
+from app.use_cases.chat.exceptions import InvalidChatRequestError, LLMProviderError
+from app.use_cases.chat.send_message import SendMessageUseCase
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+
+class _StubChatRepository(ChatRepository):
+    def get_logs_for_group(self, group_id, ascending=True):
+        raise NotImplementedError
+
+    def create_log(self, user_id, group_id, question, answer, citations, is_shared):
+        raise NotImplementedError
+
+    def get_log_by_id(self, log_id):
+        raise NotImplementedError
+
+    def update_feedback(self, log, feedback):
+        raise NotImplementedError
+
+    def get_logs_values_for_group(self, group_id):
+        raise NotImplementedError
+
+    def get_analytics_raw(self, group_id):
+        raise NotImplementedError
+
+
+class _StubGroupRepository(VideoGroupQueryRepository):
+    def get_with_members(self, group_id, user_id=None, share_token=None):
+        return None
+
+
+class _StreamingRagGateway(RagGateway):
+    """Stub gateway that streams two content chunks then a final chunk."""
+
+    def __init__(self, chunks=None, citations=None):
+        self._chunks = chunks or ["Hello ", "World"]
+        self._citations = citations
+
+    def generate_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None, group_context=None):
+        raise NotImplementedError
+
+    def stream_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None, group_context=None):
+        for text in self._chunks:
+            yield RagStreamChunk(text=text)
+        yield RagStreamChunk(is_final=True, citations=self._citations, query_text="Test query")
+
+
+class _ErrorStreamingRagGateway(RagGateway):
+    """Stub gateway that raises LLMProviderError mid-stream."""
+
+    def generate_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None, group_context=None):
+        raise NotImplementedError
+
+    def stream_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None, group_context=None):
+        yield RagStreamChunk(text="partial ")
+        raise DomainLLMProviderError("LLM exploded")
+
+
+class _UserNotFoundRagGateway(RagGateway):
+    def generate_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None, group_context=None):
+        raise NotImplementedError
+
+    def stream_reply(self, messages, user_id, video_ids=None, locale=None, api_key=None, group_context=None):
+        raise RagUserNotFoundError(f"User not found: {user_id}")
+        # Need at least one yield to make this a generator
+        yield  # pragma: no cover
+
+
+def _make_use_case(gateway=None, chat_repo=None, **kwargs):
+    return SendMessageUseCase(
+        chat_repo=chat_repo or _StubChatRepository(),
+        group_query_repo=_StubGroupRepository(),
+        rag_gateway=gateway or _StreamingRagGateway(),
+        **kwargs,
+    )
+
+
+class StreamExecuteContentTests(unittest.TestCase):
+    """Tests for the content streaming path of stream_execute()."""
+
+    def test_yields_content_chunks(self):
+        use_case = _make_use_case()
+        events = list(use_case.stream_execute(
+            user_id=99,
+            messages=[ChatMessageInput(role="user", content="hello")],
+        ))
+        content_events = [e for e in events if isinstance(e, StreamContentChunk)]
+        self.assertEqual(len(content_events), 2)
+        self.assertEqual(content_events[0].text, "Hello ")
+        self.assertEqual(content_events[1].text, "World")
+
+    def test_yields_done_event_at_end(self):
+        use_case = _make_use_case()
+        events = list(use_case.stream_execute(
+            user_id=99,
+            messages=[ChatMessageInput(role="user", content="hello")],
+        ))
+        done_events = [e for e in events if isinstance(e, StreamDoneEvent)]
+        self.assertEqual(len(done_events), 1)
+        done = done_events[0]
+        self.assertEqual(done.content, "Hello World")
+        self.assertIsNone(done.chat_log_id)
+        self.assertIsNone(done.feedback)
+
+    def test_done_event_is_last(self):
+        use_case = _make_use_case()
+        events = list(use_case.stream_execute(
+            user_id=99,
+            messages=[ChatMessageInput(role="user", content="hello")],
+        ))
+        self.assertIsInstance(events[-1], StreamDoneEvent)
+
+
+class StreamExecuteValidationTests(unittest.TestCase):
+    """Tests that stream_execute() validates input the same as execute()."""
+
+    def test_raises_on_empty_messages(self):
+        use_case = _make_use_case()
+        with self.assertRaises(InvalidChatRequestError) as cm:
+            list(use_case.stream_execute(user_id=99, messages=[]))
+        self.assertEqual(str(cm.exception), "Messages are empty.")
+
+    def test_raises_on_shared_request_missing_group_id(self):
+        use_case = _make_use_case()
+        with self.assertRaises(InvalidChatRequestError) as cm:
+            list(use_case.stream_execute(
+                user_id=None,
+                messages=[ChatMessageInput(role="user", content="hello")],
+                group_id=None,
+                share_token="token",
+                is_shared=True,
+            ))
+        self.assertEqual(str(cm.exception), "Group ID not specified.")
+
+    def test_raises_on_user_not_found(self):
+        use_case = _make_use_case(gateway=_UserNotFoundRagGateway())
+        with self.assertRaises(ResourceNotFound) as cm:
+            list(use_case.stream_execute(
+                user_id=123,
+                messages=[ChatMessageInput(role="user", content="hello")],
+            ))
+        self.assertEqual(str(cm.exception), "User not found.")
+
+    def test_raises_llm_provider_error_mid_stream(self):
+        use_case = _make_use_case(gateway=_ErrorStreamingRagGateway())
+        with self.assertRaises(LLMProviderError):
+            list(use_case.stream_execute(
+                user_id=99,
+                messages=[ChatMessageInput(role="user", content="hello")],
+            ))
+
+
+class StreamExecuteBillingTests(unittest.TestCase):
+    """Tests billing integration for stream_execute()."""
+
+    def test_checks_ai_answer_limit_before_streaming(self):
+        mock_ai_check = MagicMock()
+        use_case = _make_use_case(ai_answer_limit_check_use_case=mock_ai_check)
+
+        list(use_case.stream_execute(
+            user_id=99,
+            messages=[ChatMessageInput(role="user", content="hello")],
+        ))
+
+        mock_ai_check.execute.assert_called_once_with(99)
+
+    def test_records_ai_answer_after_streaming(self):
+        mock_ai_record = MagicMock()
+        use_case = _make_use_case(ai_answer_record_use_case=mock_ai_record)
+
+        list(use_case.stream_execute(
+            user_id=99,
+            messages=[ChatMessageInput(role="user", content="hello")],
+        ))
+
+        mock_ai_record.execute.assert_called_once_with(99)
+
+    def test_does_not_fail_when_billing_record_raises(self):
+        mock_ai_record = MagicMock()
+        mock_ai_record.execute.side_effect = RuntimeError("billing down")
+        use_case = _make_use_case(ai_answer_record_use_case=mock_ai_record)
+
+        # Should not raise
+        events = list(use_case.stream_execute(
+            user_id=99,
+            messages=[ChatMessageInput(role="user", content="hello")],
+        ))
+        self.assertIsInstance(events[-1], StreamDoneEvent)

--- a/frontend/src/components/chat/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/chat/__tests__/ChatPanel.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/lib/api', async (importOriginal) => {
     ...actual,
     apiClient: {
       chat: vi.fn(),
+      chatStream: vi.fn(),
       getChatHistory: vi.fn(),
       exportChatHistoryCsv: vi.fn(),
       setChatFeedback: vi.fn(),
@@ -16,6 +17,21 @@ vi.mock('@/lib/api', async (importOriginal) => {
     },
   }
 })
+
+// Helper: create async generator mock for chatStream
+function makeStreamMock(
+  response: { content: string; chat_log_id?: number; feedback?: 'good' | 'bad' | null; citations?: any[] }
+) {
+  return async function* () {
+    yield { type: 'content_chunk' as const, text: response.content }
+    yield {
+      type: 'done' as const,
+      chat_log_id: response.chat_log_id ?? null,
+      feedback: response.feedback ?? null,
+      citations: response.citations,
+    }
+  }
+}
 
 // Mock window.open
 const mockOpen = vi.fn()
@@ -30,12 +46,9 @@ async function sendMessage(input: HTMLElement, message: string) {
 describe('ChatPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
-      content: 'Test response',
-      chat_log_id: 1,
-      feedback: null,
-    })
+    ;(apiClient.chatStream as any).mockImplementation(
+      makeStreamMock({ content: 'Test response', chat_log_id: 1, feedback: null }),
+    )
     ;(apiClient.getOpenAIApiKeyStatus as any).mockResolvedValue({ has_api_key: true })
   })
 
@@ -55,7 +68,7 @@ describe('ChatPanel', () => {
     })
 
     await waitFor(() => {
-      expect(apiClient.chat).toHaveBeenCalled()
+      expect(apiClient.chatStream).toHaveBeenCalled()
     })
   })
 
@@ -68,7 +81,7 @@ describe('ChatPanel', () => {
       fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
     })
 
-    expect(apiClient.chat).not.toHaveBeenCalled()
+    expect(apiClient.chatStream).not.toHaveBeenCalled()
   })
 
   it('should open history when history button is clicked', async () => {
@@ -95,21 +108,12 @@ describe('ChatPanel', () => {
 
   it('should handle video navigation', async () => {
     const onVideoPlay = vi.fn()
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
+    ;(apiClient.chatStream as any).mockImplementation(makeStreamMock({
       content: 'This is grounded text[1].',
-      citations: [
-        {
-          id: 1,
-          video_id: 1,
-          title: 'Test Video',
-          start_time: '00:01:30',
-          end_time: '00:15:30',
-        },
-      ],
+      citations: [{ id: 1, video_id: 1, title: 'Test Video', start_time: '00:01:30', end_time: '00:15:30' }],
       chat_log_id: 1,
       feedback: null,
-    })
+    }))
 
     render(<ChatPanel onVideoPlay={onVideoPlay} />)
 
@@ -135,21 +139,12 @@ describe('ChatPanel', () => {
   })
 
   it('should open video in new tab when onVideoPlay is not provided', async () => {
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
+    ;(apiClient.chatStream as any).mockImplementation(makeStreamMock({
       content: 'This is grounded text[1].',
-      citations: [
-        {
-          id: 1,
-          video_id: 1,
-          title: 'Test Video',
-          start_time: '00:01:30',
-          end_time: '00:15:30',
-        },
-      ],
+      citations: [{ id: 1, video_id: 1, title: 'Test Video', start_time: '00:01:30', end_time: '00:15:30' }],
       chat_log_id: 1,
       feedback: null,
-    })
+    }))
 
     render(<ChatPanel />)
 
@@ -183,7 +178,7 @@ describe('ChatPanel', () => {
     })
 
     await waitFor(() => {
-      expect(apiClient.chat).toHaveBeenCalled()
+      expect(apiClient.chatStream).toHaveBeenCalled()
     })
   })
 
@@ -197,16 +192,13 @@ describe('ChatPanel', () => {
       fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
     })
 
-    expect(apiClient.chat).not.toHaveBeenCalled()
+    expect(apiClient.chatStream).not.toHaveBeenCalled()
   })
 
   it('should handle feedback good button click', async () => {
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
-      content: 'Response',
-      chat_log_id: 1,
-      feedback: null,
-    })
+    ;(apiClient.chatStream as any).mockImplementation(
+      makeStreamMock({ content: 'Response', chat_log_id: 1, feedback: null }),
+    )
     ;(apiClient.setChatFeedback as any).mockResolvedValue({
       chat_log_id: 1,
       feedback: 'good',
@@ -256,12 +248,9 @@ describe('ChatPanel', () => {
   })
 
   it('should handle feedback bad button click', async () => {
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
-      content: 'Response',
-      chat_log_id: 1,
-      feedback: null,
-    })
+    ;(apiClient.chatStream as any).mockImplementation(
+      makeStreamMock({ content: 'Response', chat_log_id: 1, feedback: null }),
+    )
     ;(apiClient.setChatFeedback as any).mockResolvedValue({
       chat_log_id: 1,
       feedback: 'bad',
@@ -295,12 +284,9 @@ describe('ChatPanel', () => {
   })
 
   it('should toggle feedback when clicking same button', async () => {
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
-      content: 'Response',
-      chat_log_id: 1,
-      feedback: 'good',
-    })
+    ;(apiClient.chatStream as any).mockImplementation(
+      makeStreamMock({ content: 'Response', chat_log_id: 1, feedback: 'good' }),
+    )
     ;(apiClient.setChatFeedback as any).mockResolvedValue({
       chat_log_id: 1,
       feedback: null,
@@ -430,7 +416,10 @@ describe('ChatPanel', () => {
   })
 
   it('should display error message when chat fails', async () => {
-    ;(apiClient.chat as any).mockRejectedValue(new Error('Chat failed'))
+    ;(apiClient.chatStream as any).mockImplementation(async function* () {
+      throw new Error('Chat failed')
+      yield // make it a generator
+    })
 
     render(<ChatPanel />)
 
@@ -529,12 +518,9 @@ describe('ChatPanel', () => {
 
   it('should handle setChatFeedback error', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
-      content: 'Response',
-      chat_log_id: 1,
-      feedback: null,
-    })
+    ;(apiClient.chatStream as any).mockImplementation(
+      makeStreamMock({ content: 'Response', chat_log_id: 1, feedback: null }),
+    )
     ;(apiClient.setChatFeedback as any).mockRejectedValue(new Error('Failed to update feedback'))
 
     render(<ChatPanel />)
@@ -585,7 +571,7 @@ describe('ChatPanel', () => {
     })
 
     // Should not call chat API during composition
-    expect(apiClient.chat).not.toHaveBeenCalled()
+    expect(apiClient.chatStream).not.toHaveBeenCalled()
   })
 
   it('should display citation timestamps in history', async () => {
@@ -628,28 +614,15 @@ describe('ChatPanel', () => {
   })
 
   it('should render multiple reference ids as separate buttons', async () => {
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
+    ;(apiClient.chatStream as any).mockImplementation(makeStreamMock({
       content: 'This is grounded text[1][2].',
       citations: [
-        {
-          id: 1,
-          video_id: 1,
-          title: 'Video One',
-          start_time: '00:01:30',
-          end_time: '00:15:30',
-        },
-        {
-          id: 2,
-          video_id: 2,
-          title: 'Video Two',
-          start_time: '00:02:30',
-          end_time: '00:08:30',
-        },
+        { id: 1, video_id: 1, title: 'Video One', start_time: '00:01:30', end_time: '00:15:30' },
+        { id: 2, video_id: 2, title: 'Video Two', start_time: '00:02:30', end_time: '00:08:30' },
       ],
       chat_log_id: 1,
       feedback: null,
-    })
+    }))
 
     render(<ChatPanel />)
 
@@ -671,21 +644,12 @@ describe('ChatPanel', () => {
   })
 
   it('should normalize millisecond timestamps in inline links', async () => {
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
+    ;(apiClient.chatStream as any).mockImplementation(makeStreamMock({
       content: 'Deep learning is useful[1]. It finds a good function.',
-      citations: [
-        {
-          id: 1,
-          video_id: 1,
-          title: 'Test Video',
-          start_time: '00:06:37,480',
-          end_time: '00:07:47,900',
-        },
-      ],
+      citations: [{ id: 1, video_id: 1, title: 'Test Video', start_time: '00:06:37,480', end_time: '00:07:47,900' }],
       chat_log_id: 1,
       feedback: null,
-    })
+    }))
 
     render(<ChatPanel />)
 
@@ -703,12 +667,9 @@ describe('ChatPanel', () => {
   })
 
   it('should keep unmatched citation markers as plain text', async () => {
-    ;(apiClient.chat as any).mockResolvedValue({
-      role: 'assistant',
-      content: 'Response [2]',
-      chat_log_id: 1,
-      feedback: null,
-    })
+    ;(apiClient.chatStream as any).mockImplementation(
+      makeStreamMock({ content: 'Response [2]', chat_log_id: 1, feedback: null }),
+    )
 
     render(<ChatPanel />)
 

--- a/frontend/src/hooks/__tests__/useChatMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useChatMessages.test.ts
@@ -1,0 +1,227 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useChatMessages } from '../useChatMessages'
+import { apiClient } from '@/lib/api'
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    apiClient: {
+      chatStream: vi.fn(),
+      setChatFeedback: vi.fn(),
+    },
+  }
+})
+
+// Helper: create an async generator mock for chatStream
+function makeStreamMock(
+  chunks: string[],
+  done?: { chat_log_id?: number | null; feedback?: 'good' | 'bad' | null; citations?: unknown[] },
+) {
+  return async function* () {
+    for (const text of chunks) {
+      yield { type: 'content_chunk' as const, text }
+    }
+    yield {
+      type: 'done' as const,
+      chat_log_id: done?.chat_log_id ?? null,
+      feedback: done?.feedback ?? null,
+      citations: done?.citations,
+    }
+  }
+}
+
+describe('useChatMessages streaming', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('adds an empty assistant message immediately when sending', async () => {
+    ;(apiClient.chatStream as any).mockImplementation(makeStreamMock([]))
+
+    const { result } = renderHook(() => useChatMessages({}))
+
+    act(() => {
+      result.current.setInput('Hello')
+    })
+
+    act(() => {
+      void result.current.handleSend()
+    })
+
+    // After send is triggered, an empty assistant message should appear
+    await waitFor(() => {
+      const messages = result.current.messages
+      const assistantMsgs = messages.filter((m) => m.role === 'assistant')
+      // greeting + new empty one
+      expect(assistantMsgs.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  it('accumulates content as content_chunk events arrive', async () => {
+    ;(apiClient.chatStream as any).mockImplementation(
+      makeStreamMock(['Hello ', 'World']),
+    )
+
+    const { result } = renderHook(() => useChatMessages({}))
+
+    act(() => {
+      result.current.setInput('Hi')
+    })
+
+    await act(async () => {
+      await result.current.handleSend()
+    })
+
+    await waitFor(() => {
+      const last = result.current.messages.at(-1)
+      expect(last?.content).toBe('Hello World')
+    })
+  })
+
+  it('sets chatLogId and feedback from done event', async () => {
+    ;(apiClient.chatStream as any).mockImplementation(
+      makeStreamMock(['Response'], { chat_log_id: 99, feedback: null }),
+    )
+
+    const { result } = renderHook(() => useChatMessages({}))
+
+    act(() => { result.current.setInput('Hi') })
+
+    await act(async () => { await result.current.handleSend() })
+
+    await waitFor(() => {
+      const last = result.current.messages.at(-1)
+      expect(last?.chatLogId).toBe(99)
+      expect(last?.feedback).toBeNull()
+    })
+  })
+
+  it('shows error message when stream yields error event', async () => {
+    ;(apiClient.chatStream as any).mockImplementation(async function* () {
+      yield { type: 'error', code: 'LLM_PROVIDER_ERROR', message: 'Internal error' }
+    })
+
+    const { result } = renderHook(() => useChatMessages({}))
+
+    act(() => { result.current.setInput('Hi') })
+
+    await act(async () => { await result.current.handleSend() })
+
+    await waitFor(() => {
+      const last = result.current.messages.at(-1)
+      expect(last?.role).toBe('assistant')
+      expect(last?.content).toMatch(/chat\.error/)
+    })
+  })
+
+  it('shows error message when chatStream throws', async () => {
+    ;(apiClient.chatStream as any).mockImplementation(async function* () {
+      throw new Error('Network error')
+      yield // make it a generator
+    })
+
+    const { result } = renderHook(() => useChatMessages({}))
+
+    act(() => { result.current.setInput('Hi') })
+
+    await act(async () => { await result.current.handleSend() })
+
+    await waitFor(() => {
+      const last = result.current.messages.at(-1)
+      expect(last?.role).toBe('assistant')
+      expect(last?.content).toMatch(/chat\.error/)
+    })
+  })
+
+  it('sets isLoading to false after streaming completes', async () => {
+    ;(apiClient.chatStream as any).mockImplementation(makeStreamMock(['Done']))
+
+    const { result } = renderHook(() => useChatMessages({}))
+
+    act(() => { result.current.setInput('Hi') })
+
+    await act(async () => {
+      await result.current.handleSend()
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
+
+  it('updates message content after each token (intermediate state visible between tokens)', async () => {
+    const resolvers: Array<() => void> = []
+
+    ;(apiClient.chatStream as any).mockImplementation(async function* () {
+      yield { type: 'content_chunk' as const, text: 'A' }
+      // Pause — simulates network gap between tokens
+      await new Promise<void>((resolve) => resolvers.push(resolve))
+      yield { type: 'content_chunk' as const, text: 'B' }
+      yield { type: 'done' as const, chat_log_id: null, feedback: null }
+    })
+
+    const { result } = renderHook(() => useChatMessages({}))
+    act(() => { result.current.setInput('Hi') })
+
+    // Start streaming without awaiting
+    act(() => { void result.current.handleSend() })
+
+    // First token should be visible before second arrives
+    await waitFor(() => {
+      expect(result.current.messages.at(-1)?.content).toBe('A')
+    })
+
+    // Release second token
+    act(() => { resolvers[0]?.() })
+
+    // Both tokens should now be visible
+    await waitFor(() => {
+      expect(result.current.messages.at(-1)?.content).toBe('AB')
+    })
+  })
+
+  it('renders a bursty chunk over multiple ticks instead of showing all text at once', async () => {
+    vi.useFakeTimers()
+    ;(apiClient.chatStream as any).mockImplementation(async function* () {
+      yield { type: 'content_chunk' as const, text: 'ABCDEF' }
+      yield { type: 'done' as const, chat_log_id: null, feedback: null }
+    })
+
+    const { result } = renderHook(() => useChatMessages({}))
+
+    act(() => { result.current.setInput('Hi') })
+
+    act(() => { void result.current.handleSend() })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(24)
+    })
+    expect(result.current.messages.at(-1)?.content).toBe('ABC')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(24)
+    })
+    expect(result.current.messages.at(-1)?.content).toBe('ABCDEF')
+
+    vi.useRealTimers()
+  })
+
+  it('calls chatStream with groupId when provided', async () => {
+    ;(apiClient.chatStream as any).mockImplementation(makeStreamMock(['ok']))
+
+    const { result } = renderHook(() => useChatMessages({ groupId: 5 }))
+
+    act(() => { result.current.setInput('Hi') })
+
+    await act(async () => {
+      await result.current.handleSend()
+    })
+
+    await waitFor(() => {
+      expect(apiClient.chatStream).toHaveBeenCalledWith(
+        expect.objectContaining({ group_id: 5 }),
+      )
+    })
+  })
+})

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -1,7 +1,11 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { flushSync } from 'react-dom';
 import { useMutation } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { apiClient, ApiError, type Citation } from '@/lib/api';
+
+const STREAM_RENDER_TICK_MS = 24;
+const STREAM_RENDER_CHARS_PER_TICK = 3;
 
 export interface Message {
   role: 'user' | 'assistant';
@@ -40,6 +44,88 @@ export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions)
   const [feedbackUpdatingId, setFeedbackUpdatingId] = useState<number | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const pendingContentRef = useRef('');
+  const pendingDoneEventRef = useRef<Extract<Awaited<ReturnType<typeof apiClient.chatStream>> extends AsyncGenerator<infer T> ? T : never, { type: 'done' }> | null>(null);
+  const drainTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const streamFinishedRef = useRef(false);
+  const drainWaitersRef = useRef<Array<() => void>>([]);
+
+  const stopDrainTimer = useCallback(() => {
+    if (drainTimerRef.current !== null) {
+      clearInterval(drainTimerRef.current);
+      drainTimerRef.current = null;
+    }
+  }, []);
+
+  const applyDoneMetadata = useCallback((event: NonNullable<typeof pendingDoneEventRef.current>) => {
+    setMessages((prev) => {
+      const updated = [...prev];
+      updated[updated.length - 1] = {
+        ...updated[updated.length - 1],
+        citations: event.citations,
+        chatLogId: event.chat_log_id ?? undefined,
+        feedback: event.feedback ?? null,
+      };
+      return updated;
+    });
+  }, []);
+
+  const flushDrainWaiters = useCallback(() => {
+    const waiters = drainWaitersRef.current.splice(0);
+    waiters.forEach((resolve) => resolve());
+  }, []);
+
+  const tryFinalizeDrain = useCallback(() => {
+    if (pendingContentRef.current !== '' || !streamFinishedRef.current) {
+      return;
+    }
+    stopDrainTimer();
+    if (pendingDoneEventRef.current) {
+      applyDoneMetadata(pendingDoneEventRef.current);
+      pendingDoneEventRef.current = null;
+    }
+    flushDrainWaiters();
+  }, [applyDoneMetadata, flushDrainWaiters, stopDrainTimer]);
+
+  const drainNextSlice = useCallback(() => {
+    if (pendingContentRef.current === '') {
+      tryFinalizeDrain();
+      return;
+    }
+
+    const nextText = pendingContentRef.current.slice(0, STREAM_RENDER_CHARS_PER_TICK);
+    pendingContentRef.current = pendingContentRef.current.slice(STREAM_RENDER_CHARS_PER_TICK);
+
+    flushSync(() => {
+      setMessages((prev) => {
+        const updated = [...prev];
+        const last = updated[updated.length - 1];
+        updated[updated.length - 1] = { ...last, content: last.content + nextText };
+        return updated;
+      });
+    });
+
+    tryFinalizeDrain();
+  }, [tryFinalizeDrain]);
+
+  const ensureDrainTimer = useCallback(() => {
+    if (drainTimerRef.current !== null) {
+      return;
+    }
+    drainTimerRef.current = setInterval(() => {
+      drainNextSlice();
+    }, STREAM_RENDER_TICK_MS);
+  }, [drainNextSlice]);
+
+  const waitForDrainCompletion = useCallback(async () => {
+    if (pendingContentRef.current === '' && streamFinishedRef.current) {
+      tryFinalizeDrain();
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      drainWaitersRef.current.push(resolve);
+    });
+  }, [tryFinalizeDrain]);
 
   // Auto-scroll on new messages
   useEffect(() => {
@@ -47,16 +133,6 @@ export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions)
       messagesContainerRef.current.scrollTop = messagesContainerRef.current.scrollHeight;
     }
   }, [messages]);
-
-  const chatMutation = useMutation({
-    mutationFn: async (userMessage: Message) => {
-      return await apiClient.chat({
-        messages: [userMessage],
-        ...(groupId ? { group_id: groupId } : {}),
-        ...(shareToken ? { share_slug: shareToken } : {}),
-      });
-    },
-  });
 
   const feedbackMutation = useMutation({
     mutationFn: async ({ chatLogId, nextFeedback }: { chatLogId: number; nextFeedback: 'good' | 'bad' | null }) =>
@@ -67,37 +143,78 @@ export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions)
     if (!input.trim() || isLoading) return;
 
     const userMessage: Message = { role: 'user', content: input };
-    setMessages((prev) => [...prev, userMessage]);
+    pendingContentRef.current = '';
+    pendingDoneEventRef.current = null;
+    streamFinishedRef.current = false;
+    stopDrainTimer();
+    setMessages((prev) => [...prev, userMessage, { role: 'assistant', content: '' }]);
     setInput('');
     setIsLoading(true);
 
     try {
-      const response = await chatMutation.mutateAsync(userMessage);
-
-      setMessages((prev) => [
-        ...prev,
-        {
-          role: response.role,
-          content: response.content,
-          citations: response.citations,
-          chatLogId: response.chat_log_id,
-          feedback: response.feedback ?? null,
-        },
-      ]);
+      for await (const event of apiClient.chatStream({
+        messages: [userMessage],
+        ...(groupId ? { group_id: groupId } : {}),
+        ...(shareToken ? { share_slug: shareToken } : {}),
+      })) {
+        if (event.type === 'content_chunk') {
+          pendingContentRef.current += event.text;
+          ensureDrainTimer();
+        } else if (event.type === 'done') {
+          pendingDoneEventRef.current = event;
+          streamFinishedRef.current = true;
+          tryFinalizeDrain();
+        } else if (event.type === 'error') {
+          pendingContentRef.current = '';
+          pendingDoneEventRef.current = null;
+          streamFinishedRef.current = true;
+          stopDrainTimer();
+          flushDrainWaiters();
+          const errorMessage =
+            event.code === 'OVER_QUOTA'
+              ? t('chat.errorOverQuota')
+              : t('chat.error');
+          setMessages((prev) => {
+            const updated = [...prev];
+            updated[updated.length - 1] = { role: 'assistant', content: errorMessage };
+            return updated;
+          });
+        }
+      }
+      streamFinishedRef.current = true;
+      await waitForDrainCompletion();
     } catch (error) {
+      pendingContentRef.current = '';
+      pendingDoneEventRef.current = null;
+      streamFinishedRef.current = true;
+      stopDrainTimer();
+      flushDrainWaiters();
       console.error('Chat error:', error);
       const errorMessage =
         error instanceof ApiError && error.code === 'OVER_QUOTA'
           ? t('chat.errorOverQuota')
           : t('chat.error');
-      setMessages((prev) => [
-        ...prev,
-        { role: 'assistant', content: errorMessage },
-      ]);
+      setMessages((prev) => {
+        const updated = [...prev];
+        updated[updated.length - 1] = { role: 'assistant', content: errorMessage };
+        return updated;
+      });
     } finally {
       setIsLoading(false);
     }
-  }, [input, isLoading, chatMutation, t]);
+  }, [
+    applyDoneMetadata,
+    ensureDrainTimer,
+    flushDrainWaiters,
+    groupId,
+    input,
+    isLoading,
+    shareToken,
+    stopDrainTimer,
+    t,
+    tryFinalizeDrain,
+    waitForDrainCompletion,
+  ]);
 
   const handleKeyPress = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.nativeEvent.isComposing || e.key === 'Process') return;
@@ -131,6 +248,12 @@ export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions)
       setFeedbackUpdatingId(null);
     }
   }, [messages, feedbackMutation]);
+
+  useEffect(() => {
+    return () => {
+      stopDrainTimer();
+    };
+  }, [stopDrainTimer]);
 
   return {
     messages,

--- a/frontend/src/lib/__tests__/api.stream.test.ts
+++ b/frontend/src/lib/__tests__/api.stream.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.unmock('@/lib/api')
+
+import { apiClient } from '../api'
+
+// Helper: build a fake SSE ReadableStream from an array of SSE lines
+function makeSSEResponse(lines: string[], status = 200): Response {
+  const body = lines.join('\n') + '\n'
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(body))
+      controller.close()
+    },
+  })
+  return new Response(stream, {
+    status,
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+}
+
+// Helper: collect all events from chatStream
+async function collectStreamEvents(data: Parameters<typeof apiClient.chatStream>[0]) {
+  const events = []
+  for await (const event of apiClient.chatStream(data)) {
+    events.push(event)
+  }
+  return events
+}
+
+describe('apiClient.chatStream', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    // Provide a CSRF token via cookie so ensureCsrfToken resolves quickly
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'csrftoken=test-csrf-token',
+    })
+    ;(apiClient as any).csrfToken = null
+    ;(apiClient as any).baseUrl = 'http://localhost:8000/api'
+  })
+
+  it('yields content_chunk events from SSE stream', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeSSEResponse([
+        'data: {"type":"content_chunk","text":"Hello "}',
+        'data: {"type":"content_chunk","text":"World"}',
+        'data: {"type":"done","chat_log_id":null,"feedback":null}',
+      ]),
+    )
+
+    const events = await collectStreamEvents({
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+
+    const chunks = events.filter((e) => e.type === 'content_chunk')
+    expect(chunks).toHaveLength(2)
+    expect(chunks[0]).toEqual({ type: 'content_chunk', text: 'Hello ' })
+    expect(chunks[1]).toEqual({ type: 'content_chunk', text: 'World' })
+  })
+
+  it('yields done event with metadata', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeSSEResponse([
+        'data: {"type":"content_chunk","text":"Hi"}',
+        'data: {"type":"done","chat_log_id":42,"feedback":null}',
+      ]),
+    )
+
+    const events = await collectStreamEvents({
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+
+    const done = events.find((e) => e.type === 'done')
+    expect(done).toEqual({ type: 'done', chat_log_id: 42, feedback: null })
+  })
+
+  it('yields error event from SSE', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeSSEResponse([
+        'data: {"type":"error","code":"LLM_CONFIGURATION_ERROR","message":"Invalid API key"}',
+      ]),
+    )
+
+    const events = await collectStreamEvents({
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+
+    expect(events[0]).toEqual({
+      type: 'error',
+      code: 'LLM_CONFIGURATION_ERROR',
+      message: 'Invalid API key',
+    })
+  })
+
+  it('calls correct endpoint for group chat with share_slug', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeSSEResponse(['data: {"type":"done","chat_log_id":null,"feedback":null}']),
+    )
+
+    await collectStreamEvents({
+      messages: [{ role: 'user', content: 'hi' }],
+      share_slug: 'abc123',
+    })
+
+    const calledUrl = fetchSpy.mock.calls[0][0] as string
+    expect(calledUrl).toContain('/chat/messages/stream/')
+    expect(calledUrl).toContain('share_slug=abc123')
+  })
+
+  it('throws ApiError on non-200 HTTP response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 'VALIDATION_ERROR', message: 'Bad input' } }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(collectStreamEvents({
+      messages: [{ role: 'user', content: '' }],
+    })).rejects.toThrow()
+  })
+
+  it('handles chunked SSE delivery across multiple reads', async () => {
+    const encoder = new TextEncoder()
+    // Split a single SSE line across two reads
+    const part1 = 'data: {"type":"content_chunk"'
+    const part2 = ',"text":"split"}\ndata: {"type":"done","chat_log_id":null,"feedback":null}\n'
+
+    let readCount = 0
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (readCount === 0) {
+          controller.enqueue(encoder.encode(part1))
+          readCount++
+        } else if (readCount === 1) {
+          controller.enqueue(encoder.encode(part2))
+          readCount++
+        } else {
+          controller.close()
+        }
+      },
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+    )
+
+    const events = await collectStreamEvents({
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+
+    const chunks = events.filter((e) => e.type === 'content_chunk')
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]).toEqual({ type: 'content_chunk', text: 'split' })
+  })
+})

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -144,6 +144,11 @@ export interface ChatRequest {
   share_slug?: string;
 }
 
+export type ChatStreamEvent =
+  | { type: 'content_chunk'; text: string }
+  | { type: 'done'; chat_log_id: number | null; feedback: 'good' | 'bad' | null; citations?: Citation[] }
+  | { type: 'error'; code: string; message: string };
+
 export interface Video {
   id: number;
   user: number;
@@ -677,6 +682,66 @@ class ApiClient {
       method: 'POST',
       body: bodyData,
     });
+  }
+
+  async *chatStream(data: ChatRequest): AsyncGenerator<ChatStreamEvent> {
+    const { share_slug, ...bodyData } = data;
+    const endpoint = share_slug
+      ? `/chat/messages/stream/?share_slug=${share_slug}`
+      : '/chat/messages/stream/';
+
+    const url = this.buildUrl(endpoint);
+    const headers = this.buildHeaders(bodyData);
+
+    const csrfToken = await this.ensureCsrfToken();
+    if (csrfToken) {
+      headers['X-CSRFToken'] = csrfToken;
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(bodyData),
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      await this.handleError(response);
+      return;
+    }
+
+    if (!response.body) return;
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (trimmed.startsWith('data: ')) {
+            const jsonStr = trimmed.slice(6).trim();
+            if (jsonStr) {
+              try {
+                yield JSON.parse(jsonStr) as ChatStreamEvent;
+              } catch {
+                // ignore malformed JSON
+              }
+            }
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
   }
 
   async setChatFeedback(


### PR DESCRIPTION
## Summary
- add SSE-based chat streaming flow end-to-end across chat use case, gateway, API, and frontend client
- make streamed assistant text render progressively in the UI instead of appearing all at once
- align OpenAPI docs for /chat/messages/ and /chat/messages/stream/, including share_slug and SSE response behavior

## Changes
- add streaming DTOs, use case path, SSE view, and route for messages/stream/
- add frontend streaming client parsing and hook/UI tests for incremental updates
- split batched upstream stream chunks into smaller units before emitting SSE content chunks
- document messages/stream/ as text/event-stream and add share_slug query parameter to both chat endpoints

## Testing
- docker compose run --rm backend python manage.py test --keepdb --noinput app.infrastructure.external.tests.test_rag_chat app.use_cases.chat.tests.test_stream_message app.presentation.chat.tests.test_streaming_view
- npm test -- --run src/hooks/__tests__/useChatMessages.test.ts
- npm test -- --run src/lib/__tests__/api.stream.test.ts

## Notes
- transport-level streaming was already working, but bursty chunk arrival still looked like one-shot rendering in the browser; the frontend now drains a small render queue to make progressive output visible
- OpenAPI docs now match runtime behavior for shared-access chat on both endpoints
