### PR TITLE
Remove per-character SSE splitting, stream raw LLM tokens

### DIFF
--- a/backend/app/infrastructure/external/rag_gateway.py
+++ b/backend/app/infrastructure/external/rag_gateway.py
@@ -28,18 +28,6 @@ logger = logging.getLogger(__name__)
 class RagChatGateway(RagGateway):
     """Implements RagGateway by delegating to RagChatService."""
 
-    @staticmethod
-    def _iter_text_units(text: str) -> Iterator[str]:
-        """Yield the smallest display units for streaming updates.
-
-        Upstream LLM providers may coalesce multiple characters into a single
-        streamed chunk. Split those chunks here so the downstream SSE contract
-        can update incrementally even when the provider batches output.
-        """
-        for unit in text:
-            if unit:
-                yield unit
-
     def generate_reply(
         self,
         messages: Sequence[ChatMessageDTO],
@@ -155,8 +143,8 @@ class RagChatGateway(RagGateway):
                         query_text=item.query_text,
                     )
                 else:
-                    for unit in self._iter_text_units(item):
-                        yield RagStreamChunk(text=unit)
+                    if item:
+                        yield RagStreamChunk(text=item)
         except OpenAIAuthenticationError as exc:
             raise LLMConfigurationError(
                 "Invalid OpenAI API key. Please check your API key in Settings."

--- a/backend/app/infrastructure/external/tests/test_rag_chat.py
+++ b/backend/app/infrastructure/external/tests/test_rag_chat.py
@@ -138,8 +138,8 @@ class RagChatGatewayStreamingTests(TestCase):
 
         content_chunks = [c for c in chunks if c.text is not None]
         self.assertEqual("".join(chunk.text for chunk in content_chunks), "Hello World")
-        self.assertEqual(content_chunks[0].text, "H")
-        self.assertEqual(content_chunks[-1].text, "d")
+        self.assertEqual(content_chunks[0].text, "Hello ")
+        self.assertEqual(content_chunks[-1].text, "World")
 
     @patch("app.infrastructure.external.rag_gateway.get_langchain_llm")
     @patch("app.infrastructure.external.rag_gateway.RagChatService")
@@ -162,7 +162,7 @@ class RagChatGatewayStreamingTests(TestCase):
         chunks = list(gateway.stream_reply(messages=messages, user_id=self.user.id))
 
         content_chunks = [c.text for c in chunks if c.text is not None]
-        self.assertEqual(content_chunks, ["A", "B"])
+        self.assertEqual(content_chunks, ["AB"])
 
     @patch("app.infrastructure.external.rag_gateway.get_langchain_llm")
     @patch("app.infrastructure.external.rag_gateway.RagChatService")


### PR DESCRIPTION
## Summary

- `RagChatGateway._iter_text_units()` を削除し、LLMから届いたトークンをそのままSSEで流すように変更
- 1文字ずつ分解していた実装はイベント数が増えオーバーヘッドになっていたため、一般的なトークン単位のストリーミングに統一

## Test plan

- [ ] チャットのストリーミングが正常に動作することを確認
- [ ] エラー時のSSEイベント (`type: error`) が正常に配信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)