### PR TITLE
fix: チャット履歴・評価表示でretrieved_contextsを読まない軽量projectionを追加する (#681)

### DIFF
--- a/backend/app/infrastructure/repositories/django_chat_repository.py
+++ b/backend/app/infrastructure/repositories/django_chat_repository.py
@@ -55,7 +55,7 @@ def _chat_log_to_entity(
         question=log.question,
         answer=log.answer,
         citations=citations,
-        retrieved_contexts=list(log.retrieved_contexts or []),
+        retrieved_contexts=[] if "retrieved_contexts" in log.get_deferred_fields() else list(log.retrieved_contexts or []),
         is_shared_origin=log.is_shared_origin,
         feedback=log.feedback,
         created_at=log.created_at,
@@ -88,7 +88,7 @@ class DjangoChatRepository(ChatRepository):
         self, group_id: int, ascending: bool = True
     ) -> List[ChatLogEntity]:
         order_field = "created_at" if ascending else "-created_at"
-        logs = ChatLog.objects.filter(group_id=group_id).order_by(order_field)
+        logs = ChatLog.objects.filter(group_id=group_id).defer("retrieved_contexts").order_by(order_field)
         return [_chat_log_to_entity(log) for log in logs]
 
     def create_log(
@@ -124,6 +124,7 @@ class DjangoChatRepository(ChatRepository):
     def get_log_by_id(self, log_id: int) -> Optional[ChatLogEntity]:
         log = (
             ChatLog.objects.select_related("group")
+            .defer("retrieved_contexts")
             .filter(id=log_id)
             .first()
         )
@@ -135,7 +136,7 @@ class DjangoChatRepository(ChatRepository):
         self, log: ChatLogEntity, feedback: Optional[str]
     ) -> ChatLogEntity:
         ChatLog.objects.filter(pk=log.id).update(feedback=feedback)
-        updated = ChatLog.objects.select_related("group").get(pk=log.id)
+        updated = ChatLog.objects.select_related("group").defer("retrieved_contexts").get(pk=log.id)
         return _chat_log_to_entity(updated, include_group_fields=True)
 
     def get_logs_values_for_group(self, group_id: int) -> List[ChatSceneLog]:

--- a/backend/app/infrastructure/repositories/tests/test_django_chat_repository.py
+++ b/backend/app/infrastructure/repositories/tests/test_django_chat_repository.py
@@ -1,0 +1,125 @@
+"""Integration tests for DjangoChatRepository retrieved_contexts defer behaviour."""
+
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from app.infrastructure.models import VideoGroup
+from app.infrastructure.models.chat import ChatLog
+from app.infrastructure.repositories.django_chat_repository import DjangoChatRepository
+from app.infrastructure.repositories.django_chat_log_for_evaluation_repository import (
+    DjangoChatLogForEvaluationRepository,
+)
+
+User = get_user_model()
+
+
+def _sql_selects_retrieved_contexts(queries) -> bool:
+    return any("retrieved_contexts" in q["sql"] for q in queries)
+
+
+class DjangoChatRepositoryRetrievedContextsTests(TestCase):
+    """History/feedback methods must not load the retrieved_contexts column."""
+
+    def setUp(self):
+        self.repo = DjangoChatRepository()
+        self.user = User.objects.create_user(
+            username="chatuser",
+            email="chat@example.com",
+            password="pass",
+        )
+        self.group = VideoGroup.objects.create(
+            user=self.user, name="G", description=""
+        )
+        self.log = ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="Q",
+            answer="A",
+            retrieved_contexts=["ctx1", "ctx2", "ctx3"],
+        )
+
+    def test_get_logs_for_group_does_not_select_retrieved_contexts(self):
+        with CaptureQueriesContext(connection) as ctx:
+            self.repo.get_logs_for_group(self.group.id)
+
+        self.assertFalse(
+            _sql_selects_retrieved_contexts(ctx.captured_queries),
+            "get_logs_for_group should not SELECT retrieved_contexts",
+        )
+
+    def test_get_log_by_id_does_not_select_retrieved_contexts(self):
+        with CaptureQueriesContext(connection) as ctx:
+            self.repo.get_log_by_id(self.log.id)
+
+        self.assertFalse(
+            _sql_selects_retrieved_contexts(ctx.captured_queries),
+            "get_log_by_id should not SELECT retrieved_contexts",
+        )
+
+    def test_update_feedback_does_not_select_retrieved_contexts(self):
+        from app.domain.chat.entities import ChatLogEntity
+        log_entity = ChatLogEntity(
+            id=self.log.id,
+            user_id=self.user.id,
+            group_id=self.group.id,
+            group_user_id=self.user.id,
+            group_share_token=None,
+            question="Q",
+            answer="A",
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            self.repo.update_feedback(log_entity, "good")
+
+        self.assertFalse(
+            _sql_selects_retrieved_contexts(ctx.captured_queries),
+            "update_feedback re-fetch should not SELECT retrieved_contexts",
+        )
+
+    def test_get_logs_for_group_returns_empty_retrieved_contexts(self):
+        logs = self.repo.get_logs_for_group(self.group.id)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0].retrieved_contexts, [])
+
+    def test_get_log_by_id_returns_empty_retrieved_contexts(self):
+        log = self.repo.get_log_by_id(self.log.id)
+        self.assertIsNotNone(log)
+        self.assertEqual(log.retrieved_contexts, [])
+
+
+class DjangoChatLogForEvaluationRepositoryTests(TestCase):
+    """Evaluation repository must still load retrieved_contexts."""
+
+    def setUp(self):
+        self.repo = DjangoChatLogForEvaluationRepository()
+        self.user = User.objects.create_user(
+            username="evaluser",
+            email="eval@example.com",
+            password="pass",
+        )
+        self.group = VideoGroup.objects.create(
+            user=self.user, name="G", description=""
+        )
+        self.log = ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="Q",
+            answer="A",
+            retrieved_contexts=["ctx1", "ctx2"],
+        )
+
+    def test_get_by_id_reads_retrieved_contexts(self):
+        result = self.repo.get_by_id(self.log.id)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.retrieved_contexts, ["ctx1", "ctx2"])
+
+    def test_get_by_id_selects_retrieved_contexts_in_sql(self):
+        with CaptureQueriesContext(connection) as ctx:
+            self.repo.get_by_id(self.log.id)
+
+        self.assertTrue(
+            _sql_selects_retrieved_contexts(ctx.captured_queries),
+            "evaluation repo should SELECT retrieved_contexts",
+        )


