### PR TITLE
fix: transcript save error not displayed to user

### DIFF
--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -182,6 +182,7 @@ export default function VideoDetailPage() {
   const [transcriptSearch, setTranscriptSearch] = useState('');
   const [isTranscriptEditing, setIsTranscriptEditing] = useState(false);
   const [editedTranscript, setEditedTranscript] = useState('');
+  const [transcriptSaveError, setTranscriptSaveError] = useState<string | null>(null);
   const [activeSegmentIdx, setActiveSegmentIdx] = useState<number | null>(null);
   const [mobileTab, setMobileTab] = useState<'info' | 'video'>('video');
   const [isMobile, setIsMobile] = useState(false);
@@ -259,16 +260,22 @@ export default function VideoDetailPage() {
       }
       setIsTranscriptEditing(false);
       setTranscriptSearch('');
+      setTranscriptSaveError(null);
+    },
+    onError: (err: unknown) => {
+      setTranscriptSaveError(err instanceof Error ? err.message : String(err));
     },
   });
 
   const startTranscriptEditing = () => {
     setEditedTranscript(video?.transcript ?? '');
+    setTranscriptSaveError(null);
     setIsTranscriptEditing(true);
   };
 
   const cancelTranscriptEditing = () => {
     setEditedTranscript(video?.transcript ?? '');
+    setTranscriptSaveError(null);
     setIsTranscriptEditing(false);
   };
 
@@ -593,7 +600,7 @@ export default function VideoDetailPage() {
                     </button>
                     <button
                       type="button"
-                      onClick={() => void transcriptUpdateMutation.mutateAsync()}
+                      onClick={() => transcriptUpdateMutation.mutate()}
                       disabled={transcriptUpdateMutation.isPending}
                       className="inline-flex items-center justify-center gap-1.5 rounded-xl bg-[#00652c] px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-[#005323] disabled:opacity-50"
                     >
@@ -602,6 +609,11 @@ export default function VideoDetailPage() {
                     </button>
                   </div>
                 </div>
+                {transcriptSaveError && (
+                  <p className="shrink-0 px-3 py-2 text-xs text-red-700 bg-red-50 border-b border-red-200">
+                    {transcriptSaveError}
+                  </p>
+                )}
                 <textarea
                   value={editedTranscript}
                   onChange={(event) => setEditedTranscript(event.target.value)}

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import VideoDetailPage from '../VideoDetailPage'
-import { apiClient } from '@/lib/api'
+import { apiClient, ApiError } from '@/lib/api'
 
 const mockVideo = {
   id: 1,
@@ -42,16 +42,20 @@ vi.mock('@/hooks/useTags', () => ({
   }),
 }))
 
-vi.mock('@/lib/api', () => ({
-  apiClient: {
-    getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
-    updateVideo: vi.fn(),
-    deleteVideo: vi.fn(),
-    getVideoUrl: vi.fn((url) => url),
-    addTagsToVideo: vi.fn(),
-    removeTagFromVideo: vi.fn(),
-  },
-}))
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    apiClient: {
+      getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
+      updateVideo: vi.fn(),
+      deleteVideo: vi.fn(),
+      getVideoUrl: vi.fn((url: string) => url),
+      addTagsToVideo: vi.fn(),
+      removeTagFromVideo: vi.fn(),
+    },
+  }
+})
 
 describe('VideoDetailPage', () => {
   beforeEach(() => {
@@ -122,6 +126,66 @@ describe('VideoDetailPage', () => {
   })
 
 
+})
+
+describe('VideoDetailPage - Transcript save error', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should show error message when transcript save returns API error', async () => {
+    ;(apiClient.updateVideo as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new ApiError('Transcript must be in valid SRT format.', 'INVALID_SRT_FORMAT'),
+    )
+
+    render(<VideoDetailPage />)
+
+    fireEvent.click(screen.getByText('videos.detail.editTranscriptButton'))
+    fireEvent.click(screen.getByText('videos.detail.saveTranscriptButton'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Transcript must be in valid SRT format.')).toBeInTheDocument()
+    })
+  })
+
+  it('should clear error message when transcript editing is cancelled', async () => {
+    ;(apiClient.updateVideo as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new ApiError('Transcript must be in valid SRT format.', 'INVALID_SRT_FORMAT'),
+    )
+
+    render(<VideoDetailPage />)
+
+    fireEvent.click(screen.getByText('videos.detail.editTranscriptButton'))
+    fireEvent.click(screen.getByText('videos.detail.saveTranscriptButton'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Transcript must be in valid SRT format.')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('videos.detail.cancel'))
+
+    expect(screen.queryByText('Transcript must be in valid SRT format.')).not.toBeInTheDocument()
+  })
+
+  it('should clear error message when transcript editing is restarted', async () => {
+    ;(apiClient.updateVideo as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new ApiError('Transcript must be in valid SRT format.', 'INVALID_SRT_FORMAT'),
+    )
+
+    render(<VideoDetailPage />)
+
+    fireEvent.click(screen.getByText('videos.detail.editTranscriptButton'))
+    fireEvent.click(screen.getByText('videos.detail.saveTranscriptButton'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Transcript must be in valid SRT format.')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('videos.detail.cancel'))
+    fireEvent.click(screen.getByText('videos.detail.editTranscriptButton'))
+
+    expect(screen.queryByText('Transcript must be in valid SRT format.')).not.toBeInTheDocument()
+  })
 })
 
 describe('VideoDetailPage - Delete', () => {


### PR DESCRIPTION
## Summary

- トランスクリプト編集画面で保存時にAPIエラーが返却された場合（例：SRTフォーマット不正）、フロントエンドに何も表示されなかった問題を修正

## Changes

- `transcriptUpdateMutation` に `onError` ハンドラを追加し、エラーメッセージをローカル state に保持
- ツールバー下にエラーメッセージをインライン表示（赤背景）
- キャンセル時・編集再開始時にエラーをクリア
- `mutateAsync` → `mutate` に変更して unhandled promise rejection を解消

## Test plan

- [x] テスト追加済み（3件）: エラー表示・キャンセルでクリア・再編集開始でクリア
- [x] `npx vitest run src/pages/__tests__/VideoDetailPage.test.tsx` で全13テスト通過を確認

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)