### PR TITLE
fix: register reindex_video_transcript_task in Celery entrypoints

### DIFF
--- a/backend/app/entrypoints/tasks/__init__.py
+++ b/backend/app/entrypoints/tasks/__init__.py
@@ -3,6 +3,7 @@
 from app.entrypoints.tasks.account_deletion import delete_account_data
 from app.entrypoints.tasks.evaluation import evaluate_chat_log
 from app.entrypoints.tasks.indexing import index_video_transcript_task
+from app.entrypoints.tasks.reindex_video_transcript import reindex_video_transcript_task
 from app.entrypoints.tasks.reindexing import reindex_all_videos_embeddings
 from app.entrypoints.tasks.transcription import transcribe_video
 
@@ -10,6 +11,7 @@ __all__ = [
     "delete_account_data",
     "evaluate_chat_log",
     "index_video_transcript_task",
+    "reindex_video_transcript_task",
     "reindex_all_videos_embeddings",
     "transcribe_video",
 ]


### PR DESCRIPTION
## Summary

- `app/entrypoints/tasks/__init__.py` に `reindex_video_transcript_task` のインポートと `__all__` への追加を行った

## 背景

PR #696 で `app/entrypoints/tasks/reindex_video_transcript.py` タスクファイルが追加されたが、`__init__.py` へのインポートが漏れていた。

`celery_config.py` は `app.autodiscover_tasks(["app.entrypoints"])` でタスクを検出しているが、これは `app/entrypoints/tasks/__init__.py` 経由でモジュールをインポートする仕組みのため、`__init__.py` に記載のないタスクは未登録のまま起動する。

その結果、トランスクリプト編集後に Celery ワーカーが以下のエラーでメッセージを破棄していた：

```
Received unregistered task of type 'app.entrypoints.tasks.reindex_video_transcript.reindex_video_transcript'.
The message has been ignored and discarded.
```

## 修正内容

```python
# app/entrypoints/tasks/__init__.py
from app.entrypoints.tasks.reindex_video_transcript import reindex_video_transcript_task
```

## Test plan

- [ ] `docker compose build backend` でイメージ再ビルド
- [ ] Celery ワーカー再起動後、動画のトランスクリプトを編集して PATCH リクエストを送信
- [ ] ワーカーログに `Reindex transcript task started for video ID: ...` が出力され、エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)