### PR TITLE
fix: validate SRT format before saving edited transcript

### DIFF
--- a/backend/app/presentation/video/serializers.py
+++ b/backend/app/presentation/video/serializers.py
@@ -6,6 +6,7 @@ Business logic (quota enforcement, task dispatch) lives in use cases.
 
 import logging
 import os
+import re
 import tempfile
 
 from django.conf import settings
@@ -357,12 +358,39 @@ class VideoUploadRequestResponseSerializer(serializers.Serializer):
     upload_url = serializers.URLField()
 
 
+_SRT_TIMESTAMP_RE = re.compile(
+    r"^\d{2}:\d{2}:\d{2},\d{3}\s+-->\s+\d{2}:\d{2}:\d{2},\d{3}$"
+)
+
+
 class VideoUpdateSerializer(serializers.Serializer):
     """Serializer for video updates."""
 
     title = serializers.CharField(max_length=255, required=False)
     description = serializers.CharField(required=False, allow_blank=True)
     transcript = serializers.CharField(required=False, allow_blank=True, trim_whitespace=False)
+
+    def validate_transcript(self, value):
+        if not value or not value.strip():
+            return value
+        blocks = [b.strip() for b in value.split("\n\n") if b.strip()]
+        for block in blocks:
+            lines = block.split("\n")
+            if len(lines) < 3:
+                raise serializers.ValidationError(
+                    "Transcript must be in valid SRT format."
+                )
+            try:
+                int(lines[0].strip())
+            except ValueError:
+                raise serializers.ValidationError(
+                    "Transcript must be in valid SRT format."
+                )
+            if not _SRT_TIMESTAMP_RE.match(lines[1].strip()):
+                raise serializers.ValidationError(
+                    "Transcript must be in valid SRT format."
+                )
+        return value
 
 
 class VideoGroupCreateSerializer(serializers.Serializer):

--- a/backend/app/presentation/video/tests/test_serializers.py
+++ b/backend/app/presentation/video/tests/test_serializers.py
@@ -18,6 +18,7 @@ from app.presentation.video.serializers import (
     TagUpdateSerializer,
     VideoCreateSerializer,
     VideoGroupDetailSerializer,
+    VideoUpdateSerializer,
     YoutubeVideoCreateSerializer,
     VideoSerializer,
 )
@@ -424,6 +425,70 @@ class VideoGroupDetailSerializerTests(TestCase):
 
         self.assertEqual(data["videos"], [])
         self.assertEqual(data["video_count"], 0)
