### PR TITLE
fix: remove_video_from_group デッドコードを削除する

### DIFF
--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -232,6 +232,15 @@ class VideoGroupMemberAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(VideoGroupMember.objects.count(), 0)
 
+    def test_remove_video_from_group_function_does_not_exist(self):
+        """remove_video_from_group 関数ベースビューはデッドコードのため存在しないこと"""
+        import app.presentation.video.views as views_module
+
+        self.assertFalse(
+            hasattr(views_module, "remove_video_from_group"),
+            "remove_video_from_group is dead code and should not exist in views.py",
+        )
+
     def test_video_group_detail_with_members(self):
         """Test group details with videos"""
         VideoGroupMember.objects.create(group=self.group, video=self.video, order=0)

--- a/backend/app/presentation/video/views.py
+++ b/backend/app/presentation/video/views.py
@@ -572,30 +572,6 @@ def add_videos_to_group(
 
 
 @extend_schema(
-    responses={200: VideoActionMessageResponseSerializer},
-    summary="Remove video from group",
-    description="Remove a video from a group.",
-)
-@authenticated_view_with_error_handling(["DELETE"])
-def remove_video_from_group(
-    request,
-    group_id,
-    video_id,
-    remove_video_from_group_use_case,
-):
-    """Remove video from group."""
-    use_case = DependencyResolverMixin.resolve_dependency(remove_video_from_group_use_case)
-    try:
-        use_case.execute(group_id, video_id, request.user.id)
-    except ResourceNotFound as e:
-        return create_error_response(_not_found_message(e), status.HTTP_404_NOT_FOUND)
-    except VideoNotInGroup:
-        return create_error_response("This video is not added to the group", status.HTTP_404_NOT_FOUND)
-
-    return Response({"message": "Video removed from group"}, status=status.HTTP_200_OK)
-
-
-@extend_schema(
     request=ReorderVideosRequestSerializer,
     responses={200: VideoActionMessageResponseSerializer},
     summary="Reorder videos in group",


### PR DESCRIPTION
## 概要

`app/presentation/video/views.py` に存在した `remove_video_from_group` 関数ベースビューを削除する。

## 背景

- 実際のビデオ削除処理は `AddVideoToGroupView.delete()` が担っており、`DELETE /api/videos/groups/<group_id>/videos/<video_id>/` で正常に動作している
- `remove_video_from_group` 関数は `urls.py` に登録されておらず、到達不能なデッドコードだった

## 変更内容

- `views.py` から `remove_video_from_group` 関数を削除（-24行）
- デッドコードが再導入されないよう回帰テストを追加（+9行）

## テスト

TDD で実装：
- Red: `remove_video_from_group` が存在しないことを検証するテストを追加 → 失敗確認
- Green: 関数削除 → テスト通過
- 全1012件のテストがパス

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)