### PR TITLE
Tighten core framework boundary rules

### DIFF
--- a/backend/app/domain/billing/ports.py
+++ b/backend/app/domain/billing/ports.py
@@ -26,12 +26,11 @@ class UserLimitsRepository(ABC):
     def check_and_reserve_storage(self, user_id: int, additional_bytes: int) -> None:
         """Atomically check storage limit and reserve space if within limit.
 
-        Uses a conditional F() UPDATE (WHERE used_storage_bytes <= limit - additional_bytes)
-        to prevent race conditions between concurrent upload requests. The WHERE
-        clause and UPDATE are evaluated atomically by the DB engine, so no
-        row-level locking is required. If adding additional_bytes would exceed
-        the configured storage limit, raises StorageLimitExceeded without modifying
-        used_storage_bytes. On success, increments used_storage_bytes by additional_bytes.
+        The capacity check and reservation must be one atomic mutation so
+        concurrent upload requests cannot both pass on stale usage. If adding
+        additional_bytes would exceed the configured storage limit, raises
+        StorageLimitExceeded without modifying used_storage_bytes. On success,
+        increments used_storage_bytes by additional_bytes.
         """
         ...
 
@@ -40,8 +39,8 @@ class UserLimitsRepository(ABC):
         """Atomically update used_storage_bytes by bytes_delta.
 
         Result is clamped to >= 0 to prevent negative storage values.
-        Must use a database-level atomic operation (e.g. F() expression) to
-        avoid lost updates under concurrent requests.
+        The counter mutation must be atomic to avoid lost updates under
+        concurrent requests.
         """
         ...
 
@@ -49,8 +48,8 @@ class UserLimitsRepository(ABC):
     def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
         """Atomically increment used_processing_seconds by seconds.
 
-        Must use a database-level atomic operation (e.g. F() expression) to
-        avoid lost updates under concurrent requests.
+        The counter mutation must be atomic to avoid lost updates under
+        concurrent requests.
         """
         ...
 
@@ -58,8 +57,8 @@ class UserLimitsRepository(ABC):
     def increment_ai_answers(self, user_id: int) -> None:
         """Atomically increment used_ai_answers by 1.
 
-        Must use a database-level atomic operation (e.g. F() expression) to
-        avoid lost updates under concurrent requests.
+        The counter mutation must be atomic to avoid lost updates under
+        concurrent requests.
         """
         ...
 

--- a/backend/app/domain/evaluation/gateways.py
+++ b/backend/app/domain/evaluation/gateways.py
@@ -39,7 +39,7 @@ class RagEvaluationGateway(ABC):
 
 
 class EvaluationTaskGateway(ABC):
-    """Abstract interface for dispatching evaluation Celery tasks."""
+    """Abstract interface for dispatching asynchronous evaluation work."""
 
     @abstractmethod
     def dispatch_evaluate_chat_log(self, chat_log_id: int) -> None:

--- a/backend/app/domain/shared/transaction.py
+++ b/backend/app/domain/shared/transaction.py
@@ -1,6 +1,6 @@
 """
 Abstract interface for managing database transactions.
-Allows use cases to enforce atomic boundaries without importing Django.
+Allows use cases to enforce atomic boundaries without a transaction framework.
 """
 
 from abc import ABC, abstractmethod

--- a/backend/app/tests/test_import_rules.py
+++ b/backend/app/tests/test_import_rules.py
@@ -2,8 +2,8 @@
 CI test: detect forbidden cross-layer imports.
 
 Acceptance criteria:
