### PR TITLE
fix: make transcript reindexing async via Celery after manual edit

### DIFF
--- a/backend/app/composition_root/_video_core_providers.py
+++ b/backend/app/composition_root/_video_core_providers.py
@@ -8,6 +8,7 @@ from app.use_cases.video.get_video import GetVideoDetailUseCase
 from app.use_cases.video.index_video import IndexVideoTranscriptUseCase
 from app.use_cases.video.list_videos import ListVideosUseCase
 from app.use_cases.video.reindex_all_videos import ReindexAllVideosUseCase
+from app.use_cases.video.reindex_video_transcript import ReindexVideoTranscriptUseCase
 from app.use_cases.video.request_video_upload import RequestVideoUploadUseCase
 from app.use_cases.video.run_transcription import RunTranscriptionUseCase
 from app.use_cases.video.update_video import UpdateVideoUseCase
@@ -95,8 +96,16 @@ def get_update_video_use_case() -> UpdateVideoUseCase:
     return UpdateVideoUseCase(
         shared.new_video_repository(),
         shared.new_vector_store_gateway(),
-        shared.get_vector_indexing_gateway(),
+        shared.new_video_task_gateway(),
         DjangoTransactionPort(),
+    )
+
+
+def get_reindex_video_transcript_use_case() -> ReindexVideoTranscriptUseCase:
+    return ReindexVideoTranscriptUseCase(
+        shared.new_video_repository(),
+        shared.new_vector_store_gateway(),
+        shared.get_vector_indexing_gateway(),
     )
 
 

--- a/backend/app/composition_root/video.py
+++ b/backend/app/composition_root/video.py
@@ -106,6 +106,14 @@ def get_update_video_use_case():
     return core.get_update_video_use_case()
 
 
+def get_reindex_video_transcript_use_case():
+    return core.get_reindex_video_transcript_use_case()
+
+
+def reindex_video_transcript(video_id: int) -> None:
+    get_reindex_video_transcript_use_case().execute(video_id)
+
+
 def get_delete_video_use_case():
     return core.get_delete_video_use_case()
 

--- a/backend/app/contracts/tasks.py
+++ b/backend/app/contracts/tasks.py
@@ -18,3 +18,6 @@ INDEX_VIDEO_TRANSCRIPT_TASK = (
     "app.entrypoints.tasks.indexing.index_video_transcript"
 )
 EVALUATE_CHAT_LOG_TASK = "app.entrypoints.tasks.evaluation.evaluate_chat_log"
+REINDEX_VIDEO_TRANSCRIPT_TASK = (
+    "app.entrypoints.tasks.reindex_video_transcript.reindex_video_transcript"
+)

--- a/backend/app/dependencies/tasks.py
+++ b/backend/app/dependencies/tasks.py
@@ -64,3 +64,7 @@ def get_delete_account_data_use_case():
 
 def get_reindex_all_videos_use_case():
     return _cr_video.get_reindex_all_videos_use_case()
+
+
+def reindex_video_transcript(video_id: int) -> None:
+    _cr_video.reindex_video_transcript(video_id)

--- a/backend/app/domain/video/gateways.py
+++ b/backend/app/domain/video/gateways.py
@@ -39,6 +39,11 @@ class VideoTaskGateway(ABC):
         """Enqueue full re-indexing task and return the created task id."""
         ...
 
+    @abstractmethod
+    def enqueue_reindex_transcript(self, video_id: int) -> None:
+        """Enqueue async transcript reindex (delete old vectors + re-index) for a single video."""
+        ...
+
 
 class VectorIndexingGateway(ABC):
     """Abstract interface for vector store indexing operations."""

