### PR TITLE
feat(chat): 会話履歴のリセット機能を追加する (#650)

### DIFF
--- a/backend/app/composition_root/chat.py
+++ b/backend/app/composition_root/chat.py
@@ -17,6 +17,7 @@ from app.infrastructure.tasks.task_gateway import CeleryEvaluationTaskGateway
 from app.use_cases.chat.export_history import ExportChatHistoryUseCase
 from app.use_cases.chat.get_analytics import GetChatAnalyticsUseCase
 from app.use_cases.chat.get_history import GetChatHistoryUseCase
+from app.use_cases.chat.reset_history import ResetChatHistoryUseCase
 from app.use_cases.chat.send_message import SendMessageUseCase
 from app.use_cases.chat.submit_feedback import SubmitFeedbackUseCase
 from app.composition_root import limits as _limits_cr
@@ -78,6 +79,13 @@ def get_submit_feedback_use_case() -> SubmitFeedbackUseCase:
 
 def get_export_history_use_case() -> ExportChatHistoryUseCase:
     return ExportChatHistoryUseCase(
+        _new_chat_repository(),
+        _new_video_group_query_repository(),
+    )
+
+
+def get_reset_history_use_case() -> ResetChatHistoryUseCase:
+    return ResetChatHistoryUseCase(
         _new_chat_repository(),
         _new_video_group_query_repository(),
     )

--- a/backend/app/dependencies/chat.py
+++ b/backend/app/dependencies/chat.py
@@ -20,3 +20,7 @@ def get_export_history_use_case():
 
 def get_chat_analytics_use_case():
     return _cr.get_chat_analytics_use_case()
+
+
+def get_reset_history_use_case():
+    return _cr.get_reset_history_use_case()

--- a/backend/app/domain/chat/repositories.py
+++ b/backend/app/domain/chat/repositories.py
@@ -67,6 +67,11 @@ class ChatRepository(ABC):
         """
         ...
 
+    @abstractmethod
+    def delete_logs_for_group(self, group_id: int) -> None:
+        """Delete all chat logs for the given group."""
+        ...
+
 
 class VideoGroupQueryRepository(ABC):
     """Abstract interface for fetching video groups in chat contexts."""

--- a/backend/app/infrastructure/repositories/django_chat_repository.py
+++ b/backend/app/infrastructure/repositories/django_chat_repository.py
@@ -155,6 +155,9 @@ class DjangoChatRepository(ChatRepository):
             result.append(ChatSceneLog(question=row["question"], citations=refs))
         return result
 
+    def delete_logs_for_group(self, group_id: int) -> None:
+        ChatLog.objects.filter(group_id=group_id).delete()
+
     def get_analytics_raw(self, group_id: int) -> ChatAnalyticsRaw:
         qs = ChatLog.objects.filter(group_id=group_id)
         total = qs.count()

--- a/backend/app/presentation/chat/tests/test_views.py
+++ b/backend/app/presentation/chat/tests/test_views.py
@@ -274,6 +274,79 @@ class ChatViewTests(APITestCase):
         self.assertEqual(response.data["citations"][0]["video_id"], self.video.id)
 
 
+class ChatHistoryDeleteViewTests(APITestCase):
+    """Tests for DELETE /api/v1/chat/history/ (ResetChatHistoryUseCase)."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="history_user",
+            email="history@example.com",
+            password="testpass123",
+        )
+        self.other_user = User.objects.create_user(
+            username="other_user",
+            email="other@example.com",
+            password="testpass123",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+            description="Test",
+            share_slug=secrets.token_urlsafe(32),
+        )
+        self.url = reverse("chat-history")
+
+    def _create_chat_log(self, group=None):
+        return ChatLog.objects.create(
+            user=self.user,
+            group=group or self.group,
+            question="Q",
+            answer="A",
+            citations=[],
+            retrieved_contexts=[],
+        )
+
+    def test_delete_resets_chat_history_and_returns_200(self):
+        self._create_chat_log()
+        self._create_chat_log()
+        response = self.client.delete(f"{self.url}?group_id={self.group.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["message"], "Chat history has been reset.")
+        self.assertEqual(ChatLog.objects.filter(group=self.group).count(), 0)
+
+    def test_delete_without_group_id_returns_400(self):
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_nonexistent_group_returns_404(self):
+        response = self.client.delete(f"{self.url}?group_id=99999")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_other_users_group_returns_404(self):
+        other_group = VideoGroup.objects.create(
+            user=self.other_user,
+            name="Other Group",
+            share_slug=secrets.token_urlsafe(32),
+        )
+        response = self.client.delete(f"{self.url}?group_id={other_group.id}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_after_delete_returns_empty_list(self):
+        self._create_chat_log()
+        self.client.delete(f"{self.url}?group_id={self.group.id}")
+        response = self.client.get(self.url, {"group_id": self.group.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+    def test_delete_unauthenticated_returns_401(self):
+        client = APIClient()
+        response = client.delete(f"{self.url}?group_id={self.group.id}")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
 class OpenAIChatCompletionsViewTests(APITestCase):
     """Regression tests for OpenAIChatCompletionsView limit exception handling."""
 

--- a/backend/app/presentation/chat/urls.py
+++ b/backend/app/presentation/chat/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
         ChatHistoryView.as_view(
             chat_history_use_case=chat_dependencies.get_chat_history_use_case,
             export_history_use_case=chat_dependencies.get_export_history_use_case,
+            reset_history_use_case=chat_dependencies.get_reset_history_use_case,
         ),
         name="chat-history",
     ),

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -24,7 +24,7 @@ from app.presentation.common.permissions import (
     IsAuthenticatedOrSharedAccess,
     ShareTokenAuthentication,
 )
-from app.presentation.common.responses import create_error_response
+from app.presentation.common.responses import create_error_response, create_success_response
 from app.presentation.common.throttles import (
     AuthenticatedChatThrottle,
     ShareTokenIPThrottle,
@@ -217,6 +217,7 @@ class ChatHistoryView(DependencyResolverMixin, APIView):
     serializer_class = ChatLogSerializer
     chat_history_use_case = None
     export_history_use_case = None
+    reset_history_use_case = None
 
     @extend_schema(
         parameters=[
@@ -272,6 +273,25 @@ class ChatHistoryView(DependencyResolverMixin, APIView):
         except ResourceNotFound as e:
             return create_error_response(str(e), status.HTTP_404_NOT_FOUND)
         return Response(ChatLogSerializer(logs, many=True).data)
+
+    @extend_schema(
+        parameters=[OpenApiParameter("group_id", int, required=True)],
+        responses={200: {"type": "object", "properties": {"message": {"type": "string"}}}},
+        summary="Reset chat history",
+        description="Delete all chat logs for a group (owner only).",
+    )
+    def delete(self, request, *args, **kwargs):
+        group_id = request.query_params.get("group_id")
+        if not group_id:
+            return create_error_response("Group ID not specified", status.HTTP_400_BAD_REQUEST)
+
+        use_case = self.resolve_dependency(self.reset_history_use_case)
+        try:
+            use_case.execute(group_id=int(group_id), user_id=request.user.id)
+        except ResourceNotFound as e:
+            return create_error_response(str(e), status.HTTP_404_NOT_FOUND)
+
+        return create_success_response(message="Chat history has been reset.")
 
 
 class ChatAnalyticsView(DependencyResolverMixin, APIView):

--- a/backend/app/use_cases/chat/reset_history.py
+++ b/backend/app/use_cases/chat/reset_history.py
@@ -1,0 +1,36 @@
+"""
+Use case: Reset (delete all) chat history for a group.
+"""
+
+from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
+from app.domain.chat.services import (
+    GroupContextNotFound as _DomainGroupContextNotFound,
+    require_group_context,
+)
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+
+class ResetChatHistoryUseCase:
+    """Delete all chat logs for a video group (owner only)."""
+
+    def __init__(
+        self,
+        chat_repo: ChatRepository,
+        group_query_repo: VideoGroupQueryRepository,
+    ):
+        self.chat_repo = chat_repo
+        self.group_query_repo = group_query_repo
+
+    def execute(self, group_id: int, user_id: int) -> None:
+        """
+        Raises:
+            ResourceNotFound: If the group does not exist or belongs to another user.
+        """
+        try:
+            group = require_group_context(
+                self.group_query_repo.get_with_members(group_id=group_id, user_id=user_id)
+            )
+        except _DomainGroupContextNotFound:
+            raise ResourceNotFound("Group")
+
+        self.chat_repo.delete_logs_for_group(group.id)

--- a/backend/app/use_cases/chat/tests/test_get_history.py
+++ b/backend/app/use_cases/chat/tests/test_get_history.py
@@ -32,6 +32,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def delete_logs_for_group(self, group_id: int) -> None:
+        raise NotImplementedError
+
 
 class _StubGroupRepository(VideoGroupQueryRepository):
     def __init__(self, group):

--- a/backend/app/use_cases/chat/tests/test_reset_history.py
+++ b/backend/app/use_cases/chat/tests/test_reset_history.py
@@ -1,0 +1,67 @@
+"""Tests for ResetChatHistoryUseCase."""
+
+import unittest
+from typing import List, Optional, Sequence
+
+from app.domain.chat.entities import VideoGroupContextEntity
+from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
+from app.use_cases.chat.reset_history import ResetChatHistoryUseCase
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+
+class _StubChatRepository(ChatRepository):
+    def __init__(self):
+        self.deleted_group_ids: list[int] = []
+
+    def get_logs_for_group(self, group_id: int, ascending: bool = True):
+        return []
+
+    def create_log(self, user_id, group_id, question, answer, citations, is_shared, retrieved_contexts=None):
+        raise NotImplementedError
+
+    def get_log_by_id(self, log_id: int):
+        raise NotImplementedError
+
+    def update_feedback(self, log, feedback):
+        raise NotImplementedError
+
+    def get_logs_values_for_group(self, group_id: int):
+        raise NotImplementedError
+
+    def get_analytics_raw(self, group_id: int):
+        raise NotImplementedError
+
+    def delete_logs_for_group(self, group_id: int) -> None:
+        self.deleted_group_ids.append(group_id)
+
+
+class _StubGroupRepository(VideoGroupQueryRepository):
+    def __init__(self, group: Optional[VideoGroupContextEntity]):
+        self._group = group
+
+    def get_with_members(self, group_id: int, user_id=None, share_token=None):
+        return self._group
+
+
+class ResetChatHistoryUseCaseTests(unittest.TestCase):
+    def _make_use_case(self, group=None):
+        self.chat_repo = _StubChatRepository()
+        group_repo = _StubGroupRepository(group)
+        return ResetChatHistoryUseCase(self.chat_repo, group_repo)
+
+    def test_execute_deletes_logs_for_owned_group(self):
+        group = VideoGroupContextEntity(id=5, user_id=1, name="g")
+        use_case = self._make_use_case(group=group)
+        use_case.execute(group_id=5, user_id=1)
+        self.assertIn(5, self.chat_repo.deleted_group_ids)
+
+    def test_execute_raises_resource_not_found_when_group_missing(self):
+        use_case = self._make_use_case(group=None)
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(group_id=99, user_id=1)
+
+    def test_execute_raises_resource_not_found_when_group_belongs_to_other_user(self):
+        # group_query_repo.get_with_members returns None when user_id doesn't match
+        use_case = self._make_use_case(group=None)
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(group_id=5, user_id=999)

--- a/backend/app/use_cases/chat/tests/test_reset_history.py
+++ b/backend/app/use_cases/chat/tests/test_reset_history.py
@@ -1,7 +1,7 @@
 """Tests for ResetChatHistoryUseCase."""
 
 import unittest
-from typing import List, Optional, Sequence
+from typing import Optional
 
 from app.domain.chat.entities import VideoGroupContextEntity
 from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository

--- a/backend/app/use_cases/chat/tests/test_send_message.py
+++ b/backend/app/use_cases/chat/tests/test_send_message.py
@@ -31,6 +31,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def delete_logs_for_group(self, group_id: int) -> None:
+        raise NotImplementedError
+
 
 class _StubGroupRepository(VideoGroupQueryRepository):
     def get_with_members(self, group_id: int, user_id=None, share_token=None):

--- a/backend/app/use_cases/chat/tests/test_stream_message.py
+++ b/backend/app/use_cases/chat/tests/test_stream_message.py
@@ -31,6 +31,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id):
         raise NotImplementedError
 
+    def delete_logs_for_group(self, group_id: int) -> None:
+        raise NotImplementedError
+
 
 class _StubGroupRepository(VideoGroupQueryRepository):
     def get_with_members(self, group_id, user_id=None, share_token=None):

--- a/backend/app/use_cases/chat/tests/test_submit_feedback.py
+++ b/backend/app/use_cases/chat/tests/test_submit_feedback.py
@@ -38,6 +38,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def delete_logs_for_group(self, group_id: int) -> None:
+        raise NotImplementedError
+
 
 class SubmitFeedbackUseCaseTests(unittest.TestCase):
     def _sample_log(self):


### PR DESCRIPTION
## 概要

Closes #650

特定のグループに紐づく会話履歴（チャットログ）を一括削除する `DELETE /api/chat/history/?group_id={id}` エンドポイントを追加しました。

## 変更内容

### Domain層
- `ChatRepository` に `delete_logs_for_group(group_id: int) -> None` 抽象メソッドを追加

### Infrastructure層
- `DjangoChatRepository` に `delete_logs_for_group()` を実装（`ChatLog.objects.filter(group_id=group_id).delete()`）

### Use Case層
- `ResetChatHistoryUseCase` を新規作成
  - グループの存在確認・オーナー確認後に削除
  - グループ未発見時: `ResourceNotFound` を raise

### Presentation層
- `ChatHistoryView` に `DELETE` メソッドを追加
  - 成功時: `{"message": "Chat history has been reset."}` (HTTP 200)
  - `group_id` 未指定: 400
  - グループ未発見: 404

### DI配線
- `composition_root/chat.py`、`dependencies/chat.py`、`presentation/chat/urls.py` に配線を追加

## テスト

- `ResetChatHistoryUseCase` ユニットテスト 3件
- `ChatHistoryView.delete()` 統合テスト 6件
- 既存スタブへの `delete_logs_for_group()` 実装追加（4ファイル）

## 動作確認

```
# 全58件パス
Ran 58 tests in 4.353s
OK
```

## 備考

`DELETE /api/chat/history/?group_id=` のURL設計（クエリパラメータ）は #651 でパスパラメータへの移行を予定しています。