### PR DESCRIPTION
## 概要

チャット履歴・フィードバック更新APIで、レスポンスに含まれない `retrieved_contexts` 列を常にSELECTしていた問題を修正する。

closes #681

## 変更内容

### `django_chat_repository.py`
- `get_logs_for_group`: `.defer("retrieved_contexts")` を追加
- `get_log_by_id`: `.defer("retrieved_contexts")` を追加
- `update_feedback`: 再取得クエリに `.defer("retrieved_contexts")` を追加
- `_chat_log_to_entity`: `get_deferred_fields()` で defer 済みの場合はアクセスをスキップし `[]` を返す（追加 SELECT 防止）

### 変更なし
- `DjangoChatLogForEvaluationRepository`: RAGAS評価用のため `retrieved_contexts` を引き続き読む

## テスト

- `DjangoChatRepositoryRetrievedContextsTests`（5件）
  - `get_logs_for_group` / `get_log_by_id` / `update_feedback` の SQL に `retrieved_contexts` が含まれないことを確認
  - entity の `retrieved_contexts` が `[]` になることを確認
- `DjangoChatLogForEvaluationRepositoryTests`（2件）
  - 評価リポジトリでは `retrieved_contexts` が正しく読まれることを確認

## 影響範囲

`retrieved_contexts` が必要な `DjangoChatLogForEvaluationRepository` と `create_log`（メモリ上のオブジェクト）は影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)