--- a/backend/app/entrypoints/tasks/reindex_video_transcript.py
+++ b/backend/app/entrypoints/tasks/reindex_video_transcript.py
@@ -1,0 +1,36 @@
+"""
+Celery task: reindex a single video's transcript after a manual edit.
+Delegates all processing to ReindexVideoTranscriptUseCase.
+"""
+
+import logging
+
+from celery import shared_task
+
+from app.contracts.tasks import REINDEX_VIDEO_TRANSCRIPT_TASK
+from app.dependencies.tasks import reindex_video_transcript
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(
+    bind=True,
+    max_retries=3,
+    name=REINDEX_VIDEO_TRANSCRIPT_TASK,
+)
+def reindex_video_transcript_task(self, video_id: int) -> None:
+    """
+    Reindex vectors for a single video after a manual transcript edit.
+    Retry up to 3 times on failure (60s, 120s, 180s backoff).
+    """
+    logger.info("Reindex transcript task started for video ID: %d", video_id)
+    try:
+        reindex_video_transcript(video_id)
+        logger.info("Successfully reindexed transcript for video %d", video_id)
+    except Exception as exc:
+        if self.request.retries < self.max_retries:
+            raise self.retry(exc=exc, countdown=60 * (self.request.retries + 1))
+        logger.error(
+            "Reindex transcript exhausted all retries for video %d", video_id, exc_info=True
+        )
+        raise

--- a/backend/app/infrastructure/tasks/task_gateway.py
+++ b/backend/app/infrastructure/tasks/task_gateway.py
@@ -11,6 +11,7 @@ from app.contracts.tasks import (
     EVALUATE_CHAT_LOG_TASK,
     INDEX_VIDEO_TRANSCRIPT_TASK,
     REINDEX_ALL_VIDEOS_EMBEDDINGS_TASK,
+    REINDEX_VIDEO_TRANSCRIPT_TASK,
     TRANSCRIBE_VIDEO_TASK,
 )
 
@@ -40,6 +41,15 @@ class CeleryVideoTaskGateway(VideoTaskGateway):
         """Dispatch full re-indexing task immediately and return task id."""
         result = current_app.send_task(REINDEX_ALL_VIDEOS_EMBEDDINGS_TASK)
         return result.id
+
+    def enqueue_reindex_transcript(self, video_id: int) -> None:
+        """Dispatch transcript reindex task after the current DB transaction commits."""
+        transaction.on_commit(
+            lambda: current_app.send_task(
+                REINDEX_VIDEO_TRANSCRIPT_TASK,
+                args=[video_id],
+            )
+        )
 
 
 class CeleryAuthTaskGateway(AuthTaskGateway):

--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -432,10 +432,9 @@ class VideoDetailViewTests(APITestCase):
         self.assertEqual(self.video.description, "Updated Description")
         self.assertEqual(self.video.title, "Original Title")
 
-    @patch("app.infrastructure.external.vector_gateway.delete_video_vectors")
-    @patch("app.infrastructure.external.scene_indexer.index_scenes_batch")
-    def test_update_video_transcript_reindexes_pgvector(self, mock_index, mock_delete):
-        """Test that updating video transcript refreshes PGVector contents."""
+    @patch("app.infrastructure.tasks.task_gateway.current_app")
+    def test_update_video_transcript_enqueues_reindex_task(self, mock_celery):
+        """Test that updating video transcript enqueues async reindex task."""
         self.video.transcript = "old transcript"
         self.video.save(update_fields=["transcript"])
         url = reverse("video-detail", kwargs={"pk": self.video.pk})
@@ -448,8 +447,10 @@ class VideoDetailViewTests(APITestCase):
         self.assertEqual(response.data["transcript"], "new transcript")
         self.video.refresh_from_db()
         self.assertEqual(self.video.transcript, "new transcript")
-        mock_delete.assert_called_once_with(self.video.id)
-        self.assertEqual(mock_index.call_args.args[0], "new transcript")
+        mock_celery.send_task.assert_called_once_with(
+            "app.entrypoints.tasks.reindex_video_transcript.reindex_video_transcript",
+            args=[self.video.id],
+        )
 
 
 class TagViewTests(APITestCase):

