### PR TITLE
docs: simplify ollama model pull example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,7 @@ WHISPER_LOCAL_URL=http://host.docker.internal:8080
 
 **モデルを取得:**
 ```bash
-ollama pull qwen3:0.6b  # 小さく高速なモデル
-# または
-ollama pull llama3:8b   # より大きく高性能なモデル
+ollama pull qwen3:0.6b
 ```
 
 **VideoQを設定:**


### PR DESCRIPTION
## Summary

- README の ollama モデル取得例から代替コマンド行（`llama3:8b`）とコメントを削除し、`qwen3:0.6b` の1行のみに簡潔化

## Test plan

- [x] README の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)