### PR TITLE
feat: 教育改善ダッシュボードの keywords 読み込みを初期表示から分離する (#705)

### DIFF
--- a/backend/app/composition_root/chat.py
+++ b/backend/app/composition_root/chat.py
@@ -17,6 +17,7 @@ from app.infrastructure.tasks.task_gateway import CeleryEvaluationTaskGateway
 from app.use_cases.chat.export_history import ExportChatHistoryUseCase
 from app.use_cases.chat.get_analytics import GetChatAnalyticsUseCase
 from app.use_cases.chat.get_history import GetChatHistoryUseCase
+from app.use_cases.chat.get_keywords import GetChatKeywordsUseCase
 from app.use_cases.chat.reset_history import ResetChatHistoryUseCase
 from app.use_cases.chat.send_message import SendMessageUseCase
 from app.use_cases.chat.submit_feedback import SubmitFeedbackUseCase
@@ -67,6 +68,13 @@ def get_chat_history_use_case() -> GetChatHistoryUseCase:
 
 def get_chat_analytics_use_case() -> GetChatAnalyticsUseCase:
     return GetChatAnalyticsUseCase(
+        _new_chat_repository(),
+        _new_video_group_query_repository(),
+    )
+
+
+def get_chat_keywords_use_case() -> GetChatKeywordsUseCase:
+    return GetChatKeywordsUseCase(
         _new_chat_repository(),
         _new_video_group_query_repository(),
         _get_keyword_extractor(),

--- a/backend/app/dependencies/chat.py
+++ b/backend/app/dependencies/chat.py
@@ -22,5 +22,9 @@ def get_chat_analytics_use_case():
     return _cr.get_chat_analytics_use_case()
 
 
+def get_chat_keywords_use_case():
+    return _cr.get_chat_keywords_use_case()
+
+
 def get_reset_history_use_case():
     return _cr.get_reset_history_use_case()

--- a/backend/app/domain/chat/entities.py
+++ b/backend/app/domain/chat/entities.py
@@ -91,4 +91,3 @@ class ChatAnalyticsRaw:
     logs_for_scenes: List[ChatSceneLog]
     time_series: List[TimeSeriesPoint]
     feedback: FeedbackSummary
-    questions: List[str]

--- a/backend/app/domain/chat/repositories.py
+++ b/backend/app/domain/chat/repositories.py
@@ -68,6 +68,11 @@ class ChatRepository(ABC):
         ...
 
     @abstractmethod
+    def get_questions_for_group(self, group_id: int) -> List[str]:
+        """Return all question strings for a group (used for keyword extraction)."""
+        ...
+
+    @abstractmethod
     def delete_logs_for_group(self, group_id: int) -> None:
         """Delete all chat logs for the given group."""
         ...

--- a/backend/app/infrastructure/repositories/django_chat_repository.py
+++ b/backend/app/infrastructure/repositories/django_chat_repository.py
@@ -220,8 +220,6 @@ class DjangoChatRepository(ChatRepository):
             none=feedback_counts.get("none", 0) or 0,
         )
 
-        questions = list(qs.values_list("question", flat=True))
-
         return ChatAnalyticsRaw(
             total=total,
             first_date=first_date,
@@ -229,7 +227,11 @@ class DjangoChatRepository(ChatRepository):
             logs_for_scenes=logs_for_scenes,
             time_series=time_series,
             feedback=feedback,
-            questions=questions,
+        )
+
+    def get_questions_for_group(self, group_id: int) -> List[str]:
+        return list(
+            ChatLog.objects.filter(group_id=group_id).values_list("question", flat=True)
         )
 
 

--- a/backend/app/presentation/chat/serializers.py
+++ b/backend/app/presentation/chat/serializers.py
@@ -116,4 +116,7 @@ class ChatAnalyticsResponseSerializer(serializers.Serializer):
     scene_distribution = ChatAnalyticsSceneSerializer(many=True)
     time_series = ChatAnalyticsTimeSeriesSerializer(many=True)
     feedback = ChatAnalyticsFeedbackSerializer()
+
+
+class ChatAnalyticsKeywordsResponseSerializer(serializers.Serializer):
     keywords = ChatAnalyticsKeywordSerializer(many=True)

--- a/backend/app/presentation/chat/tests/test_new_urls.py
+++ b/backend/app/presentation/chat/tests/test_new_urls.py
@@ -200,6 +200,13 @@ class ChatGroupAnalyticsViewTests(APITestCase):
         self.assertIn("summary", response.data)
         self.assertIn("feedback", response.data)
 
+    def test_get_analytics_does_not_include_keywords(self):
+        """GET /api/chat/groups/{group_id}/analytics/ must NOT return keywords."""
+        url = reverse("chat-group-analytics", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("keywords", response.data)
+
     def test_get_analytics_nonexistent_group_returns_404(self):
         url = reverse("chat-group-analytics", kwargs={"group_id": 99999})
         response = self.client.get(url)
@@ -220,3 +227,74 @@ class ChatGroupAnalyticsViewTests(APITestCase):
         url = reverse("chat-group-analytics", kwargs={"group_id": self.group.id})
         response = client.get(url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class ChatGroupAnalyticsKeywordsViewTests(APITestCase):
+    """Tests for GET /api/chat/groups/{group_id}/analytics/keywords/"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="keywords_path_user",
+            email="keywords_path@example.com",
+            password="testpass123",
+        )
+        self.other_user = User.objects.create_user(
+            username="keywords_other_user",
+            email="keywords_other@example.com",
+            password="testpass123",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+            description="Test",
+            share_slug=secrets.token_urlsafe(32),
+        )
+
+    def test_get_keywords_returns_200_with_keywords_key(self):
+        """GET /api/chat/groups/{group_id}/analytics/keywords/ returns 200 with keywords."""
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("keywords", response.data)
+        self.assertIsInstance(response.data["keywords"], list)
+
+    def test_get_keywords_nonexistent_group_returns_404(self):
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": 99999})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_keywords_other_users_group_returns_404(self):
+        other_group = VideoGroup.objects.create(
+            user=self.other_user,
+            name="Other",
+            share_slug=secrets.token_urlsafe(32),
+        )
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": other_group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_keywords_unauthenticated_returns_401(self):
+        client = APIClient()
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": self.group.id})
+        response = client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_get_keywords_returns_word_and_count_fields(self):
+        """Each keyword item must have word and count fields."""
+        ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="What is machine learning?",
+            answer="A",
+            citations=[],
+            retrieved_contexts=[],
+        )
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        if response.data["keywords"]:
+            kw = response.data["keywords"][0]
+            self.assertIn("word", kw)
+            self.assertIn("count", kw)

--- a/backend/app/presentation/chat/urls.py
+++ b/backend/app/presentation/chat/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from app.dependencies import chat as chat_dependencies
 
 from .views import (
+    ChatGroupAnalyticsKeywordsView,
     ChatGroupAnalyticsView,
     ChatGroupHistoryView,
     ChatLogFeedbackView,
@@ -43,5 +44,12 @@ urlpatterns = [
             chat_analytics_use_case=chat_dependencies.get_chat_analytics_use_case
         ),
         name="chat-group-analytics",
+    ),
+    path(
+        "groups/<int:group_id>/analytics/keywords/",
+        ChatGroupAnalyticsKeywordsView.as_view(
+            chat_keywords_use_case=chat_dependencies.get_chat_keywords_use_case
+        ),
+        name="chat-group-analytics-keywords",
     ),
 ]

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -43,6 +43,7 @@ from django.http import HttpResponse, StreamingHttpResponse
 
 from .exporters import write_chat_history_csv
 from .serializers import (
+    ChatAnalyticsKeywordsResponseSerializer,
     ChatAnalyticsResponseSerializer,
     ChatFeedbackRequestSerializer,
     ChatFeedbackResponseSerializer,
@@ -322,9 +323,32 @@ class ChatGroupAnalyticsView(DependencyResolverMixin, APIView):
                 "bad": dto.feedback.bad,
                 "none": dto.feedback.none,
             },
+        })
+
+
+class ChatGroupAnalyticsKeywordsView(DependencyResolverMixin, APIView):
+    """Keyword extraction for a chat group's analytics (group_id in URL path)."""
+
+    authentication_classes = [APIKeyAuthentication, CookieJWTAuthentication]
+    permission_classes = [IsAuthenticated, ApiKeyScopePermission]
+    chat_keywords_use_case = None
+
+    @extend_schema(
+        responses={200: ChatAnalyticsKeywordsResponseSerializer},
+        summary="Get chat analytics keywords",
+        description="Return keyword frequency data for a chat group's questions.",
+    )
+    def get(self, request, group_id):
+        use_case = self.resolve_dependency(self.chat_keywords_use_case)
+        try:
+            keywords = use_case.execute(group_id=group_id, user_id=request.user.id)
+        except ResourceNotFound as e:
+            return create_error_response(str(e), status.HTTP_404_NOT_FOUND)
+
+        return Response({
             "keywords": [
                 {"word": item.word, "count": item.count}
-                for item in dto.keywords
+                for item in keywords
             ],
         })
 

--- a/backend/app/use_cases/chat/dto.py
+++ b/backend/app/use_cases/chat/dto.py
@@ -95,7 +95,6 @@ class ChatAnalyticsDTO:
     scene_distribution: List[SceneDistributionItemDTO]
     time_series: List["TimeSeriesPointDTO"]
     feedback: "FeedbackSummaryDTO"
-    keywords: List["KeywordCountDTO"]
 
 
 @dataclass(frozen=True)

--- a/backend/app/use_cases/chat/get_analytics.py
+++ b/backend/app/use_cases/chat/get_analytics.py
@@ -2,7 +2,6 @@
 Use case: Build analytics dashboard data for a chat group.
 """
 
-from app.domain.chat.ports import KeywordExtractor
 from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
 from app.domain.chat.services import (
     GroupContextNotFound as _DomainGroupContextNotFound,
@@ -15,7 +14,6 @@ from app.use_cases.chat.dto import (
     ChatAnalyticsDTO,
     DateRangeDTO,
     FeedbackSummaryDTO,
-    KeywordCountDTO,
     SceneDistributionItemDTO,
     TimeSeriesPointDTO,
 )
@@ -23,22 +21,20 @@ from app.use_cases.shared.exceptions import ResourceNotFound
 
 
 class GetChatAnalyticsUseCase:
-    """Aggregate chat analytics: summary, scene distribution, time series, feedback, keywords."""
+    """Aggregate chat analytics: summary, scene distribution, time series, feedback."""
 
     def __init__(
         self,
         chat_repo: ChatRepository,
         group_query_repo: VideoGroupQueryRepository,
-        keyword_extractor: KeywordExtractor,
     ):
         self.chat_repo = chat_repo
         self.group_query_repo = group_query_repo
-        self.keyword_extractor = keyword_extractor
 
     def execute(self, group_id: int, user_id: int) -> ChatAnalyticsDTO:
         """
         Returns:
-            ChatAnalyticsDTO with summary, scene_distribution, time_series, feedback, keywords.
+            ChatAnalyticsDTO with summary, scene_distribution, time_series, feedback.
 
         Raises:
             ResourceNotFound: If the group does not exist.
@@ -71,8 +67,6 @@ class GetChatAnalyticsUseCase:
             for key, count in top_scenes
         ]
 
-        keywords = self.keyword_extractor.extract(raw.questions)
-
         return ChatAnalyticsDTO(
             total_questions=raw.total,
             date_range=date_range,
@@ -86,8 +80,4 @@ class GetChatAnalyticsUseCase:
                 bad=raw.feedback.bad,
                 none=raw.feedback.none,
             ),
-            keywords=[
-                KeywordCountDTO(word=item.word, count=item.count)
-                for item in keywords
-            ],
         )

--- a/backend/app/use_cases/chat/get_keywords.py
+++ b/backend/app/use_cases/chat/get_keywords.py
@@ -1,0 +1,51 @@
+"""
+Use case: Extract keywords from chat questions for a group.
+"""
+
+from typing import List
+
+from app.domain.chat.ports import KeywordExtractor
+from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
+from app.domain.chat.services import (
+    GroupContextNotFound as _DomainGroupContextNotFound,
+    require_group_context,
+)
+from app.use_cases.chat.dto import KeywordCountDTO
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+
+class GetChatKeywordsUseCase:
+    """Extract top keywords from chat questions for a group."""
+
+    def __init__(
+        self,
+        chat_repo: ChatRepository,
+        group_query_repo: VideoGroupQueryRepository,
+        keyword_extractor: KeywordExtractor,
+    ):
+        self.chat_repo = chat_repo
+        self.group_query_repo = group_query_repo
+        self.keyword_extractor = keyword_extractor
+
+    def execute(self, group_id: int, user_id: int) -> List[KeywordCountDTO]:
+        """
+        Returns:
+            List of KeywordCountDTO sorted by frequency.
+
+        Raises:
+            ResourceNotFound: If the group does not exist.
+        """
+        try:
+            require_group_context(
+                self.group_query_repo.get_with_members(group_id=group_id, user_id=user_id)
+            )
+        except _DomainGroupContextNotFound:
+            raise ResourceNotFound("Group")
+
+        raw = self.chat_repo.get_analytics_raw(group_id)
+        keywords = self.keyword_extractor.extract(raw.questions)
+
+        return [
+            KeywordCountDTO(word=item.word, count=item.count)
+            for item in keywords
+        ]

--- a/backend/app/use_cases/chat/get_keywords.py
+++ b/backend/app/use_cases/chat/get_keywords.py
@@ -42,8 +42,8 @@ class GetChatKeywordsUseCase:
         except _DomainGroupContextNotFound:
             raise ResourceNotFound("Group")
 
-        raw = self.chat_repo.get_analytics_raw(group_id)
-        keywords = self.keyword_extractor.extract(raw.questions)
+        questions = self.chat_repo.get_questions_for_group(group_id)
+        keywords = self.keyword_extractor.extract(questions)
 
         return [
             KeywordCountDTO(word=item.word, count=item.count)

--- a/backend/app/use_cases/chat/tests/test_get_history.py
+++ b/backend/app/use_cases/chat/tests/test_get_history.py
@@ -32,6 +32,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id: int):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         raise NotImplementedError
 

--- a/backend/app/use_cases/chat/tests/test_get_keywords.py
+++ b/backend/app/use_cases/chat/tests/test_get_keywords.py
@@ -1,0 +1,121 @@
+"""Tests for GetChatKeywordsUseCase."""
+
+import unittest
+from typing import List
+
+from app.domain.chat.entities import VideoGroupContextEntity, ChatAnalyticsRaw
+from app.domain.chat.ports import KeywordExtractor
+from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
+from app.domain.chat.value_objects import KeywordCount
+from app.use_cases.chat.get_keywords import GetChatKeywordsUseCase
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+
+class _StubChatRepository(ChatRepository):
+    def __init__(self, questions=None):
+        self._questions = questions or []
+
+    def get_analytics_raw(self, group_id: int):
+        raw = ChatAnalyticsRaw.__new__(ChatAnalyticsRaw)
+        raw.total = 0
+        raw.first_date = None
+        raw.last_date = None
+        raw.logs_for_scenes = []
+        raw.time_series = []
+        raw.feedback = None
+        raw.questions = self._questions
+        return raw
+
+    def get_logs_for_group(self, group_id, ascending=True):
+        raise NotImplementedError
+
+    def create_log(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_log_by_id(self, log_id):
+        raise NotImplementedError
+
+    def update_feedback(self, log, feedback):
+        raise NotImplementedError
+
+    def get_logs_values_for_group(self, group_id):
+        raise NotImplementedError
+
+    def delete_logs_for_group(self, group_id):
+        raise NotImplementedError
+
+
+class _StubGroupRepository(VideoGroupQueryRepository):
+    def __init__(self, group):
+        self._group = group
+
+    def get_with_members(self, group_id, user_id=None, share_token=None):
+        return self._group
+
+
+class _StubKeywordExtractor(KeywordExtractor):
+    def __init__(self, result: List[KeywordCount]):
+        self._result = result
+
+    def extract(self, questions: List[str], limit: int = 30) -> List[KeywordCount]:
+        return self._result
+
+
+class GetChatKeywordsUseCaseTests(unittest.TestCase):
+    def _make_group(self):
+        return VideoGroupContextEntity(id=1, user_id=42, name="g1")
+
+    def test_execute_returns_keyword_count_dto_list(self):
+        keywords = [KeywordCount(word="python", count=5), KeywordCount(word="flask", count=3)]
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=_StubChatRepository(questions=["What is python?"]),
+            group_query_repo=_StubGroupRepository(self._make_group()),
+            keyword_extractor=_StubKeywordExtractor(keywords),
+        )
+
+        result = use_case.execute(group_id=1, user_id=42)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].word, "python")
+        self.assertEqual(result[0].count, 5)
+        self.assertEqual(result[1].word, "flask")
+        self.assertEqual(result[1].count, 3)
+
+    def test_execute_raises_when_group_not_found(self):
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=_StubChatRepository(),
+            group_query_repo=_StubGroupRepository(None),
+            keyword_extractor=_StubKeywordExtractor([]),
+        )
+
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(group_id=999, user_id=42)
+
+    def test_execute_returns_empty_list_when_no_questions(self):
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=_StubChatRepository(questions=[]),
+            group_query_repo=_StubGroupRepository(self._make_group()),
+            keyword_extractor=_StubKeywordExtractor([]),
+        )
+
+        result = use_case.execute(group_id=1, user_id=42)
+
+        self.assertEqual(result, [])
+
+    def test_keyword_extractor_receives_questions_from_raw(self):
+        received = []
+
+        class _CapturingExtractor(KeywordExtractor):
+            def extract(self, questions, limit=30):
+                received.extend(questions)
+                return []
+
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=_StubChatRepository(questions=["q1", "q2"]),
+            group_query_repo=_StubGroupRepository(self._make_group()),
+            keyword_extractor=_CapturingExtractor(),
+        )
+
+        use_case.execute(group_id=1, user_id=42)
+
+        self.assertEqual(received, ["q1", "q2"])

