### PR TITLE
docs: Fix Mermaid parse errors and sync docs with current implementation

### DIFF
--- a/docs/architecture/prompt-engineering.md
+++ b/docs/architecture/prompt-engineering.md
@@ -10,10 +10,11 @@ VideoQのAIチャット機能は、RAG（Retrieval-Augmented Generation）アー
 
 RAGチャットのシステムプロンプトは以下の要素で構成されます:
 
-1. **ヘッダー**: アシスタントの役割と知識の権威範囲を定義
-2. **ルール**: 回答生成の厳密な制約（例: 根拠、前提の取り扱い、不確実性の処理）
-3. **フォーマット指示**: 自然な文章出力と箇条書きの回避を指定
-4. **参考資料**: ベクトル検索から取得した関連シーン情報
+1. **ヘッダー**: アシスタントの役割・背景・リクエストを定義
+2. **グループコンテキスト** (任意): グループに関する補足情報
+3. **ルール**: 回答生成の詳細な制約（根拠・前提の取り扱い・引用ルール等）
+4. **フォーマット指示**: 自然な文章出力、インライン引用 `[N]` の使い方
+5. **参照シーン**: ベクトル検索から取得した関連シーン情報（`[1]`, `[2]` 番号付き）
 
 ### プロンプト生成フロー
 
