### PR TITLE
fix: 動画一覧・グループ詳細で不要なtranscript列を読み込まないようにする (#672)

### DIFF
--- a/backend/app/infrastructure/common/query_optimizer.py
+++ b/backend/app/infrastructure/common/query_optimizer.py
@@ -47,10 +47,8 @@ class QueryOptimizer:
 
         queryset = QueryOptimizer._apply_prefetch_related(queryset, prefetch_objects)
 
-        if include_transcript:
-            queryset = queryset.only(
-                "id", "title", "file", "status", "transcript", "uploaded_at", "user_id"
-            )
+        if not include_transcript:
+            queryset = queryset.defer("transcript")
 
         return queryset
 
@@ -69,8 +67,8 @@ class QueryOptimizer:
             queryset = queryset.prefetch_related(
                 Prefetch(
                     "members",
-                    queryset=VideoGroupMember.objects.select_related(
-                        "video"
+                    queryset=VideoGroupMember.objects.select_related("video").defer(
+                        "video__transcript"
                     ).prefetch_related(
                         Prefetch(
                             "video__video_tags",

--- a/backend/app/infrastructure/common/tests/test_query_optimizer.py
+++ b/backend/app/infrastructure/common/tests/test_query_optimizer.py
@@ -150,6 +150,57 @@ class QueryOptimizerTests(TestCase):
         self.assertEqual(groups.first(), group)
 
 
+class TranscriptDeferTests(TestCase):
+    """Tests that transcript is deferred in list/group queries."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="deferuser",
+            email="defer@example.com",
+            password="pass",
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Test",
+            status="completed",
+            transcript="long transcript text",
+        )
+
+    def test_optimize_video_queryset_defers_transcript_by_default(self):
+        queryset = Video.objects.all()
+        optimized = QueryOptimizer.optimize_video_queryset(queryset)
+        video = optimized.get(pk=self.video.pk)
+        self.assertIn("transcript", video.get_deferred_fields())
+
+    def test_optimize_video_queryset_defers_transcript_when_false(self):
+        queryset = Video.objects.all()
+        optimized = QueryOptimizer.optimize_video_queryset(queryset, include_transcript=False)
+        video = optimized.get(pk=self.video.pk)
+        self.assertIn("transcript", video.get_deferred_fields())
+
+    def test_optimize_video_queryset_does_not_defer_transcript_when_true(self):
+        queryset = Video.objects.all()
+        optimized = QueryOptimizer.optimize_video_queryset(queryset, include_transcript=True)
+        video = optimized.get(pk=self.video.pk)
+        self.assertNotIn("transcript", video.get_deferred_fields())
+
+    def test_get_videos_with_metadata_defers_transcript_by_default(self):
+        qs = QueryOptimizer.get_videos_with_metadata(user_id=self.user.id)
+        video = qs.get(pk=self.video.pk)
+        self.assertIn("transcript", video.get_deferred_fields())
+
+    def test_optimize_video_group_queryset_defers_transcript_in_nested_videos(self):
+        group = VideoGroup.objects.create(user=self.user, name="G", description="")
+        VideoGroupMember.objects.create(group=group, video=self.video, order=0)
+
+        qs = QueryOptimizer.optimize_video_group_queryset(
+            VideoGroup.objects.filter(pk=group.pk), include_videos=True
+        )
+        fetched_group = qs.first()
+        member = fetched_group.members.all()[0]
+        self.assertIn("transcript", member.video.get_deferred_fields())
+
+
 class BatchProcessorTests(TestCase):
     """Tests for BatchProcessor class"""
 

--- a/backend/app/infrastructure/repositories/django_video_repository.py
+++ b/backend/app/infrastructure/repositories/django_video_repository.py
@@ -80,7 +80,7 @@ def _video_to_entity(video: Video) -> VideoEntity:
         youtube_video_id=video.youtube_video_id or None,
         error_message=video.error_message or None,
         uploaded_at=video.uploaded_at,
-        transcript=video.transcript or None,
+        transcript=None if "transcript" in video.get_deferred_fields() else (video.transcript or None),
         tags=tags,
     )
 

--- a/backend/app/infrastructure/repositories/tests/test_django_video_repository.py
+++ b/backend/app/infrastructure/repositories/tests/test_django_video_repository.py
@@ -1,0 +1,76 @@
+"""Integration tests for DjangoVideoRepository transcript defer behaviour."""
+
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from app.infrastructure.models import Video, VideoGroup, VideoGroupMember
+from app.infrastructure.repositories.django_video_repository import (
+    DjangoVideoGroupRepository,
+    DjangoVideoRepository,
+)
+
+User = get_user_model()
+
+
+def _sql_selects_transcript(queries) -> bool:
+    return any('"transcript"' in q["sql"] or "`transcript`" in q["sql"] for q in queries)
+
+
+class DjangoVideoRepositoryListForUserTranscriptTests(TestCase):
+    """list_for_user must not load the transcript column."""
+
+    def setUp(self):
+        self.repo = DjangoVideoRepository()
+        self.user = User.objects.create_user(
+            username="listuser",
+            email="list@example.com",
+            password="pass",
+        )
+        Video.objects.create(
+            user=self.user,
+            title="Video A",
+            status="completed",
+            transcript="some long transcript",
+        )
+
+    def test_list_for_user_does_not_select_transcript_column(self):
+        with CaptureQueriesContext(connection) as ctx:
+            self.repo.list_for_user(self.user.id)
+
+        self.assertFalse(
+            _sql_selects_transcript(ctx.captured_queries),
+            "list_for_user should not SELECT transcript",
+        )
+
+
+class DjangoVideoGroupRepositoryTranscriptTests(TestCase):
+    """Group detail nested videos must not load the transcript column."""
+
+    def setUp(self):
+        self.repo = DjangoVideoGroupRepository()
+        self.user = User.objects.create_user(
+            username="groupuser",
+            email="group@example.com",
+            password="pass",
+        )
+        self.video = Video.objects.create(
+            user=self.user,
+            title="Video B",
+            status="completed",
+            transcript="another long transcript",
+        )
+        self.group = VideoGroup.objects.create(
+            user=self.user, name="G", description=""
+        )
+        VideoGroupMember.objects.create(group=self.group, video=self.video, order=0)
+
+    def test_get_by_id_with_videos_does_not_select_transcript_column(self):
+        with CaptureQueriesContext(connection) as ctx:
+            self.repo.get_by_id(self.group.id, self.user.id, include_videos=True)
+
+        self.assertFalse(
+            _sql_selects_transcript(ctx.captured_queries),
+            "group detail nested videos should not SELECT transcript",
+        )


### PR DESCRIPTION
## 概要

動画一覧・グループ詳細APIで、レスポンスに含まれない `transcript` 列を常にSELECTしていた問題を修正する。

closes #672

## 変更内容

### `query_optimizer.py`
- `optimize_video_queryset`: `include_transcript=False`（デフォルト）時に `.defer("transcript")` を追加
- `optimize_video_group_queryset`: ネスト動画のクエリに `select_related("video").defer("video__transcript")` を適用（JOINは維持）

### `django_video_repository.py`
- `_video_to_entity`: `get_deferred_fields()` で transcript が defer 済みか確認し、defer 済みの場合はアクセスをスキップ（defer だけでは Python 側アクセス時に追加 SELECT が走るため）

## テスト

- `TranscriptDeferTests`（5件）: QueryOptimizer レベルで transcript が deferred fields に含まれることを確認
- `DjangoVideoRepositoryListForUserTranscriptTests`（1件）: `list_for_user` の SQL に `transcript` 列が含まれないことを確認
- `DjangoVideoGroupRepositoryTranscriptTests`（1件）: グループ詳細ネスト動画の SQL に `transcript` 列が含まれないことを確認

## 影響範囲

transcript が必要な処理（`get_by_id`・`get_by_id_for_task`・`list_completed_with_transcript`）は独自クエリを持ち defer を適用しないため、影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)