--- a/backend/app/use_cases/video/reindex_video_transcript.py
+++ b/backend/app/use_cases/video/reindex_video_transcript.py
@@ -1,0 +1,50 @@
+"""
+Use case: Reindex a video's transcript in the vector store after a manual edit.
+Runs asynchronously via Celery after the transcript update is committed.
+"""
+
+import logging
+
+from app.domain.video.gateways import VectorIndexingGateway, VectorStoreGateway
+from app.domain.video.repositories import VideoTranscriptionRepository
+
+logger = logging.getLogger(__name__)
+
+
+class ReindexVideoTranscriptUseCase:
+    """
+    Orchestrates vector reindexing after a manual transcript edit:
+    1. Fetch the video (no status restriction — video is already COMPLETED)
+    2. Delete existing vectors
+    3. Re-index from the current transcript (skip if empty)
+    """
+
+    def __init__(
+        self,
+        video_repo: VideoTranscriptionRepository,
+        vector_store_gateway: VectorStoreGateway,
+        vector_indexing_gateway: VectorIndexingGateway,
+    ):
+        self.video_repo = video_repo
+        self.vector_store_gateway = vector_store_gateway
+        self.vector_indexing_gateway = vector_indexing_gateway
+
+    def execute(self, video_id: int) -> None:
+        video = self.video_repo.get_by_id_for_task(video_id)
+        if video is None:
+            logger.warning("ReindexVideoTranscript: video %d not found, skipping", video_id)
+            return
+
+        self.vector_store_gateway.delete_video_vectors(video_id)
+
+        if video.transcript:
+            self.vector_indexing_gateway.index_video_transcript(
+                video.id,
+                video.user_id,
+                video.title,
+                video.transcript,
+                api_key=None,
+            )
+            logger.info("Reindexed transcript for video %d", video_id)
+        else:
+            logger.info("Transcript cleared for video %d; vectors deleted, no reindex", video_id)

--- a/backend/app/use_cases/video/tests/test_reindex_video_transcript.py
+++ b/backend/app/use_cases/video/tests/test_reindex_video_transcript.py
@@ -1,0 +1,104 @@
+"""Unit tests for ReindexVideoTranscriptUseCase."""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from app.domain.video.entities import VideoEntity
+from app.use_cases.video.reindex_video_transcript import ReindexVideoTranscriptUseCase
+
+
+class ReindexVideoTranscriptUseCaseTests(TestCase):
+    def setUp(self):
+        self.video_repo = MagicMock()
+        self.vector_store_gateway = MagicMock()
+        self.vector_indexing_gateway = MagicMock()
+        self.use_case = ReindexVideoTranscriptUseCase(
+            self.video_repo,
+            self.vector_store_gateway,
+            self.vector_indexing_gateway,
+        )
+
+    def test_deletes_and_reindexes_when_transcript_present(self):
+        video = VideoEntity(
+            id=5,
+            user_id=10,
+            title="My Video",
+            transcript="1\n00:00:00,000 --> 00:00:05,000\nHello world",
+            status="completed",
+        )
+        self.video_repo.get_by_id_for_task.return_value = video
+
+        self.use_case.execute(5)
+
+        self.vector_store_gateway.delete_video_vectors.assert_called_once_with(5)
+        self.vector_indexing_gateway.index_video_transcript.assert_called_once_with(
+            5, 10, "My Video",
+            "1\n00:00:00,000 --> 00:00:05,000\nHello world",
+            api_key=None,
+        )
+
+    def test_only_deletes_when_transcript_empty(self):
+        video = VideoEntity(
+            id=5,
+            user_id=10,
+            title="My Video",
+            transcript="",
+            status="completed",
+        )
+        self.video_repo.get_by_id_for_task.return_value = video
+
+        self.use_case.execute(5)
+
+        self.vector_store_gateway.delete_video_vectors.assert_called_once_with(5)
+        self.vector_indexing_gateway.index_video_transcript.assert_not_called()
+
+    def test_only_deletes_when_transcript_is_none(self):
+        video = VideoEntity(
+            id=5,
+            user_id=10,
+            title="My Video",
+            transcript=None,
+            status="completed",
+        )
+        self.video_repo.get_by_id_for_task.return_value = video
+
+        self.use_case.execute(5)
+
+        self.vector_store_gateway.delete_video_vectors.assert_called_once_with(5)
+        self.vector_indexing_gateway.index_video_transcript.assert_not_called()
+
+    def test_no_op_when_video_not_found(self):
+        self.video_repo.get_by_id_for_task.return_value = None
+
+        self.use_case.execute(99)
+
+        self.vector_store_gateway.delete_video_vectors.assert_not_called()
+        self.vector_indexing_gateway.index_video_transcript.assert_not_called()
+
+    def test_propagates_indexing_error(self):
+        video = VideoEntity(
+            id=5,
+            user_id=10,
+            title="My Video",
+            transcript="some transcript",
+            status="completed",
+        )
+        self.video_repo.get_by_id_for_task.return_value = video
+        self.vector_indexing_gateway.index_video_transcript.side_effect = RuntimeError("oops")
+
+        with self.assertRaises(RuntimeError):
+            self.use_case.execute(5)
+
+    def test_propagates_delete_error(self):
+        video = VideoEntity(
+            id=5,
+            user_id=10,
+            title="My Video",
+            transcript="some transcript",
+            status="completed",
+        )
+        self.video_repo.get_by_id_for_task.return_value = video
+        self.vector_store_gateway.delete_video_vectors.side_effect = RuntimeError("oops")
+
+        with self.assertRaises(RuntimeError):
+            self.use_case.execute(5)

