### PR TITLE
feat: shorten title and OGP to focus on user outcome

### DIFF
--- a/frontend/functions/ja/[[path]].ts
+++ b/frontend/functions/ja/[[path]].ts
@@ -1,4 +1,4 @@
-const JA_TITLE = 'VideoQ | 動画をアップロード。AI文字起こし＆インスタント検索 - 教育・研修向け';
+const JA_TITLE = 'VideoQ | 動画にAIで質問、見たいシーンへ';
 const JA_DESCRIPTION = 'AIに質問するだけで、見たいシーンに瞬時にジャンプ。動画をアップロードするだけでAIが自動文字起こし＆検索を可能にします。';
 
 export const onRequest: PagesFunction = async (context) => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,10 +6,10 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VideoQ | Upload Your Video. AI Transcription &amp; Instant Search for Education &amp; Training</title>
+    <title>VideoQ | Ask AI, Jump to Any Scene</title>
     <meta name="description" content="Ask AI, jump to the scene instantly. Upload your video and AI auto-transcribes it for instant natural language search." />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="VideoQ | Upload Your Video. AI Transcription &amp; Instant Search for Education &amp; Training" />
+    <meta property="og:title" content="VideoQ | Ask AI, Jump to Any Scene" />
     <meta property="og:description" content="Ask AI, jump to the scene instantly. Upload your video and AI auto-transcribes it for instant natural language search." />
     <meta property="og:locale" content="en_US" />
     <meta property="og:locale:alternate" content="ja_JP" />


### PR DESCRIPTION
## Summary

- タイトルと OGP タイトルを「仕組み説明」から「ユーザーが何できるか」に変更
- EN: `VideoQ | Ask AI, Jump to Any Scene`（87文字 → 34文字）
- JA: `VideoQ | 動画にAIで質問、見たいシーンへ`（43文字 → 21文字）

## Changes

- `frontend/index.html` — `<title>` と `og:title` を更新
- `frontend/functions/ja/[[path]].ts` — `JA_TITLE` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)