-  - app/domain/**   : no app.models, django, rest_framework, celery, app.infrastructure, app.use_cases
-  - app/use_cases/**: no app.models, django, rest_framework, app.infrastructure
+  - app/domain/**   : no framework imports or outer app-layer imports
+  - app/use_cases/**: no framework imports or outer app-layer imports
   - app/presentation/**: no app.models, no app.infrastructure.*
   - app/dependencies/**: no app.models, django, rest_framework, app.infrastructure
   - app/composition_root/**: no app.models, django, rest_framework, app.presentation
@@ -34,6 +34,40 @@ LAYER_ROOTS = {
     "tests",
     "migrations",
 }
+
+# Domain and use-case code must keep running as plain Python when Django, DRF,
+# or task-worker adapters are replaced.
+CORE_FRAMEWORK_IMPORTS = [
+    "celery",
+    "django",
+    "drf_spectacular",
+    "rest_framework",
+    "rest_framework_simplejwt",
+]
+CORE_OUTER_APP_IMPORTS = [
+    "app.admin",
+    "app.apps",
+    "app.celery_config",
+    "app.composition_root",
+    "app.contracts",
+    "app.dependencies",
+    "app.entrypoints",
+    "app.infrastructure",
+    "app.presentation",
+    "app.urls",
+    "videoq",
+]
+DOMAIN_FORBIDDEN_IMPORTS = [
+    "app.models",
+    "app.use_cases",
+    *CORE_FRAMEWORK_IMPORTS,
+    *CORE_OUTER_APP_IMPORTS,
+]
+USE_CASE_FORBIDDEN_IMPORTS = [
+    "app.models",
+    *CORE_FRAMEWORK_IMPORTS,
+    *CORE_OUTER_APP_IMPORTS,
+]
 
 # Service locator is prohibited in framework entrypoints.
 # Keep this allowlist empty by default; if temporary exceptions are needed,
@@ -361,19 +395,26 @@ class ImportRulesTest(unittest.TestCase):
             ),
         )
 
-    def test_domain_has_no_forbidden_imports(self):
-        """domain layer must not import from app.models, django, rest_framework, celery, app.infrastructure, or app.use_cases."""
-        self._check(
-            "domain",
-            [
-                "app.models",
-                "django",
-                "rest_framework",
-                "celery",
-                "app.infrastructure",
-                "app.use_cases",
-            ],
+    def _check_tests(self, layer_paths, forbidden):
+        all_violations = {}
+        for layer_path in layer_paths:
+            for fp in sorted(self._iter_layer_test_files(layer_path)):
+                rel = os.path.relpath(fp, BASE)
+                v = check_forbidden_imports(fp, forbidden)
+                if v:
+                    all_violations[rel] = v
+        self.assertEqual(
+            {},
+            all_violations,
+            "Forbidden imports found in core-layer tests:\n"
+            + "\n".join(
+                f"  {f}: {vs}" for f, vs in all_violations.items()
+            ),
         )
+
+    def test_domain_has_no_forbidden_imports(self):
+        """domain must not import frameworks, use cases, or outer app layers."""
+        self._check("domain", DOMAIN_FORBIDDEN_IMPORTS)
 
     def test_layer_scan_counts_are_non_zero(self):
         counts = {
@@ -393,8 +434,19 @@ class ImportRulesTest(unittest.TestCase):
             )
 
     def test_use_cases_has_no_forbidden_imports(self):
-        """use_cases layer must not import from app.models, django, rest_framework, or app.infrastructure."""
-        self._check("use_cases", ["app.models", "django", "rest_framework", "app.infrastructure"])
+        """use_cases must not import frameworks or outer app layers."""
+        self._check("use_cases", USE_CASE_FORBIDDEN_IMPORTS)
+
+    def test_core_layer_tests_have_no_framework_or_outer_layer_imports(self):
+        """Core tests stay plain unit tests without framework or adapter wiring."""
+        self._check_tests(
+            ["domain", "use_cases"],
+            [
+                "app.models",
+                *CORE_FRAMEWORK_IMPORTS,
+                *CORE_OUTER_APP_IMPORTS,
+            ],
+        )
 
     def test_core_layers_have_no_dynamic_import_calls(self):
         """Dynamic imports are disallowed in app layers guarded by import rules."""

--- a/backend/app/use_cases/evaluation/evaluate_chat_log.py
+++ b/backend/app/use_cases/evaluation/evaluate_chat_log.py
@@ -29,7 +29,7 @@ class EvaluateChatLogUseCase:
     Fetches a ChatLog by ID, runs RAGAS evaluation, and saves the result.
 
     On any failure the evaluation is persisted with status='failed' and the
-    error message — the task never re-raises so the Celery worker does not retry.
+    error message without asking the task runner to retry.
     """
 
     def __init__(
@@ -57,7 +57,7 @@ class EvaluateChatLogUseCase:
 
         chat_log = self.chat_log_repo.get_by_id(chat_log_id)
         if chat_log is None:
-            # No FK exists → cannot persist. Log and return silently.
+            # No source record exists, so there is nothing to persist.
             logger.warning("ChatLog %s not found; skipping evaluation.", chat_log_id)
             pending.status = "failed"
             pending.error_message = f"ChatLog {chat_log_id} not found."

--- a/backend/app/use_cases/video/reindex_video_transcript.py
+++ b/backend/app/use_cases/video/reindex_video_transcript.py
@@ -1,6 +1,6 @@
 """
 Use case: Reindex a video's transcript in the vector store after a manual edit.
-Runs asynchronously via Celery after the transcript update is committed.
+Can run asynchronously after the transcript update is committed.
 """
 
 import logging


### PR DESCRIPTION
## Summary
- strengthen import rules so `domain` and `use_cases` cannot depend on frameworks or outer app layers
- keep core-layer tests plain unit tests without framework or adapter wiring
- remove Django/Celery/ORM implementation wording from core ports and use-case docs

## Testing
- `docker compose run --rm backend python manage.py test app.tests.test_import_rules`
- `docker compose run --rm backend python -m unittest discover -s app/domain -p 'test*.py'`\n- `docker compose run --rm backend python -m unittest discover -s app/use_cases -p 'test*.py'`\n- `git diff --check`