--- a/backend/app/use_cases/video/tests/test_update_video.py
+++ b/backend/app/use_cases/video/tests/test_update_video.py
@@ -25,11 +25,11 @@ class UpdateVideoUseCaseTests(TestCase):
     def setUp(self):
         self.video_repo = MagicMock()
         self.vector_gateway = MagicMock()
-        self.vector_indexing_gateway = MagicMock()
+        self.task_gateway = MagicMock()
         self.use_case = UpdateVideoUseCase(
             self.video_repo,
             self.vector_gateway,
-            self.vector_indexing_gateway,
+            self.task_gateway,
             _FakeTransactionPort(),
         )
 
@@ -82,8 +82,7 @@ class UpdateVideoUseCaseTests(TestCase):
         )
 
         self.vector_gateway.update_video_title.assert_not_called()
-        self.vector_gateway.delete_video_vectors.assert_not_called()
-        self.vector_indexing_gateway.index_video_transcript.assert_not_called()
+        self.task_gateway.enqueue_reindex_transcript.assert_not_called()
 
     def test_vector_sync_failure_is_non_fatal(self):
         before = VideoEntity(id=7, user_id=10, title="old", status="completed")
@@ -101,7 +100,7 @@ class UpdateVideoUseCaseTests(TestCase):
         self.assertEqual(result.title, "new")
         self.video_repo.update.assert_called_once()
 
-    def test_reindexes_transcript_when_transcript_changed(self):
+    def test_enqueues_reindex_when_transcript_changed(self):
         before = VideoEntity(
             id=7,
             user_id=10,
@@ -126,16 +125,9 @@ class UpdateVideoUseCaseTests(TestCase):
         )
 
         self.assertEqual(result.transcript, "new transcript")
-        self.vector_gateway.delete_video_vectors.assert_called_once_with(7)
-        self.vector_indexing_gateway.index_video_transcript.assert_called_once_with(
-            7,
-            10,
-            "Video",
-            "new transcript",
-            api_key=None,
-        )
+        self.task_gateway.enqueue_reindex_transcript.assert_called_once_with(7)
 
-    def test_deletes_vectors_without_reindex_when_transcript_cleared(self):
+    def test_enqueues_reindex_when_transcript_cleared(self):
         before = VideoEntity(
             id=7,
             user_id=10,
@@ -159,5 +151,23 @@ class UpdateVideoUseCaseTests(TestCase):
             input=UpdateVideoInput(transcript=""),
         )
 
