### PR TITLE
RAGAS評価結果をダッシュボードと会話履歴に表示する

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState } from 'react';
-import { type ChatHistoryItem, type Citation } from '@/lib/api';
+import { type ChatHistoryItem, type ChatLogEvaluation, type Citation } from '@/lib/api';
 import { timeStringToSeconds } from '@/lib/utils/video';
 import { cn } from '@/lib/utils';
 import { InlineSpinner } from '@/components/common/InlineSpinner';
@@ -154,6 +154,70 @@ function ChatMessageBubble({ message, feedbackUpdatingId, onVideoNavigate, onFee
 
 // ── History item ──────────────────────────────────────────────────────────────
 
+function formatEvaluationPercent(value: number | null | undefined) {
+  if (value == null) return '-';
+  return `${Math.round(value * 100)}%`;
+}
+
+function EvaluationMetric({
+  label,
+  value,
+}: {
+  label: string;
+  value: number | null | undefined;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-stone-500">{label}</span>
+      <span className="font-semibold text-stone-800">{formatEvaluationPercent(value)}</span>
+    </div>
+  );
+}
+
+function HistoryEvaluation({ evaluation }: { evaluation?: ChatLogEvaluation }) {
+  const { t } = useTranslation();
+
+  if (!evaluation) return null;
+
+  if (evaluation.status === 'pending') {
+    return (
+      <div className="rounded-lg bg-stone-50 px-3 py-2 text-[11px] font-medium text-stone-500">
+        {t('chat.evaluation.status.pending')}
+      </div>
+    );
+  }
+
+  if (evaluation.status === 'failed') {
+    return (
+      <div className="rounded-lg bg-stone-50 px-3 py-2 text-[11px] font-medium text-stone-500">
+        {t('chat.evaluation.status.failed')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-stone-100 bg-stone-50/70 px-3 py-2">
+      <div className="mb-2 text-[11px] font-semibold text-[#00652c]">
+        {t('chat.evaluation.status.completed')}
+      </div>
+      <div className="space-y-1.5 text-[11px]">
+        <EvaluationMetric
+          label={t('chat.evaluation.metrics.faithfulness')}
+          value={evaluation.faithfulness}
+        />
+        <EvaluationMetric
+          label={t('chat.evaluation.metrics.answerRelevancy')}
+          value={evaluation.answer_relevancy}
+        />
+        <EvaluationMetric
+          label={t('chat.evaluation.metrics.contextPrecision')}
+          value={evaluation.context_precision}
+        />
+      </div>
+    </div>
+  );
+}
+
 function HistoryItem({ item, onVideoNavigate }: { item: ChatHistoryItem; onVideoNavigate: (videoId: number, startTime: string) => void }) {
   const { t } = useTranslation();
   return (
@@ -184,6 +248,7 @@ function HistoryItem({ item, onVideoNavigate }: { item: ChatHistoryItem; onVideo
             citations={item.citations}
             onVideoNavigate={onVideoNavigate}
           />
+          <HistoryEvaluation evaluation={item.evaluation} />
           {item.feedback && (
             <div className={`flex items-center gap-1 pt-1 text-[10px] font-bold ${item.feedback === 'good' ? 'text-[#00652c]' : 'text-red-400'}`}>
               {item.feedback === 'good' ? <ThumbsUp className="w-3 h-3" /> : <ThumbsDown className="w-3 h-3" />}

--- a/frontend/src/components/chat/__tests__/ChatPanel.test.tsx
+++ b/frontend/src/components/chat/__tests__/ChatPanel.test.tsx
@@ -11,6 +11,7 @@ vi.mock('@/lib/api', async (importOriginal) => {
       chat: vi.fn(),
       chatStream: vi.fn(),
       getChatHistory: vi.fn(),
+      getChatEvaluations: vi.fn(),
       exportChatHistoryCsv: vi.fn(),
       setChatFeedback: vi.fn(),
       getOpenAIApiKeyStatus: vi.fn(),
@@ -49,6 +50,7 @@ describe('ChatPanel', () => {
     ;(apiClient.chatStream as any).mockImplementation(
       makeStreamMock({ content: 'Test response', chat_log_id: 1, feedback: null }),
     )
+    ;(apiClient.getChatEvaluations as any).mockResolvedValue([])
     ;(apiClient.getOpenAIApiKeyStatus as any).mockResolvedValue({ has_api_key: true })
   })
 
@@ -345,6 +347,119 @@ describe('ChatPanel', () => {
       expect(screen.getByText('Test question')).toBeInTheDocument()
       expect(screen.getByText('Test answer')).toBeInTheDocument()
     })
+  })
+
+  it('should display RAGAS evaluation scores for history answers', async () => {
+    const mockHistory = [
+      {
+        id: 1,
+        group: 1,
+        question: 'Test question',
+        answer: 'Test answer',
+        is_shared_origin: false,
+        created_at: '2024-01-15T10:00:00Z',
+        feedback: null,
+      },
+    ]
+    ;(apiClient.getChatHistory as any).mockResolvedValue(mockHistory)
+    ;(apiClient.getChatEvaluations as any).mockResolvedValue([
+      {
+        chat_log_id: 1,
+        status: 'completed',
+        faithfulness: 0.86,
+        answer_relevancy: 0.81,
+        context_precision: 0.78,
+        error_message: '',
+        evaluated_at: '2024-01-15T10:01:00Z',
+      },
+    ])
+
+    render(<ChatPanel groupId={1} />)
+
+    const historyButton = screen.getByText(/chat.history/)
+
+    await act(async () => {
+      fireEvent.click(historyButton)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('chat.evaluation.status.completed')).toBeInTheDocument()
+      expect(screen.getByText('chat.evaluation.metrics.faithfulness')).toBeInTheDocument()
+      expect(screen.getByText('86%')).toBeInTheDocument()
+      expect(screen.getByText('chat.evaluation.metrics.answerRelevancy')).toBeInTheDocument()
+      expect(screen.getByText('81%')).toBeInTheDocument()
+      expect(screen.getByText('chat.evaluation.metrics.contextPrecision')).toBeInTheDocument()
+      expect(screen.getByText('78%')).toBeInTheDocument()
+    })
+  })
+
+  it('should display pending and failed evaluation states without showing missing evaluations', async () => {
+    const mockHistory = [
+      {
+        id: 1,
+        group: 1,
+        question: 'Pending question',
+        answer: 'Pending answer',
+        is_shared_origin: false,
+        created_at: '2024-01-15T10:00:00Z',
+        feedback: null,
+      },
+      {
+        id: 2,
+        group: 1,
+        question: 'Failed question',
+        answer: 'Failed answer',
+        is_shared_origin: false,
+        created_at: '2024-01-15T10:01:00Z',
+        feedback: null,
+      },
+      {
+        id: 3,
+        group: 1,
+        question: 'No evaluation question',
+        answer: 'No evaluation answer',
+        is_shared_origin: false,
+        created_at: '2024-01-15T10:02:00Z',
+        feedback: null,
+      },
+    ]
+    ;(apiClient.getChatHistory as any).mockResolvedValue(mockHistory)
+    ;(apiClient.getChatEvaluations as any).mockResolvedValue([
+      {
+        chat_log_id: 1,
+        status: 'pending',
+        faithfulness: null,
+        answer_relevancy: null,
+        context_precision: null,
+        error_message: '',
+        evaluated_at: null,
+      },
+      {
+        chat_log_id: 2,
+        status: 'failed',
+        faithfulness: null,
+        answer_relevancy: null,
+        context_precision: null,
+        error_message: 'ragas error',
+        evaluated_at: null,
+      },
+    ])
+
+    render(<ChatPanel groupId={1} />)
+
+    const historyButton = screen.getByText(/chat.history/)
+
+    await act(async () => {
+      fireEvent.click(historyButton)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('chat.evaluation.status.pending')).toBeInTheDocument()
+      expect(screen.getByText('chat.evaluation.status.failed')).toBeInTheDocument()
+      expect(screen.getByText('No evaluation answer')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('chat.evaluation.status.completed')).not.toBeInTheDocument()
   })
 
   it('should switch back to chat tab from history', async () => {

--- a/frontend/src/components/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/components/dashboard/AnalyticsDashboard.tsx
@@ -1,18 +1,25 @@
 import { useTranslation } from 'react-i18next';
-import type { ChatAnalytics } from '@/lib/api';
+import type { ChatAnalytics, EvaluationSummary } from '@/lib/api';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { DashboardEmptyState } from './DashboardEmptyState';
-import { SceneDistributionChart } from './SceneDistributionChart';
 import { QuestionTimeSeriesChart } from './QuestionTimeSeriesChart';
 import { FeedbackDonutChart } from './FeedbackDonutChart';
 import { KeywordCloudChart } from './KeywordCloudChart';
+import { EvaluationSummaryCard } from './EvaluationSummaryCard';
 
 interface AnalyticsDashboardProps {
   data: ChatAnalytics | undefined;
+  evaluationSummary?: EvaluationSummary;
   isLoading: boolean;
+  isEvaluationLoading?: boolean;
 }
 
-export function AnalyticsDashboard({ data, isLoading }: AnalyticsDashboardProps) {
+export function AnalyticsDashboard({
+  data,
+  evaluationSummary,
+  isLoading,
+  isEvaluationLoading = false,
+}: AnalyticsDashboardProps) {
   const { t } = useTranslation();
 
   if (isLoading) {
@@ -52,11 +59,12 @@ export function AnalyticsDashboard({ data, isLoading }: AnalyticsDashboardProps)
           <FeedbackDonutChart data={data.feedback} />
         </div>
 
-        {data.scene_distribution.length > 0 && (
-          <div className="bg-white border border-gray-200 rounded-lg p-4">
-            <SceneDistributionChart data={data.scene_distribution} />
-          </div>
-        )}
+        <div className="bg-white border border-gray-200 rounded-lg p-4">
+          <EvaluationSummaryCard
+            summary={evaluationSummary}
+            isLoading={isEvaluationLoading}
+          />
+        </div>
 
         {data.keywords.length > 0 && (
           <div className="bg-white border border-gray-200 rounded-lg p-4">

--- a/frontend/src/components/dashboard/DashboardButton.tsx
+++ b/frontend/src/components/dashboard/DashboardButton.tsx
@@ -4,6 +4,7 @@ import { BarChart3 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useChatAnalytics } from '@/hooks/useChatAnalytics';
+import { useEvaluationSummary } from '@/hooks/useEvaluationSummary';
 import { AnalyticsDashboard } from './AnalyticsDashboard';
 
 interface DashboardButtonProps {
@@ -15,6 +16,10 @@ export function DashboardButton({ groupId, size = 'default' }: DashboardButtonPr
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const { data, isLoading } = useChatAnalytics(groupId, isOpen);
+  const {
+    data: evaluationSummary,
+    isLoading: isEvaluationLoading,
+  } = useEvaluationSummary(groupId, isOpen);
 
   return (
     <>
@@ -33,7 +38,12 @@ export function DashboardButton({ groupId, size = 'default' }: DashboardButtonPr
           <DialogHeader>
             <DialogTitle>{t('dashboard.title')}</DialogTitle>
           </DialogHeader>
-          <AnalyticsDashboard data={data} isLoading={isLoading} />
+          <AnalyticsDashboard
+            data={data}
+            evaluationSummary={evaluationSummary}
+            isLoading={isLoading}
+            isEvaluationLoading={isEvaluationLoading}
+          />
         </DialogContent>
       </Dialog>
     </>

--- a/frontend/src/components/dashboard/EvaluationSummaryCard.tsx
+++ b/frontend/src/components/dashboard/EvaluationSummaryCard.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from 'react-i18next';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import type { EvaluationSummary } from '@/lib/api';
+
+interface EvaluationSummaryCardProps {
+  summary: EvaluationSummary | undefined;
+  isLoading: boolean;
+}
+
+function formatPercent(value: number | null | undefined) {
+  if (value == null) return '-';
+  return `${Math.round(value * 100)}%`;
+}
+
+function MetricRow({ label, value }: { label: string; value: number | null | undefined }) {
+  const percentage = value == null ? 0 : Math.max(0, Math.min(value * 100, 100));
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-3 text-xs">
+        <span className="font-medium text-gray-700">{label}</span>
+        <span className="font-semibold text-gray-900">{formatPercent(value)}</span>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-gray-100">
+        <div className="h-full rounded-full bg-[#00652c]" style={{ width: `${percentage}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function EvaluationSummaryCard({ summary, isLoading }: EvaluationSummaryCardProps) {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[220px] items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (!summary || summary.evaluated_count === 0) {
+    return (
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold text-gray-900">
+          {t('dashboard.evaluation.title')}
+        </h3>
+        <div className="flex h-[180px] items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50/60 px-4 text-center text-sm text-gray-500">
+          {t('dashboard.evaluation.empty')}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-gray-900">
+          {t('dashboard.evaluation.title')}
+        </h3>
+        <span className="text-xs font-medium text-gray-500">
+          {t('dashboard.evaluation.evaluatedCount', { count: summary.evaluated_count })}
+        </span>
+      </div>
+
+      <div className="space-y-4">
+        <MetricRow
+          label={t('dashboard.evaluation.metrics.faithfulness')}
+          value={summary.avg_faithfulness}
+        />
+        <MetricRow
+          label={t('dashboard.evaluation.metrics.answerRelevancy')}
+          value={summary.avg_answer_relevancy}
+        />
+        <MetricRow
+          label={t('dashboard.evaluation.metrics.contextPrecision')}
+          value={summary.avg_context_precision}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react'
+import { AnalyticsDashboard } from '../AnalyticsDashboard'
+import type { ChatAnalytics, EvaluationSummary } from '@/lib/api'
+
+const analytics: ChatAnalytics = {
+  summary: {
+    total_questions: 24,
+    date_range: { first: '2026-04-01T00:00:00Z', last: '2026-04-22T00:00:00Z' },
+  },
+  scene_distribution: [
+    {
+      video_id: 1,
+      title: 'Scene title',
+      start_time: '00:00:10',
+      end_time: '00:00:20',
+      question_count: 3,
+    },
+  ],
+  time_series: [],
+  feedback: { good: 1, bad: 0, none: 23 },
+  keywords: [],
+}
+
+const evaluationSummary: EvaluationSummary = {
+  group_id: 1,
+  evaluated_count: 24,
+  avg_faithfulness: 0.86,
+  avg_answer_relevancy: 0.81,
+  avg_context_precision: 0.78,
+}
+
+describe('AnalyticsDashboard', () => {
+  it('replaces scene distribution with RAG evaluation summary', () => {
+    render(
+      <AnalyticsDashboard
+        data={analytics}
+        evaluationSummary={evaluationSummary}
+        isLoading={false}
+        isEvaluationLoading={false}
+      />,
+    )
+
+    expect(screen.getByText('dashboard.evaluation.title')).toBeInTheDocument()
+    expect(screen.getByText(/dashboard\.evaluation\.evaluatedCount/)).toBeInTheDocument()
+    expect(screen.getByText('86%')).toBeInTheDocument()
+    expect(screen.getByText('81%')).toBeInTheDocument()
+    expect(screen.getByText('78%')).toBeInTheDocument()
+    expect(screen.queryByText('dashboard.sceneDistribution.title')).not.toBeInTheDocument()
+  })
+
+  it('shows evaluation empty state when no answers are evaluated', () => {
+    render(
+      <AnalyticsDashboard
+        data={analytics}
+        evaluationSummary={{ ...evaluationSummary, evaluated_count: 0 }}
+        isLoading={false}
+        isEvaluationLoading={false}
+      />,
+    )
+
+    expect(screen.getByText('dashboard.evaluation.empty')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/hooks/useChatHistory.ts
+++ b/frontend/src/hooks/useChatHistory.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient, type ChatHistoryItem } from '@/lib/api';
+import { apiClient, type ChatHistoryItem, type ChatLogEvaluation } from '@/lib/api';
 import { queryKeys } from '@/lib/queryKeys';
 
 interface UseChatHistoryParams {
@@ -23,11 +23,42 @@ export function useChatHistory({ groupId, shareToken, enabled }: UseChatHistoryP
     },
   });
 
+  const evaluationsQuery = useQuery<ChatLogEvaluation[]>({
+    queryKey: queryKeys.chat.evaluations(groupId ?? null),
+    enabled: enabled && !!groupId && !shareToken,
+    queryFn: async () => {
+      if (!groupId || shareToken) {
+        return [];
+      }
+      return await apiClient.getChatEvaluations(groupId);
+    },
+  });
+
   useEffect(() => {
     if (enabled && historyQuery.error) {
       console.error('Failed to load history', historyQuery.error);
     }
   }, [enabled, historyQuery.error]);
+
+  useEffect(() => {
+    if (enabled && evaluationsQuery.error) {
+      console.error('Failed to load chat evaluations', evaluationsQuery.error);
+    }
+  }, [enabled, evaluationsQuery.error]);
+
+  const historyWithEvaluations = (() => {
+    const history = historyQuery.data ?? null;
+    if (!history) return null;
+
+    const evaluationsByChatLogId = new Map(
+      (evaluationsQuery.data ?? []).map((evaluation) => [evaluation.chat_log_id, evaluation]),
+    );
+
+    return history.map((item) => ({
+      ...item,
+      evaluation: evaluationsByChatLogId.get(item.id),
+    }));
+  })();
 
   const exportHistoryCsvMutation = useMutation({
     mutationFn: async () => {
@@ -68,8 +99,12 @@ export function useChatHistory({ groupId, shareToken, enabled }: UseChatHistoryP
   );
 
   return {
-    history: historyQuery.data ?? null,
-    historyLoading: historyQuery.isLoading || historyQuery.isFetching,
+    history: historyWithEvaluations,
+    historyLoading:
+      historyQuery.isLoading ||
+      historyQuery.isFetching ||
+      evaluationsQuery.isLoading ||
+      evaluationsQuery.isFetching,
     historyError: historyQuery.error,
     exportHistoryCsv,
     isExportingHistoryCsv: exportHistoryCsvMutation.isPending,

--- a/frontend/src/hooks/useEvaluationSummary.ts
+++ b/frontend/src/hooks/useEvaluationSummary.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient, type EvaluationSummary } from '@/lib/api';
+import { queryKeys } from '@/lib/queryKeys';
+
+export function useEvaluationSummary(groupId: number | null, enabled = true) {
+  return useQuery<EvaluationSummary>({
+    queryKey: queryKeys.chat.evaluationSummary(groupId),
+    queryFn: () => apiClient.getEvaluationSummary(groupId!),
+    enabled: enabled && groupId != null,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -553,7 +553,19 @@
     "placeholder": "Type a message...",
     "assistantGreeting": "Hello! Ask me anything about your videos.",
     "error": "An error occurred in the chat.",
-    "errorOverQuota": "AI chat is unavailable because your storage is over the configured limit. Please delete videos to free up space."
+    "errorOverQuota": "AI chat is unavailable because your storage is over the configured limit. Please delete videos to free up space.",
+    "evaluation": {
+      "status": {
+        "pending": "Evaluating",
+        "completed": "Evaluated",
+        "failed": "Could not evaluate"
+      },
+      "metrics": {
+        "faithfulness": "Grounding match",
+        "answerRelevancy": "Question relevance",
+        "contextPrecision": "Reference precision"
+      }
+    }
   },
   "shared": {
     "loadError": "Failed to load the shared chat group.",
@@ -752,6 +764,16 @@
       "good": "Good",
       "bad": "Bad",
       "none": "Not rated"
+    },
+    "evaluation": {
+      "title": "RAG Evaluation Summary",
+      "evaluatedCount": "{{count}} evaluated answers",
+      "empty": "No answers have been evaluated yet",
+      "metrics": {
+        "faithfulness": "Grounding match",
+        "answerRelevancy": "Question relevance",
+        "contextPrecision": "Reference precision"
+      }
     },
     "keywords": {
       "title": "Frequent Keywords"

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -561,9 +561,9 @@
         "failed": "Could not evaluate"
       },
       "metrics": {
-        "faithfulness": "Grounding match",
-        "answerRelevancy": "Question relevance",
-        "contextPrecision": "Reference precision"
+        "faithfulness": "Faithfulness",
+        "answerRelevancy": "Answer relevancy",
+        "contextPrecision": "Context precision"
       }
     }
   },
@@ -766,13 +766,13 @@
       "none": "Not rated"
     },
     "evaluation": {
-      "title": "RAG Evaluation Summary",
+      "title": "RAGAS Metrics",
       "evaluatedCount": "{{count}} evaluated answers",
       "empty": "No answers have been evaluated yet",
       "metrics": {
-        "faithfulness": "Grounding match",
-        "answerRelevancy": "Question relevance",
-        "contextPrecision": "Reference precision"
+        "faithfulness": "Faithfulness",
+        "answerRelevancy": "Answer relevancy",
+        "contextPrecision": "Context precision"
       }
     },
     "keywords": {

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -553,7 +553,19 @@
     "placeholder": "メッセージを入力...",
     "assistantGreeting": "こんにちは！動画に関する質問にお答えします。何か質問はありますか？",
     "error": "チャットでエラーが発生しました。",
-    "errorOverQuota": "ストレージ超過のためAIチャットを利用できません。動画を削除してストレージを空けてください。"
+    "errorOverQuota": "ストレージ超過のためAIチャットを利用できません。動画を削除してストレージを空けてください。",
+    "evaluation": {
+      "status": {
+        "pending": "評価中",
+        "completed": "評価済み",
+        "failed": "評価できませんでした"
+      },
+      "metrics": {
+        "faithfulness": "根拠との一致",
+        "answerRelevancy": "質問への関連度",
+        "contextPrecision": "参照情報の的確さ"
+      }
+    }
   },
   "shared": {
     "loadError": "共有チャットグループの読み込みに失敗しました。",
@@ -752,6 +764,16 @@
       "good": "Good",
       "bad": "Bad",
       "none": "未評価"
+    },
+    "evaluation": {
+      "title": "RAG評価サマリー",
+      "evaluatedCount": "評価済み回答 {{count}}件",
+      "empty": "まだ評価された回答はありません",
+      "metrics": {
+        "faithfulness": "根拠との一致",
+        "answerRelevancy": "質問への関連度",
+        "contextPrecision": "参照情報の的確さ"
+      }
     },
     "keywords": {
       "title": "頻出キーワード"

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -766,7 +766,7 @@
       "none": "未評価"
     },
     "evaluation": {
-      "title": "RAG評価サマリー",
+      "title": "RAGAS指標",
       "evaluatedCount": "評価済み回答 {{count}}件",
       "empty": "まだ評価された回答はありません",
       "metrics": {

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -677,6 +677,36 @@ describe('ApiClient', () => {
       expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/chat/history/?group_id=1', expect.anything());
     });
 
+    it('getEvaluationSummary calls correct endpoint', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify({
+          group_id: 1,
+          evaluated_count: 2,
+          avg_faithfulness: 0.86,
+          avg_answer_relevancy: 0.81,
+          avg_context_precision: 0.78,
+        }))
+      });
+
+      await apiClient.getEvaluationSummary(1);
+
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/evaluation/summary/?group_id=1', expect.anything());
+    });
+
+    it('getChatEvaluations calls correct endpoint', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify([]))
+      });
+
+      await apiClient.getChatEvaluations(1);
+
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/evaluation/logs/?group_id=1&limit=200', expect.anything());
+    });
+
     it('exportChatHistoryCsv should download file', async () => {
       // Mock DOM methods
       const mockUrl = 'blob:url';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -111,6 +111,7 @@ export interface ChatHistoryItem {
   is_shared_origin: boolean;
   feedback?: 'good' | 'bad' | null;
   created_at: string;
+  evaluation?: ChatLogEvaluation;
 }
 
 export interface ChatMessage {
@@ -136,6 +137,26 @@ export interface ChatAnalytics {
   time_series: { date: string; count: number }[];
   feedback: { good: number; bad: number; none: number };
   keywords: { word: string; count: number }[];
+}
+
+export type EvaluationStatus = 'pending' | 'completed' | 'failed';
+
+export interface EvaluationSummary {
+  group_id: number;
+  evaluated_count: number;
+  avg_faithfulness: number | null;
+  avg_answer_relevancy: number | null;
+  avg_context_precision: number | null;
+}
+
+export interface ChatLogEvaluation {
+  chat_log_id: number;
+  status: EvaluationStatus;
+  faithfulness: number | null;
+  answer_relevancy: number | null;
+  context_precision: number | null;
+  error_message: string;
+  evaluated_at: string | null;
 }
 
 export interface ChatRequest {
@@ -762,6 +783,14 @@ class ApiClient {
 
   async getChatHistory(groupId: number): Promise<ChatHistoryItem[]> {
     return this.request<ChatHistoryItem[]>(`/chat/history/?group_id=${groupId}`);
+  }
+
+  async getEvaluationSummary(groupId: number): Promise<EvaluationSummary> {
+    return this.request<EvaluationSummary>(`/evaluation/summary/?group_id=${groupId}`);
+  }
+
+  async getChatEvaluations(groupId: number, limit = 200): Promise<ChatLogEvaluation[]> {
+    return this.request<ChatLogEvaluation[]>(`/evaluation/logs/?group_id=${groupId}&limit=${limit}`);
   }
 
 

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -29,5 +29,7 @@ export const queryKeys = {
   chat: {
     history: (groupId: number | null, shareToken?: string) => ['chatHistory', groupId, shareToken ?? null] as const,
     analytics: (groupId: number) => ['chatAnalytics', groupId] as const,
+    evaluations: (groupId: number | null) => ['chatEvaluations', groupId] as const,
+    evaluationSummary: (groupId: number | null) => ['evaluationSummary', groupId] as const,
   },
 } as const;


### PR DESCRIPTION
## 概要

- ダッシュボードの「シーン別の質問分布」を RAGAS 指標カードに置き換え
- 会話履歴の AI 回答ごとに RAGAS 評価状態と 3 指標を表示
- 評価サマリー / 評価ログ API の frontend client・query key・hook を追加
- 英語 UI は RAGAS 用語（Faithfulness / Answer relevancy / Context precision）に合わせ、日本語 UI はユーザー向けラベルを維持

## テスト

- `npm run typecheck`
- `npm run lint`
  - 既存 warning: `frontend/src/hooks/useChatMessages.ts:205` の hook dependency warning のみ
- `npm test`

Closes #638
