### PR TITLE
fix: propagate errors from delete_video_vectors instead of swallowing them

### DIFF
--- a/backend/app/infrastructure/external/tests/test_vector_store.py
+++ b/backend/app/infrastructure/external/tests/test_vector_store.py
@@ -250,12 +250,21 @@ class DeleteVideoVectorsTests(SimpleTestCase):
 
     @patch.object(PGVectorManager, "_get_management_store")
     @patch("app.infrastructure.external.vector_store.logger")
-    def test_delete_video_vectors_error(self, mock_logger, mock_get_store):
+    def test_delete_video_vectors_logs_and_propagates_error(self, mock_logger, mock_get_store):
         mock_get_store.side_effect = Exception("Database error")
 
-        delete_video_vectors(123)
+        with self.assertRaises(Exception):
+            delete_video_vectors(123)
 
         mock_logger.warning.assert_called()
+
+    @patch.object(PGVectorManager, "_get_management_store")
+    def test_delete_video_vectors_propagates_exception(self, mock_get_store):
+        """Exceptions from the store must propagate so callers can handle failures."""
+        mock_get_store.side_effect = RuntimeError("Vector deletion failed")
+
+        with self.assertRaises(RuntimeError, msg="Vector deletion failed"):
+            delete_video_vectors(123)
 
 
 class UpdateVideoTitleTests(SimpleTestCase):

--- a/backend/app/infrastructure/external/vector_store.py
+++ b/backend/app/infrastructure/external/vector_store.py
@@ -152,6 +152,7 @@ def delete_video_vectors(video_id: int) -> None:
         logger.warning(
             "Failed to delete vectors for video ID %s: %s", video_id, e, exc_info=True
         )
+        raise
 
 
 def update_video_title_in_vectors(video_id: int, new_title: str) -> int:


### PR DESCRIPTION
## Summary

- `delete_video_vectors()` が例外を握り潰していた問題を修正
- ログ出力後に `raise` するよう変更し、呼び出し元が失敗を明示的に処理できるようにした（`delete_all_vectors()` と同じ挙動に統一）

Closes #695

## Problem

トランスクリプト編集時のリインデックスフローで `delete_video_vectors()` が失敗しても例外が伝播せず、古いベクターが残ったまま新しいベクターが追加される状態になっていた。

## Changes

- **`vector_store.py`**: `except` ブロックに `raise` を追加
- **`test_vector_store.py`**:
  - `test_delete_video_vectors_error` → `test_delete_video_vectors_logs_and_propagates_error` にリネーム。`assertRaises` を追加し、ログ出力＋例外伝播の両方を検証
  - `test_delete_video_vectors_propagates_exception` を新規追加（呼び出し元に例外が届くことを単独で検証）

## Test plan

- [x] `test_delete_video_vectors_propagates_exception` — 例外が呼び出し元に伝播する
- [x] `test_delete_video_vectors_logs_and_propagates_error` — 警告ログ出力 + 例外伝播
- [x] `test_delete_video_vectors` — 正常系は引き続き動作
- [x] 全 1079 テスト中、新規 failure なし（pre-existing 2件を除く）

🤖 Generated with [Claude Code](https://claude.com/claude-code)