### PR TITLE
feat: rewrite OGP/title for /ja/* via nginx sub_filter locally

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -40,6 +40,24 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # Japanese locale - rewrite OGP/title tags (mirrors Cloudflare Pages function)
+        location /ja/ {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Accept-Encoding "";
+
+            sub_filter 'VideoQ | Ask AI, Jump to Any Scene' 'VideoQ | 動画にAIで質問、見たいシーンへ';
+            sub_filter 'Ask AI, jump to the scene instantly. Upload your video and AI auto-transcribes it for instant natural language search.' 'AIに質問するだけで、見たいシーンに瞬時にジャンプ。動画をアップロードするだけでAIが自動文字起こし＆検索を可能にします。';
+            sub_filter 'og:locale" content="en_US"' 'og:locale" content="ja_JP"';
+            sub_filter_once off;
+        }
+
         # All other routes to frontend
         location / {
             proxy_pass http://frontend;


### PR DESCRIPTION
## Summary

- `/ja/*` へのリクエストに対して、外側の reverse-proxy nginx に専用の `location` ブロックを追加
- `sub_filter` でタイトル・description・`og:locale` を英語から日本語に書き換え
- Cloudflare Pages の `functions/ja/[[path]].ts`（HTMLRewriter）と同じ動作をローカル Docker 環境でも再現

## Background

Cloudflare Pages ではエッジ関数が OGP を動的に書き換えているが、ローカルでは nginx がそのまま英語の `index.html` を返していた。

## Test plan

- [ ] `docker compose build frontend && docker compose up -d frontend nginx`
- [ ] `http://localhost/ja/` にアクセスし、ページタイトルが「VideoQ | 動画にAIで質問、見たいシーンへ」になっていることを確認
- [ ] `http://localhost/` にアクセスし、英語タイトルが変わっていないことを確認
- [ ] `/api/*` など他のルートが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)