--- a/backend/app/use_cases/chat/tests/test_get_keywords.py
+++ b/backend/app/use_cases/chat/tests/test_get_keywords.py
@@ -3,7 +3,7 @@
 import unittest
 from typing import List
 
-from app.domain.chat.entities import VideoGroupContextEntity, ChatAnalyticsRaw
+from app.domain.chat.entities import VideoGroupContextEntity
 from app.domain.chat.ports import KeywordExtractor
 from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
 from app.domain.chat.value_objects import KeywordCount
@@ -15,16 +15,11 @@ class _StubChatRepository(ChatRepository):
     def __init__(self, questions=None):
         self._questions = questions or []
 
+    def get_questions_for_group(self, group_id: int) -> List[str]:
+        return self._questions
+
     def get_analytics_raw(self, group_id: int):
-        raw = ChatAnalyticsRaw.__new__(ChatAnalyticsRaw)
-        raw.total = 0
-        raw.first_date = None
-        raw.last_date = None
-        raw.logs_for_scenes = []
-        raw.time_series = []
-        raw.feedback = None
-        raw.questions = self._questions
-        return raw
+        raise NotImplementedError
 
     def get_logs_for_group(self, group_id, ascending=True):
         raise NotImplementedError
@@ -102,7 +97,7 @@ class GetChatKeywordsUseCaseTests(unittest.TestCase):
 
         self.assertEqual(result, [])
 