@@ -43,21 +44,27 @@ Generate Answer (English or Japanese)
 {
   "rag": {
     "default": {
-      "header": "You are {role}. Because {background}, please {request}. Follow the rules below and respond using the specified format.",
-      "role": "an assistant that answers strictly and exclusively based on scenes linked to the user's video group",
-      "background": "the conversation must remain fully grounded in the provided video scenes and their explanations",
-      "request": "answer the user's latest message",
-      "format_instruction": "Respond in clear, natural sentences. Avoid bullet points unless structural clarity would otherwise be lost.",
+      "header": "You are {role}. Because {background}, {request}. Follow the rules below strictly and respond using the specified format.",
+      "role": "an assistant that answers strictly using only the scenes included in the user's video group as evidence",
+      "background": "the conversation must be based entirely on the scope of knowledge defined by the provided scenes in the video group and their explanations",
+      "request": "answer the user's latest question",
+      "format_instruction": "As a rule, do not use bullet points unless the structure would otherwise become unclear. Explain things clearly and concisely in natural prose. Do not stitch together spoken fragments from the video verbatim; rewrite them into polished sentences for the user. When you use a provided scene, place [N] (e.g., [1], [2]) immediately after the relevant phrase or sentence. Do not attach markers to statements that are not supported by evidence.",
+      "section_titles": {
+        "rules": "# Rules",
+        "format": "# Format",
+        "reference": "# Reference Scenes",
+        "group_context": "# Group Context"
+      },
       "rules": [
-        "Treat the provided video scenes as the sole authoritative source of truth.",
-        "Do not rely on general knowledge or external information.",
-        "If the premise clearly contradicts the video scenes, explicitly point out the misunderstanding.",
-        "If you are genuinely unsure, explicitly state that you do not know rather than guessing.",
-        "Always answer in English."
+        "Treat the provided video scenes as the primary source of supporting evidence.",
+        "Do not rely on general knowledge, external information, or independent expert knowledge that is not grounded in the video scenes.",
+        "...(18 rules total)"
       ],
       "reference": {
-        "lead": "Below are relevant scenes extracted from the user's video group.",
-        "empty": "If no relevant scenes are available, explicitly state that the content is outside the scope of the video materials."
+        "lead": "The following are relevant scenes extracted from the user's video group.",
+        "usage": "When answering factual or definitional questions, cite the relevant scenes inline in the form [N].",
+        "footer": "Include a brief description of a scene only when it is needed to supplement the explanation.",
+        "empty": "If no relevant scenes are provided, explicitly state that the content is outside the scope of the video materials and do not speculate."
       }
     }
   }
@@ -66,7 +73,7 @@ Generate Answer (English or Japanese)
 
 ### 日本語プロンプト
 
-日本語ロケール（`ja`）用のプロンプトも定義されており、`Accept-Language` ヘッダーに基づいて自動選択されます。
+日本語ロケール（`ja`）用のプロンプトも定義されており、`Accept-Language` ヘッダーに基づいて自動選択されます。ルール・フォーマット指示・セクションタイトル・参照テキストがすべて日本語で上書きされます。
 
 ## プロンプト生成の詳細
 
@@ -74,45 +81,63 @@ Generate Answer (English or Japanese)
 
 `backend/app/infrastructure/external/prompts/loader.py` の `build_system_prompt` 関数は、プロンプトテンプレートと検索結果を組み合わせて最終的なシステムプロンプトを生成します。
 
+**シグネチャ:**
+```python
+def build_system_prompt(
+    locale: Optional[str] = None,
+    references: Optional[Sequence[str]] = None,
+    group_context: Optional[str] = None,
+) -> str:
+```
+
 **パラメータ:**
 - `locale`: ロケール（例: `"ja"`、`"en"`）。`None` の場合はデフォルト（英語）を使用
-- `references`: ベクトル検索から取得した関連シーンのリスト
+- `references`: ベクトル検索から取得した関連シーンの文字列リスト（`[i]` プレフィックス付き）
+- `group_context`: グループに関する補足情報（任意）。指定するとルールの前に `# Group Context` セクションとして挿入される
 
 **生成されるプロンプト構成:**
 
 ```
 [Header]
 
+# Group Context        ← group_context が指定された場合のみ
+[Group Context]
+
 # Rules
 1. [Rule 1]
 2. [Rule 2]
+...
 
 # Format
 [Format Instruction]
 
-# Reference Materials
+# Reference Scenes
 [Reference Lead Text]
-[Related Scene 1]
-[Related Scene 2]
+[1] [Video Title] [Start Time] - [End Time]
+[Scene Content]
+[2] [Video Title] [Start Time] - [End Time]
+[Scene Content]
 ...
 [Reference Footer]
 ```
 
-### 参考情報のフォーマット
+### 参照情報のフォーマット
 
-各関連シーンは以下のフォーマットでプロンプトに含まれます:
+各関連シーンは以下のフォーマットでプロンプトに含まれます（`_build_reference_entries` in `rag_service.py`）:
 
 ```
-[Video Title] [Start Time] - [End Time]
-[Scene Transcription Content]
+[{i}] {video_title} {start_time} - {end_time}
+{page_content}
 ```
 
 Example:
 ```
-Project Overview Video 00:01:23 - 00:02:45
+[1] Project Overview Video 00:01:23 - 00:02:45
 This project is a web application that provides video transcription and AI chat features.
 Main features include video upload, automatic transcription, and AI chat.
 ```
+
+`[N]` 番号はインライン引用で使われるため、エントリに番号が付与されます。
 
 ## ロケールサポート
 
@@ -126,6 +151,8 @@ Main features include video upload, automatic transcription, and AI chat.
 1. 指定されたロケール（例: `"ja-JP"`）
 2. ロケールの言語部分（例: `"ja"`）
 3. デフォルト（`"default"`）
+
+新しいロケールを追加すると、`_deep_merge` を使用して `default` とマージされます（指定フィールドのみ上書き）。
 
 ### ロケールの指定
 
@@ -147,21 +174,19 @@ Accept-Language: ja,en;q=0.9
 
 ### 検索結果の処理
 
-検索から取得したドキュメントは、RAGサービスの `_build_reference_entries` メソッドによってプロンプトの参考情報に変換されます:
+検索から取得したドキュメントは、`PGVectorRAGService._build_reference_entries` によってプロンプトの参照情報に変換されます:
 
 ```python
 def _build_reference_entries(self, docs: Sequence[Any]) -> List[str]:
-    """Generate reference information list for detailed prompt from documents"""
     reference_entries = []
-    for doc in docs:
+    for i, doc in enumerate(docs, start=1):
         metadata = getattr(doc, "metadata", {}) or {}
         title = metadata.get("video_title", "")
         start_time = metadata.get("start_time", "")
         end_time = metadata.get("end_time", "")
         page_content = getattr(doc, "page_content", "")
-        
         reference_entries.append(
-            f"{title} {start_time} - {end_time}\n{page_content}"
+            f"[{i}] {title} {start_time} - {end_time}\n{page_content}"
         )
     return reference_entries
 ```
@@ -174,7 +199,7 @@ def _build_reference_entries(self, docs: Sequence[Any]) -> List[str]:
 
 **注意事項:**
 - 既存のキー構成を維持してください
-- 必須フィールド（`header`, `role`, `background`, `request`, `format_instruction`）を含めてください
+- 必須フィールド（`header`, `role`, `background`, `request`, `format_instruction`, `rules`, `section_titles`, `reference`）を含めてください
 - 新しいロケールを追加すると、`_deep_merge` を使用して `default` とマージされます
 
 ### 新しいロケールの追加
@@ -187,17 +212,20 @@ def _build_reference_entries(self, docs: Sequence[Any]) -> List[str]:
     "default": { ... },
     "ja": { ... },
     "fr": {
-      "header": "Vous êtes {role}. Parce que {background}, veuillez {request}...",
+      "header": "Vous êtes {role}. Parce que {background}, {request}...",
       "role": "un assistant qui répond en utilisant des scènes liées au groupe vidéo de l'utilisateur",
-      ...
+      "section_titles": {
+        "rules": "# Règles",
+        "format": "# Format",
+        "reference": "# Scènes de référence",
+        "group_context": "# Contexte du groupe"
+      },
+      "rules": [...],
+      "reference": { ... }
     }
   }
 }
 ```
-
-### プロンプト構成の変更
-
-プロンプト構成を大幅に変更する必要がある場合は、`backend/app/infrastructure/external/prompts/loader.py` の `build_system_prompt` 関数も更新する必要があります。
 
 ## ベストプラクティス
 
@@ -205,8 +233,9 @@ def _build_reference_entries(self, docs: Sequence[Any]) -> List[str]:
 
 1. **明確な役割定義**: アシスタントの役割を明確に定義
 2. **コンテキストの強調**: 提供されたシーン情報を優先するよう指示
-3. **不確実性の処理**: 不確実な場合は、憶測ではなくそのことを明確に述べる
-4. **出力フォーマットの指定**: 一貫した出力フォーマットを指定
+3. **引用ルールの明示**: `[N]` インライン引用の使い方をフォーマット指示に含める
+4. **不確実性の処理**: 不確実な場合は、憶測ではなくそのことを明確に述べる
+5. **前提チェック**: 質問に誤った前提が含まれる場合の処理を明示
 
 ### パフォーマンス最適化
 
@@ -224,14 +253,15 @@ from app.infrastructure.external.prompts import build_system_prompt
 # Default locale
 prompt = build_system_prompt(
     locale=None,
-    references=["Test Video 00:00:00 - 00:01:00\nTest content"]
+    references=["[1] Test Video 00:00:00 - 00:01:00\nTest content"]
 )
 print(prompt)
 
-# Japanese locale
+# Japanese locale with group context
 prompt_ja = build_system_prompt(
     locale="ja",
-    references=["テスト動画 00:00:00 - 00:01:00\nテスト内容"]
+    references=["[1] テスト動画 00:00:00 - 00:01:00\nテスト内容"],
+    group_context="このグループはPythonチュートリアルシリーズです。",
 )
 print(prompt_ja)
 ```