-        self.vector_gateway.delete_video_vectors.assert_called_once_with(7)
-        self.vector_indexing_gateway.index_video_transcript.assert_not_called()
+        self.task_gateway.enqueue_reindex_transcript.assert_called_once_with(7)
+
+    def test_does_not_enqueue_reindex_when_transcript_unchanged(self):
+        video = VideoEntity(
+            id=7,
+            user_id=10,
+            title="Video",
+            transcript="same transcript",
+            status="completed",
+        )
+        self.video_repo.get_by_id.return_value = video
+        self.video_repo.update.return_value = video
+
+        self.use_case.execute(
+            video_id=7,
+            user_id=10,
+            input=UpdateVideoInput(transcript="same transcript"),
+        )
+
+        self.task_gateway.enqueue_reindex_transcript.assert_not_called()

--- a/backend/app/use_cases/video/update_video.py
+++ b/backend/app/use_cases/video/update_video.py
@@ -6,7 +6,7 @@ import logging
 
 from app.domain.shared.transaction import TransactionPort
 from app.domain.video.dto import UpdateVideoParams
-from app.domain.video.gateways import VectorIndexingGateway, VectorStoreGateway
+from app.domain.video.gateways import VideoTaskGateway, VectorStoreGateway
 from app.domain.video.repositories import VideoRepository
 from app.use_cases.video.dto import UpdateVideoInput, VideoResponseDTO
 from app.use_cases.video.exceptions import ResourceNotFound
@@ -21,18 +21,19 @@ class UpdateVideoUseCase:
     1. Retrieve the video
     2. Apply changes
     3. Sync PGVector metadata if the title changed
+    4. Enqueue async transcript reindex if the transcript changed
     """
 
     def __init__(
         self,
         video_repo: VideoRepository,
         vector_gateway: VectorStoreGateway,
-        vector_indexing_gateway: VectorIndexingGateway,
+        task_gateway: VideoTaskGateway,
         tx: TransactionPort,
     ):
         self.video_repo = video_repo
         self.vector_gateway = vector_gateway
-        self.vector_indexing_gateway = vector_indexing_gateway
+        self.task_gateway = task_gateway
         self.tx = tx
 
     def execute(self, video_id: int, user_id: int, input: UpdateVideoInput) -> VideoResponseDTO:
@@ -72,24 +73,6 @@ class UpdateVideoUseCase:
                 self.tx.on_commit(_sync_vector_title)
 
             if transcript_changed:
-                def _reindex_transcript() -> None:
-                    try:
-                        self.vector_gateway.delete_video_vectors(video.id)
-                        if video.transcript:
-                            self.vector_indexing_gateway.index_video_transcript(
-                                video.id,
-                                video.user_id,
-                                video.title,
-                                video.transcript,
-                                api_key=None,
-                            )
-                    except Exception:
-                        logger.warning(
-                            "Failed to reindex transcript for video %s after manual edit",
-                            video.id,
-                            exc_info=True,
-                        )
-
-                self.tx.on_commit(_reindex_transcript)
+                self.tx.on_commit(lambda: self.task_gateway.enqueue_reindex_transcript(video.id))
 
         return to_video_response_dto(video)


### PR DESCRIPTION
## Summary

Closes #693.

Transcript reindexing after a manual edit was running synchronously in the request lifecycle via `on_commit`. This blocked the PATCH response for long transcripts and silently swallowed failures, leaving the vector index out of sync with no retry.

## Changes

- **`UpdateVideoUseCase`**: removed inline reindex logic; replaced with `task_gateway.enqueue_reindex_transcript(video_id)`
- **`ReindexVideoTranscriptUseCase`**: new use case that deletes old vectors and re-indexes from the current transcript (no status transition required — video is already COMPLETED)
- **`reindex_video_transcript` Celery task**: retries up to 3 times with 60s/120s/180s backoff
- **`VideoTaskGateway`**: added `enqueue_reindex_transcript()` abstract method
- **`REINDEX_VIDEO_TRANSCRIPT_TASK`**: added task name constant to `contracts/tasks.py`
- **Composition root / dependencies**: wired up new use case

## Tests

- Unit tests for `UpdateVideoUseCase`: verify `enqueue_reindex_transcript` is called on transcript change, not called when unchanged
- Unit tests for `ReindexVideoTranscriptUseCase`: covers transcript present, transcript cleared, video not found, and error propagation
- Integration test updated: asserts Celery task is enqueued instead of checking synchronous vector ops