-    def test_keyword_extractor_receives_questions_from_raw(self):
+    def test_keyword_extractor_receives_questions_from_repository(self):
         received = []
 
         class _CapturingExtractor(KeywordExtractor):
@@ -119,3 +114,23 @@ class GetChatKeywordsUseCaseTests(unittest.TestCase):
         use_case.execute(group_id=1, user_id=42)
 
         self.assertEqual(received, ["q1", "q2"])
+
+    def test_get_analytics_raw_is_not_called(self):
+        """get_questions_for_group must be used; get_analytics_raw must NOT be called."""
+        class _TrackingRepo(_StubChatRepository):
+            analytics_raw_called = False
+
+            def get_analytics_raw(self, group_id):
+                self.__class__.analytics_raw_called = True
+                raise AssertionError("get_analytics_raw should not be called")
+
+        repo = _TrackingRepo(questions=["q"])
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=repo,
+            group_query_repo=_StubGroupRepository(self._make_group()),
+            keyword_extractor=_StubKeywordExtractor([]),
+        )
+
+        use_case.execute(group_id=1, user_id=42)
+
+        self.assertFalse(_TrackingRepo.analytics_raw_called)

--- a/backend/app/use_cases/chat/tests/test_reset_history.py
+++ b/backend/app/use_cases/chat/tests/test_reset_history.py
@@ -31,6 +31,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id: int):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         self.deleted_group_ids.append(group_id)
 