+
+
+class VideoUpdateSerializerTests(TestCase):
+    """Tests for VideoUpdateSerializer — validates SRT format for transcript field."""
+
+    VALID_SRT = (
+        "1\n"
+        "00:00:01,000 --> 00:00:03,000\n"
+        "Hello world\n\n"
+        "2\n"
+        "00:00:04,000 --> 00:00:06,000\n"
+        "Goodbye world"
+    )
+
+    def test_valid_srt_transcript_passes(self):
+        """Valid SRT content is accepted."""
+        serializer = VideoUpdateSerializer(data={"transcript": self.VALID_SRT})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_blank_transcript_passes(self):
+        """Empty transcript is accepted (field is optional)."""
+        serializer = VideoUpdateSerializer(data={"transcript": ""})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_missing_transcript_passes(self):
+        """Omitting transcript is accepted (title-only update)."""
+        serializer = VideoUpdateSerializer(data={"title": "New Title"})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_plain_text_transcript_rejected(self):
+        """Plain text without SRT timestamps is rejected."""
+        serializer = VideoUpdateSerializer(
+            data={"transcript": "This is plain text without SRT format"}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("transcript", serializer.errors)
+
+    def test_broken_timestamp_rejected(self):
+        """SRT block with malformed timestamp arrow is rejected."""
+        broken = "1\n00:00:01 -> 00:00:03\nHello world"
+        serializer = VideoUpdateSerializer(data={"transcript": broken})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("transcript", serializer.errors)
+
+    def test_missing_text_line_rejected(self):
+        """SRT block with index and timestamp but no text line is rejected."""
+        no_text = "1\n00:00:01,000 --> 00:00:03,000"
+        serializer = VideoUpdateSerializer(data={"transcript": no_text})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("transcript", serializer.errors)
+
+    def test_non_integer_index_rejected(self):
+        """SRT block whose first line is not a sequence number is rejected."""
+        bad_index = "one\n00:00:01,000 --> 00:00:03,000\nHello world"
+        serializer = VideoUpdateSerializer(data={"transcript": bad_index})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("transcript", serializer.errors)
+
+    def test_dot_separator_timestamp_rejected(self):
+        """WebVTT-style dots in timestamp (00:00:01.000) are rejected."""
+        vtt_style = "1\n00:00:01.000 --> 00:00:03.000\nHello world"
+        serializer = VideoUpdateSerializer(data={"transcript": vtt_style})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("transcript", serializer.errors)
 
 
 class TagDetailSerializerTests(TestCase):

--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -436,20 +436,30 @@ class VideoDetailViewTests(APITestCase):
     @patch("app.infrastructure.external.scene_indexer.index_scenes_batch")
     def test_update_video_transcript_reindexes_pgvector(self, mock_index, mock_delete):
         """Test that updating video transcript refreshes PGVector contents."""
-        self.video.transcript = "old transcript"
+        old_srt = "1\n00:00:01,000 --> 00:00:03,000\nold transcript"
+        new_srt = "1\n00:00:01,000 --> 00:00:03,000\nnew transcript"
+        self.video.transcript = old_srt
         self.video.save(update_fields=["transcript"])
         url = reverse("video-detail", kwargs={"pk": self.video.pk})
-        data = {"transcript": "new transcript"}
+        data = {"transcript": new_srt}
 
         with self.captureOnCommitCallbacks(execute=True):
             response = self.client.patch(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["transcript"], "new transcript")
+        self.assertEqual(response.data["transcript"], new_srt)
         self.video.refresh_from_db()
-        self.assertEqual(self.video.transcript, "new transcript")
+        self.assertEqual(self.video.transcript, new_srt)
         mock_delete.assert_called_once_with(self.video.id)
-        self.assertEqual(mock_index.call_args.args[0], "new transcript")
+        self.assertEqual(mock_index.call_args.args[0], new_srt)
+
+    def test_update_video_with_plain_text_transcript_returns_400(self):
+        """Submitting plain text as transcript is rejected with 400."""
+        url = reverse("video-detail", kwargs={"pk": self.video.pk})
+        response = self.client.patch(url, {"transcript": "plain text"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.video.refresh_from_db()
+        self.assertNotEqual(self.video.transcript, "plain text")
 
 
 class TagViewTests(APITestCase):


### PR DESCRIPTION
## Summary

- `VideoUpdateSerializer` に `validate_transcript` を追加し、非SRT形式のトランスクリプト送信を 400 で拒否
- plain text や WebVTT 形式（ドット区切り）を保存前にブロックし、ベクター削除→再インデックス失敗のサイレントバグを防止

Closes #694

## Changes

- **`serializers.py`**: `_SRT_TIMESTAMP_RE` 正規表現 + `validate_transcript()` を `VideoUpdateSerializer` に追加
  - 各ブロックで整数シーケンス番号・`HH:MM:SS,mmm --> HH:MM:SS,mmm` 形式・テキスト行の存在を検証
  - 空・未送信は通過（既存の optional 挙動を維持）
- **`test_serializers.py`**: `VideoUpdateSerializerTests` を新規追加（8ケース）
- **`test_views.py`**: plain text PATCH が 400 を返し DB に保存されないことを view レベルで確認 / 既存テストのフィクスチャを valid SRT に修正

## Test plan

- [x] `VideoUpdateSerializerTests` 8ケース（valid SRT, blank, missing, plain text, broken arrow, missing text line, non-integer index, WebVTT dot separator）
- [x] `test_update_video_with_plain_text_transcript_returns_400`（view レベル）
- [x] `test_update_video_transcript_reindexes_pgvector`（valid SRT で引き続き正常動作）
- [x] 全 109 presentation テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)