--- a/docs/architecture/system-configuration-diagram.md
+++ b/docs/architecture/system-configuration-diagram.md
@@ -152,8 +152,8 @@ graph TB
     end
 
     Browser -->|Request| CloudFront
-    CloudFront -->|/* (Static)| Pages
-    CloudFront -->|/api/*| API_GW
+    CloudFront -->|"/* (Static)"| Pages
+    CloudFront -->|"/api/*"| API_GW
     
     API_GW --> LambdaAPI
     LambdaAPI --> NeonDB

--- a/docs/database/er-diagram.md
+++ b/docs/database/er-diagram.md
@@ -37,7 +37,9 @@ erDiagram
         datetime deactivated_at
     }
 
-    User {
+    Subscription {
+        int id PK
+        int user_id FK
         string plan
         bigint used_storage_bytes
         int used_processing_seconds

--- a/docs/design/class-diagram.md
+++ b/docs/design/class-diagram.md
@@ -66,7 +66,7 @@ classDiagram
         +datetime created_at
     }
 
-    Note: ChatLog.feedback uses FeedbackChoices (good/bad)
+    %% ChatLog.feedback: FeedbackChoices (good/bad)
 
     class Tag {
         +int id
@@ -109,7 +109,7 @@ classDiagram
         +datetime requested_at
     }
 
-    class UserPlan {
+    class Subscription {
         +string plan
         +bigint used_storage_bytes
         +int used_processing_seconds

--- a/docs/design/component-diagram.md
+++ b/docs/design/component-diagram.md
@@ -166,6 +166,12 @@ graph TB
             subgraph MediaPres["media/"]
                 MediaViews[ProtectedMediaView]
             end
+            subgraph BillingPres["billing/"]
+                BillingViews["Views - PlanList, CurrentSubscription,
+                CreateCheckoutSession, CreateBillingPortal,
+                HandleWebhook"]
+                BillingSer[Serializers]
+            end
             CommonPres["common/ - auth (CookieJWTAuthentication,
             ApiKeyAuthentication, ShareTokenAuthentication),
             permissions, throttles"]
@@ -341,7 +347,8 @@ graph TB
                 ShareTokenResolver[ShareTokenResolver]
             end
             subgraph TasksInfra["tasks/"]
-                CeleryTaskGW[CeleryTaskGateway]
+                CeleryVideoTaskGW[CeleryVideoTaskGateway]
+                CeleryAuthTaskGW[CeleryAuthTaskGateway]
             end
             subgraph ChatInfra["chat/"]
                 KwExtractor[JanomeNltkKeywordExtractor]

--- a/docs/design/deployment-diagram.md
+++ b/docs/design/deployment-diagram.md
@@ -295,12 +295,12 @@ graph TB
     subgraph AWSCloud["AWS Region (ap-northeast-1)"]
         subgraph API_Layer["API Layer"]
             APIGW[API Gateway HTTP API]
-            LambdaAPI[Lambda API (Django + LWA)]
+            LambdaAPI["Lambda API (Django + LWA)"]
         end
         
         subgraph Worker_Layer["Worker Layer"]
             SQS[Amazon SQS Queue]
-            LambdaWorker[Lambda Worker (Celery)]
+            LambdaWorker["Lambda Worker (Celery)"]
         end
         
         subgraph ECR["Container Registry"]
@@ -329,8 +329,8 @@ graph TB
         NeonDB[(Neon Serverless<br>PostgreSQL)]
     end
     
-    CF -->|/*| Pages
-    CF -->|/api/*| APIGW
+    CF -->|"/*"| Pages
+    CF -->|"/api/*"| APIGW
     LambdaAPI -->|PostgreSQL connection| NeonDB
     LambdaWorker -->|PostgreSQL connection| NeonDB
     LambdaAPI -->|S3 API| R2


### PR DESCRIPTION
## Summary

- Mermaid 図のパースエラーを修正し、レンダリング不能だった図を修正
- 各ドキュメントの内容を現在の実装に追従させ、古い記述を更新

## Changes

### Mermaid パースエラー修正

- `system-configuration-diagram.md` — `/*` および `(Static)` を含むエッジラベルをクォートで修正
- `deployment-diagram.md` — `Lambda API (Django + LWA)` 等の `(` を含むノードラベルをクォートで修正、`/*` エッジラベルも修正

### ドキュメントと実装の同期

**er-diagram.md**
- `User` エンティティが2つ定義されていたパースエラーを修正（2つ目を `Subscription` エンティティに改名し `id`, `user_id FK` フィールドを追加）

**class-diagram.md**
- 無効な `Note:` 構文を `%%` コメント構文に変換（パースエラー修正）
- `UserPlan` クラスを `Subscription` に改名（ドメイン命名と統一）

**component-diagram.md**
- `CeleryTaskGateway`（廃止）を `CeleryVideoTaskGateway` + `CeleryAuthTaskGateway` の2つに更新
- presentation 層に `billing/` サブグラフを追加（`PlanList`, `CurrentSubscription`, `CreateCheckoutSession`, `CreateBillingPortal`, `HandleWebhook`）

**prompt-engineering.md**
- `prompts.json` のサンプルを実際の内容に更新（ルール 6件 → 18件、`[N]` インライン引用システム、`section_titles` キー、`reference` の4フィールド）
- `build_system_prompt` のシグネチャに `group_context` パラメータを追記
- 参照エントリのフォーマットを `[i]` インデックスプレフィックス付きに修正

## Test plan

- [ ] 各 Mermaid 図が GitHub / IDE でエラーなくレンダリングされることを確認
- [ ] ドキュメントのリンクが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)