--- a/backend/app/use_cases/chat/tests/test_send_message.py
+++ b/backend/app/use_cases/chat/tests/test_send_message.py
@@ -31,6 +31,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id: int):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         raise NotImplementedError
 

--- a/backend/app/use_cases/chat/tests/test_stream_message.py
+++ b/backend/app/use_cases/chat/tests/test_stream_message.py
@@ -31,6 +31,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         raise NotImplementedError
 

--- a/backend/app/use_cases/chat/tests/test_submit_feedback.py
+++ b/backend/app/use_cases/chat/tests/test_submit_feedback.py
@@ -38,6 +38,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id: int):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         raise NotImplementedError
 

--- a/frontend/src/components/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/components/dashboard/AnalyticsDashboard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import type { ChatAnalytics, EvaluationSummary } from '@/lib/api';
+import type { ChatAnalytics, ChatAnalyticsKeywords, EvaluationSummary } from '@/lib/api';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { DashboardEmptyState } from './DashboardEmptyState';
 import { QuestionTimeSeriesChart } from './QuestionTimeSeriesChart';
@@ -12,6 +12,8 @@ interface AnalyticsDashboardProps {
   evaluationSummary?: EvaluationSummary;
   isLoading: boolean;
   isEvaluationLoading?: boolean;
+  keywordsData?: ChatAnalyticsKeywords;
+  isKeywordsLoading?: boolean;
 }
 
 export function AnalyticsDashboard({
@@ -19,6 +21,8 @@ export function AnalyticsDashboard({
   evaluationSummary,
   isLoading,
   isEvaluationLoading = false,
+  keywordsData,
+  isKeywordsLoading = false,
 }: AnalyticsDashboardProps) {
   const { t } = useTranslation();
 
@@ -66,9 +70,15 @@ export function AnalyticsDashboard({
           />
         </div>
 
-        {data.keywords.length > 0 && (
+        {isKeywordsLoading && (
+          <div className="bg-white border border-gray-200 rounded-lg p-4 flex justify-center items-center" data-testid="keywords-loading">
+            <LoadingSpinner />
+          </div>
+        )}
+
+        {!isKeywordsLoading && keywordsData && keywordsData.keywords.length > 0 && (
           <div className="bg-white border border-gray-200 rounded-lg p-4">
-            <KeywordCloudChart data={data.keywords} />
+            <KeywordCloudChart data={keywordsData.keywords} />
           </div>
         )}
       </div>

--- a/frontend/src/components/dashboard/DashboardButton.tsx
+++ b/frontend/src/components/dashboard/DashboardButton.tsx
@@ -4,6 +4,7 @@ import { BarChart3 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useChatAnalytics } from '@/hooks/useChatAnalytics';
+import { useChatKeywords } from '@/hooks/useChatKeywords';
 import { useEvaluationSummary } from '@/hooks/useEvaluationSummary';
 import { AnalyticsDashboard } from './AnalyticsDashboard';
 
@@ -20,6 +21,10 @@ export function DashboardButton({ groupId, size = 'default' }: DashboardButtonPr
     data: evaluationSummary,
     isLoading: isEvaluationLoading,
   } = useEvaluationSummary(groupId, isOpen);
+  const {
+    data: keywordsData,
+    isLoading: isKeywordsLoading,
+  } = useChatKeywords(groupId, isOpen);
 
   return (
     <>
@@ -43,6 +48,8 @@ export function DashboardButton({ groupId, size = 'default' }: DashboardButtonPr
             evaluationSummary={evaluationSummary}
             isLoading={isLoading}
             isEvaluationLoading={isEvaluationLoading}
+            keywordsData={keywordsData}
+            isKeywordsLoading={isKeywordsLoading}
           />
         </DialogContent>
       </Dialog>

--- a/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import { AnalyticsDashboard } from '../AnalyticsDashboard'
-import type { ChatAnalytics, EvaluationSummary } from '@/lib/api'
+import type { ChatAnalytics, ChatAnalyticsKeywords, EvaluationSummary } from '@/lib/api'
+
+vi.mock('../KeywordCloudChart', () => ({
+  KeywordCloudChart: ({ data }: { data: { word: string; count: number }[] }) => (
+    <div data-testid="keyword-cloud">
+      {data.map((kw) => (
+        <span key={kw.word}>{kw.word}</span>
+      ))}
+    </div>
+  ),
+}))
 
 const analytics: ChatAnalytics = {
   summary: {
@@ -18,7 +28,6 @@ const analytics: ChatAnalytics = {
   ],
   time_series: [],
   feedback: { good: 1, bad: 0, none: 23 },
-  keywords: [],
 }
 
 const evaluationSummary: EvaluationSummary = {
@@ -27,6 +36,13 @@ const evaluationSummary: EvaluationSummary = {
   avg_faithfulness: 0.86,
   avg_answer_relevancy: 0.81,
   avg_context_precision: 0.78,
+}
+
+const keywordsData: ChatAnalyticsKeywords = {
+  keywords: [
+    { word: 'machine learning', count: 5 },
+    { word: 'python', count: 3 },
+  ],
 }
 
 describe('AnalyticsDashboard', () => {
@@ -59,5 +75,54 @@ describe('AnalyticsDashboard', () => {
     )
 
     expect(screen.getByText('dashboard.evaluation.empty')).toBeInTheDocument()
+  })
+
+  it('renders keyword cloud when keywords data is provided', () => {
+    render(
+      <AnalyticsDashboard
+        data={analytics}
+        evaluationSummary={evaluationSummary}
+        isLoading={false}
+        isEvaluationLoading={false}
+        keywordsData={keywordsData}
+        isKeywordsLoading={false}
+      />,
+    )
+
+    expect(screen.getByText('machine learning')).toBeInTheDocument()
+  })
+
+  it('shows keywords loading spinner independently when keywords are loading', () => {
+    render(
+      <AnalyticsDashboard
+        data={analytics}
+        evaluationSummary={evaluationSummary}
+        isLoading={false}
+        isEvaluationLoading={false}
+        isKeywordsLoading={true}
+      />,
+    )
+
+    // Main dashboard content should still be visible
+    expect(screen.getByText(/dashboard\.totalQuestions/)).toBeInTheDocument()
+    // Keywords spinner should appear inside keywords card area
+    expect(screen.getByTestId('keywords-loading')).toBeInTheDocument()
+  })
+
+  it('does not render keywords section when keywords data is undefined and not loading', () => {
+    render(
+      <AnalyticsDashboard
+        data={analytics}
+        evaluationSummary={evaluationSummary}
+        isLoading={false}
+        isEvaluationLoading={false}
+        isKeywordsLoading={false}
+      />,
+    )
+
+    // Main dashboard should be shown regardless
+    expect(screen.getByText(/dashboard\.totalQuestions/)).toBeInTheDocument()
+    // No keyword cloud when data is absent and not loading
+    expect(screen.queryByTestId('keywords-loading')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/hooks/useChatKeywords.ts
+++ b/frontend/src/hooks/useChatKeywords.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient, type ChatAnalyticsKeywords } from '@/lib/api';
+import { queryKeys } from '@/lib/queryKeys';
+
+export function useChatKeywords(groupId: number | null, enabled = true) {
+  return useQuery<ChatAnalyticsKeywords>({
+    queryKey: queryKeys.chat.keywords(groupId!),
+    queryFn: () => apiClient.getChatKeywords(groupId!),
+    enabled: enabled && groupId != null,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -143,6 +143,9 @@ export interface ChatAnalytics {
   }[];
   time_series: { date: string; count: number }[];
   feedback: { good: number; bad: number; none: number };
+}
+
+export interface ChatAnalyticsKeywords {
   keywords: { word: string; count: number }[];
 }
 
@@ -1168,6 +1171,10 @@ class ApiClient {
 
   async getChatAnalytics(groupId: number): Promise<ChatAnalytics> {
     return this.request<ChatAnalytics>(`/chat/groups/${groupId}/analytics/`);
+  }
+
+  async getChatKeywords(groupId: number): Promise<ChatAnalyticsKeywords> {
+    return this.request<ChatAnalyticsKeywords>(`/chat/groups/${groupId}/analytics/keywords/`);
   }
 
 }

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -29,6 +29,7 @@ export const queryKeys = {
   chat: {
     history: (groupId: number | null, shareToken?: string) => ['chatHistory', groupId, shareToken ?? null] as const,
     analytics: (groupId: number) => ['chatAnalytics', groupId] as const,
+    keywords: (groupId: number) => ['chatAnalyticsKeywords', groupId] as const,
     evaluations: (groupId: number | null) => ['chatEvaluations', groupId] as const,
     evaluationSummary: (groupId: number | null) => ['evaluationSummary', groupId] as const,
   },


### PR DESCRIPTION
## Summary

closes #705

- `GET /api/chat/groups/{id}/analytics/` から keyword extraction を除去し、初期表示が Janome/NLTK の初期化待ちをしなくなった
- `GET /api/chat/groups/{id}/analytics/keywords/` を新設し、keywords を独立したリクエストで遅延取得できるようにした
- フロントエンドで `useChatKeywords` hook を追加し、`useChatAnalytics` とは独立した React Query で取得。`AnalyticsDashboard` の keywords loading がダッシュボード本体の表示をブロックしない構造にした

## Changes

### Backend
- `GetChatKeywordsUseCase` 新規作成（`use_cases/chat/get_keywords.py`）
- `GetChatAnalyticsUseCase` から `keyword_extractor` 依存と keywords 集計を除去
- `ChatAnalyticsDTO` から `keywords` フィールドを削除
- `ChatGroupAnalyticsKeywordsView` 追加（`GET groups/<id>/analytics/keywords/`）
- `ChatAnalyticsResponseSerializer` から `keywords` を除去、`ChatAnalyticsKeywordsResponseSerializer` を新設

### Frontend
- `ChatAnalytics` 型から `keywords` を除去、`ChatAnalyticsKeywords` 型を新設
- `apiClient.getChatKeywords()` メソッド追加
- `queryKeys.chat.keywords(groupId)` 追加
- `useChatKeywords` hook 新規作成
- `AnalyticsDashboard`: `keywordsData` / `isKeywordsLoading` props を追加し、keywords の spinner を本体 loading と独立して表示
- `DashboardButton`: `useChatKeywords` を呼び出して props に渡すよう更新

## Performance (ローカル実測: group_id=18, ChatLog 75件)

| | 変更前 (analytics 全体) | 変更後 /analytics/ | 変更後 /analytics/keywords/ |
|---|---:|---:|---:|
| cold (初回) | 579 ms | **13 ms** | 566 ms |
| warm (平均) | 17 ms | **5 ms** | 12 ms |

初期表示に必要な `/analytics/` の初回コストが **579 ms → 13 ms** に短縮。
keywords は独立して非同期取得されるためダッシュボード本体の表示をブロックしない。

## Test plan

- [x] `GetChatKeywordsUseCaseTests` — ユースケース単体テスト (4件)
- [x] `ChatGroupAnalyticsKeywordsViewTests` — 新エンドポイント 200/404/401 (5件)
- [x] `test_get_analytics_does_not_include_keywords` — `/analytics/` が `keywords` を含まないことを確認
- [x] `AnalyticsDashboard` — `keywordsData` 表示・`isKeywordsLoading` 独立 spinner・未ロード時の非表示 (3件追加)
- [x] バックエンド全テスト: 1099件 (既存の無関係な失敗2件を除き全 PASS)
- [x] フロントエンド全テスト: 533件 全 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)