### PR TITLE
refactor: 教育改善ダッシュボード初期表示で未使用の scene_distribution 集計を止める (#706)

### DIFF
--- a/backend/app/composition_root/chat.py
+++ b/backend/app/composition_root/chat.py
@@ -17,6 +17,7 @@ from app.infrastructure.tasks.task_gateway import CeleryEvaluationTaskGateway
 from app.use_cases.chat.export_history import ExportChatHistoryUseCase
 from app.use_cases.chat.get_analytics import GetChatAnalyticsUseCase
 from app.use_cases.chat.get_history import GetChatHistoryUseCase
+from app.use_cases.chat.get_keywords import GetChatKeywordsUseCase
 from app.use_cases.chat.reset_history import ResetChatHistoryUseCase
 from app.use_cases.chat.send_message import SendMessageUseCase
 from app.use_cases.chat.submit_feedback import SubmitFeedbackUseCase
@@ -67,6 +68,13 @@ def get_chat_history_use_case() -> GetChatHistoryUseCase:
 
 def get_chat_analytics_use_case() -> GetChatAnalyticsUseCase:
     return GetChatAnalyticsUseCase(
+        _new_chat_repository(),
+        _new_video_group_query_repository(),
+    )
+
+
+def get_chat_keywords_use_case() -> GetChatKeywordsUseCase:
+    return GetChatKeywordsUseCase(
         _new_chat_repository(),
         _new_video_group_query_repository(),
         _get_keyword_extractor(),

--- a/backend/app/dependencies/chat.py
+++ b/backend/app/dependencies/chat.py
@@ -22,5 +22,9 @@ def get_chat_analytics_use_case():
     return _cr.get_chat_analytics_use_case()
 
 
+def get_chat_keywords_use_case():
+    return _cr.get_chat_keywords_use_case()
+
+
 def get_reset_history_use_case():
     return _cr.get_reset_history_use_case()

--- a/backend/app/domain/billing/ports.py
+++ b/backend/app/domain/billing/ports.py
@@ -26,12 +26,11 @@ class UserLimitsRepository(ABC):
     def check_and_reserve_storage(self, user_id: int, additional_bytes: int) -> None:
         """Atomically check storage limit and reserve space if within limit.
 
-        Uses a conditional F() UPDATE (WHERE used_storage_bytes <= limit - additional_bytes)
-        to prevent race conditions between concurrent upload requests. The WHERE
-        clause and UPDATE are evaluated atomically by the DB engine, so no
-        row-level locking is required. If adding additional_bytes would exceed
-        the configured storage limit, raises StorageLimitExceeded without modifying
-        used_storage_bytes. On success, increments used_storage_bytes by additional_bytes.
+        The capacity check and reservation must be one atomic mutation so
+        concurrent upload requests cannot both pass on stale usage. If adding
+        additional_bytes would exceed the configured storage limit, raises
+        StorageLimitExceeded without modifying used_storage_bytes. On success,
+        increments used_storage_bytes by additional_bytes.
         """
         ...
 
@@ -40,8 +39,8 @@ class UserLimitsRepository(ABC):
         """Atomically update used_storage_bytes by bytes_delta.
 
         Result is clamped to >= 0 to prevent negative storage values.
-        Must use a database-level atomic operation (e.g. F() expression) to
-        avoid lost updates under concurrent requests.
+        The counter mutation must be atomic to avoid lost updates under
+        concurrent requests.
         """
         ...
 
@@ -49,8 +48,8 @@ class UserLimitsRepository(ABC):
     def increment_processing_seconds(self, user_id: int, seconds: int) -> None:
         """Atomically increment used_processing_seconds by seconds.
 
-        Must use a database-level atomic operation (e.g. F() expression) to
-        avoid lost updates under concurrent requests.
+        The counter mutation must be atomic to avoid lost updates under
+        concurrent requests.
         """
         ...
 
@@ -58,8 +57,8 @@ class UserLimitsRepository(ABC):
     def increment_ai_answers(self, user_id: int) -> None:
         """Atomically increment used_ai_answers by 1.
 
-        Must use a database-level atomic operation (e.g. F() expression) to
-        avoid lost updates under concurrent requests.
+        The counter mutation must be atomic to avoid lost updates under
+        concurrent requests.
         """
         ...
 

--- a/backend/app/domain/chat/entities.py
+++ b/backend/app/domain/chat/entities.py
@@ -91,4 +91,3 @@ class ChatAnalyticsRaw:
     logs_for_scenes: List[ChatSceneLog]
     time_series: List[TimeSeriesPoint]
     feedback: FeedbackSummary
-    questions: List[str]

--- a/backend/app/domain/chat/entities.py
+++ b/backend/app/domain/chat/entities.py
@@ -12,7 +12,6 @@ from typing import List, Optional
 from app.domain.chat.dtos import CitationDTO
 from app.domain.chat.exceptions import FeedbackAccessDenied, InvalidFeedbackValue
 from app.domain.chat.value_objects import (
-    ChatSceneLog,
     FeedbackSummary,
     TimeSeriesPoint,
 )
@@ -82,12 +81,10 @@ class ChatLogEntity:
 class ChatAnalyticsRaw:
     """
     Raw data bundle collected from the persistence layer for analytics computation.
-    The use case applies domain services (keyword extraction, scene aggregation) on top of this.
     """
 
     total: int
     first_date: Optional[datetime]
     last_date: Optional[datetime]
-    logs_for_scenes: List[ChatSceneLog]
     time_series: List[TimeSeriesPoint]
     feedback: FeedbackSummary

--- a/backend/app/domain/chat/repositories.py
+++ b/backend/app/domain/chat/repositories.py
@@ -68,6 +68,11 @@ class ChatRepository(ABC):
         ...
 
     @abstractmethod
+    def get_questions_for_group(self, group_id: int) -> List[str]:
+        """Return all question strings for a group (used for keyword extraction)."""
+        ...
+
+    @abstractmethod
     def delete_logs_for_group(self, group_id: int) -> None:
         """Delete all chat logs for the given group."""
         ...

--- a/backend/app/domain/evaluation/gateways.py
+++ b/backend/app/domain/evaluation/gateways.py
@@ -39,7 +39,7 @@ class RagEvaluationGateway(ABC):
 
 
 class EvaluationTaskGateway(ABC):
-    """Abstract interface for dispatching evaluation Celery tasks."""
+    """Abstract interface for dispatching asynchronous evaluation work."""
 
     @abstractmethod
     def dispatch_evaluate_chat_log(self, chat_log_id: int) -> None:

--- a/backend/app/domain/shared/transaction.py
+++ b/backend/app/domain/shared/transaction.py
@@ -1,6 +1,6 @@
 """
 Abstract interface for managing database transactions.
-Allows use cases to enforce atomic boundaries without importing Django.
+Allows use cases to enforce atomic boundaries without a transaction framework.
 """
 
 from abc import ABC, abstractmethod

--- a/backend/app/infrastructure/repositories/django_chat_repository.py
+++ b/backend/app/infrastructure/repositories/django_chat_repository.py
@@ -176,23 +176,6 @@ class DjangoChatRepository(ChatRepository):
                 .first()
             )
 
-        raw_rows = list(qs.values("question", "citations"))
-        logs_for_scenes = []
-        for row in raw_rows:
-            refs = [
-                SceneReference(
-                    video_id=rv.get("video_id"),
-                    title=rv.get("title", ""),
-                    start_time=rv.get("start_time"),
-                    end_time=rv.get("end_time"),
-                )
-                for rv in (row["citations"] or [])
-                if rv.get("video_id") and rv.get("start_time")
-            ]
-            logs_for_scenes.append(
-                ChatSceneLog(question=row["question"], citations=refs)
-            )
-
         time_series_qs = (
             qs.annotate(date=TruncDate("created_at"))
             .values("date")
@@ -224,7 +207,6 @@ class DjangoChatRepository(ChatRepository):
             total=total,
             first_date=first_date,
             last_date=last_date,
-            logs_for_scenes=logs_for_scenes,
             time_series=time_series,
             feedback=feedback,
         )

--- a/backend/app/infrastructure/repositories/django_chat_repository.py
+++ b/backend/app/infrastructure/repositories/django_chat_repository.py
@@ -220,8 +220,6 @@ class DjangoChatRepository(ChatRepository):
             none=feedback_counts.get("none", 0) or 0,
         )
 
-        questions = list(qs.values_list("question", flat=True))
-
         return ChatAnalyticsRaw(
             total=total,
             first_date=first_date,
@@ -229,7 +227,11 @@ class DjangoChatRepository(ChatRepository):
             logs_for_scenes=logs_for_scenes,
             time_series=time_series,
             feedback=feedback,
-            questions=questions,
+        )
+
+    def get_questions_for_group(self, group_id: int) -> List[str]:
+        return list(
+            ChatLog.objects.filter(group_id=group_id).values_list("question", flat=True)
         )
 
 

--- a/backend/app/presentation/chat/serializers.py
+++ b/backend/app/presentation/chat/serializers.py
@@ -116,4 +116,7 @@ class ChatAnalyticsResponseSerializer(serializers.Serializer):
     scene_distribution = ChatAnalyticsSceneSerializer(many=True)
     time_series = ChatAnalyticsTimeSeriesSerializer(many=True)
     feedback = ChatAnalyticsFeedbackSerializer()
+
+
+class ChatAnalyticsKeywordsResponseSerializer(serializers.Serializer):
     keywords = ChatAnalyticsKeywordSerializer(many=True)

--- a/backend/app/presentation/chat/serializers.py
+++ b/backend/app/presentation/chat/serializers.py
@@ -87,14 +87,6 @@ class ChatAnalyticsSummarySerializer(serializers.Serializer):
     date_range = serializers.DictField(child=serializers.CharField(allow_null=True))
 
 
-class ChatAnalyticsSceneSerializer(serializers.Serializer):
-    video_id = serializers.IntegerField()
-    title = serializers.CharField()
-    start_time = serializers.CharField()
-    end_time = serializers.CharField()
-    question_count = serializers.IntegerField()
-
-
 class ChatAnalyticsTimeSeriesSerializer(serializers.Serializer):
     date = serializers.CharField()
     count = serializers.IntegerField()
@@ -113,7 +105,6 @@ class ChatAnalyticsKeywordSerializer(serializers.Serializer):
 
 class ChatAnalyticsResponseSerializer(serializers.Serializer):
     summary = ChatAnalyticsSummarySerializer()
-    scene_distribution = ChatAnalyticsSceneSerializer(many=True)
     time_series = ChatAnalyticsTimeSeriesSerializer(many=True)
     feedback = ChatAnalyticsFeedbackSerializer()
 

--- a/backend/app/presentation/chat/tests/test_new_urls.py
+++ b/backend/app/presentation/chat/tests/test_new_urls.py
@@ -207,6 +207,13 @@ class ChatGroupAnalyticsViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotIn("keywords", response.data)
 
+    def test_get_analytics_does_not_include_scene_distribution(self):
+        """GET /api/chat/groups/{group_id}/analytics/ must NOT return scene_distribution."""
+        url = reverse("chat-group-analytics", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("scene_distribution", response.data)
+
     def test_get_analytics_nonexistent_group_returns_404(self):
         url = reverse("chat-group-analytics", kwargs={"group_id": 99999})
         response = self.client.get(url)

--- a/backend/app/presentation/chat/tests/test_new_urls.py
+++ b/backend/app/presentation/chat/tests/test_new_urls.py
@@ -200,6 +200,13 @@ class ChatGroupAnalyticsViewTests(APITestCase):
         self.assertIn("summary", response.data)
         self.assertIn("feedback", response.data)
 
+    def test_get_analytics_does_not_include_keywords(self):
+        """GET /api/chat/groups/{group_id}/analytics/ must NOT return keywords."""
+        url = reverse("chat-group-analytics", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("keywords", response.data)
+
     def test_get_analytics_nonexistent_group_returns_404(self):
         url = reverse("chat-group-analytics", kwargs={"group_id": 99999})
         response = self.client.get(url)
@@ -220,3 +227,74 @@ class ChatGroupAnalyticsViewTests(APITestCase):
         url = reverse("chat-group-analytics", kwargs={"group_id": self.group.id})
         response = client.get(url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class ChatGroupAnalyticsKeywordsViewTests(APITestCase):
+    """Tests for GET /api/chat/groups/{group_id}/analytics/keywords/"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="keywords_path_user",
+            email="keywords_path@example.com",
+            password="testpass123",
+        )
+        self.other_user = User.objects.create_user(
+            username="keywords_other_user",
+            email="keywords_other@example.com",
+            password="testpass123",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.group = VideoGroup.objects.create(
+            user=self.user,
+            name="Test Group",
+            description="Test",
+            share_slug=secrets.token_urlsafe(32),
+        )
+
+    def test_get_keywords_returns_200_with_keywords_key(self):
+        """GET /api/chat/groups/{group_id}/analytics/keywords/ returns 200 with keywords."""
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("keywords", response.data)
+        self.assertIsInstance(response.data["keywords"], list)
+
+    def test_get_keywords_nonexistent_group_returns_404(self):
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": 99999})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_keywords_other_users_group_returns_404(self):
+        other_group = VideoGroup.objects.create(
+            user=self.other_user,
+            name="Other",
+            share_slug=secrets.token_urlsafe(32),
+        )
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": other_group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_keywords_unauthenticated_returns_401(self):
+        client = APIClient()
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": self.group.id})
+        response = client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_get_keywords_returns_word_and_count_fields(self):
+        """Each keyword item must have word and count fields."""
+        ChatLog.objects.create(
+            user=self.user,
+            group=self.group,
+            question="What is machine learning?",
+            answer="A",
+            citations=[],
+            retrieved_contexts=[],
+        )
+        url = reverse("chat-group-analytics-keywords", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        if response.data["keywords"]:
+            kw = response.data["keywords"][0]
+            self.assertIn("word", kw)
+            self.assertIn("count", kw)

--- a/backend/app/presentation/chat/urls.py
+++ b/backend/app/presentation/chat/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from app.dependencies import chat as chat_dependencies
 
 from .views import (
+    ChatGroupAnalyticsKeywordsView,
     ChatGroupAnalyticsView,
     ChatGroupHistoryView,
     ChatLogFeedbackView,
@@ -43,5 +44,12 @@ urlpatterns = [
             chat_analytics_use_case=chat_dependencies.get_chat_analytics_use_case
         ),
         name="chat-group-analytics",
+    ),
+    path(
+        "groups/<int:group_id>/analytics/keywords/",
+        ChatGroupAnalyticsKeywordsView.as_view(
+            chat_keywords_use_case=chat_dependencies.get_chat_keywords_use_case
+        ),
+        name="chat-group-analytics-keywords",
     ),
 ]

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -304,16 +304,6 @@ class ChatGroupAnalyticsView(DependencyResolverMixin, APIView):
                     "last": dto.date_range.last,
                 },
             },
-            "scene_distribution": [
-                {
-                    "video_id": s.video_id,
-                    "title": s.title,
-                    "start_time": s.start_time,
-                    "end_time": s.end_time,
-                    "question_count": s.question_count,
-                }
-                for s in dto.scene_distribution
-            ],
             "time_series": [
                 {"date": item.date, "count": item.count}
                 for item in dto.time_series

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -43,6 +43,7 @@ from django.http import HttpResponse, StreamingHttpResponse
 
 from .exporters import write_chat_history_csv
 from .serializers import (
+    ChatAnalyticsKeywordsResponseSerializer,
     ChatAnalyticsResponseSerializer,
     ChatFeedbackRequestSerializer,
     ChatFeedbackResponseSerializer,
@@ -322,9 +323,32 @@ class ChatGroupAnalyticsView(DependencyResolverMixin, APIView):
                 "bad": dto.feedback.bad,
                 "none": dto.feedback.none,
             },
+        })
+
+
+class ChatGroupAnalyticsKeywordsView(DependencyResolverMixin, APIView):
+    """Keyword extraction for a chat group's analytics (group_id in URL path)."""
+
+    authentication_classes = [APIKeyAuthentication, CookieJWTAuthentication]
+    permission_classes = [IsAuthenticated, ApiKeyScopePermission]
+    chat_keywords_use_case = None
+
+    @extend_schema(
+        responses={200: ChatAnalyticsKeywordsResponseSerializer},
+        summary="Get chat analytics keywords",
+        description="Return keyword frequency data for a chat group's questions.",
+    )
+    def get(self, request, group_id):
+        use_case = self.resolve_dependency(self.chat_keywords_use_case)
+        try:
+            keywords = use_case.execute(group_id=group_id, user_id=request.user.id)
+        except ResourceNotFound as e:
+            return create_error_response(str(e), status.HTTP_404_NOT_FOUND)
+
+        return Response({
             "keywords": [
                 {"word": item.word, "count": item.count}
-                for item in dto.keywords
+                for item in keywords
             ],
         })
 

--- a/backend/app/tests/test_import_rules.py
+++ b/backend/app/tests/test_import_rules.py
@@ -2,8 +2,8 @@
 CI test: detect forbidden cross-layer imports.
 
 Acceptance criteria:
-  - app/domain/**   : no app.models, django, rest_framework, celery, app.infrastructure, app.use_cases
-  - app/use_cases/**: no app.models, django, rest_framework, app.infrastructure
+  - app/domain/**   : no framework imports or outer app-layer imports
+  - app/use_cases/**: no framework imports or outer app-layer imports
   - app/presentation/**: no app.models, no app.infrastructure.*
   - app/dependencies/**: no app.models, django, rest_framework, app.infrastructure
   - app/composition_root/**: no app.models, django, rest_framework, app.presentation
@@ -34,6 +34,40 @@ LAYER_ROOTS = {
     "tests",
     "migrations",
 }
+
+# Domain and use-case code must keep running as plain Python when Django, DRF,
+# or task-worker adapters are replaced.
+CORE_FRAMEWORK_IMPORTS = [
+    "celery",
+    "django",
+    "drf_spectacular",
+    "rest_framework",
+    "rest_framework_simplejwt",
+]
+CORE_OUTER_APP_IMPORTS = [
+    "app.admin",
+    "app.apps",
+    "app.celery_config",
+    "app.composition_root",
+    "app.contracts",
+    "app.dependencies",
+    "app.entrypoints",
+    "app.infrastructure",
+    "app.presentation",
+    "app.urls",
+    "videoq",
+]
+DOMAIN_FORBIDDEN_IMPORTS = [
+    "app.models",
+    "app.use_cases",
+    *CORE_FRAMEWORK_IMPORTS,
+    *CORE_OUTER_APP_IMPORTS,
+]
+USE_CASE_FORBIDDEN_IMPORTS = [
+    "app.models",
+    *CORE_FRAMEWORK_IMPORTS,
+    *CORE_OUTER_APP_IMPORTS,
+]
 
 # Service locator is prohibited in framework entrypoints.
 # Keep this allowlist empty by default; if temporary exceptions are needed,
@@ -361,19 +395,26 @@ class ImportRulesTest(unittest.TestCase):
             ),
         )
 
-    def test_domain_has_no_forbidden_imports(self):
-        """domain layer must not import from app.models, django, rest_framework, celery, app.infrastructure, or app.use_cases."""
-        self._check(
-            "domain",
-            [
-                "app.models",
-                "django",
-                "rest_framework",
-                "celery",
-                "app.infrastructure",
-                "app.use_cases",
-            ],
+    def _check_tests(self, layer_paths, forbidden):
+        all_violations = {}
+        for layer_path in layer_paths:
+            for fp in sorted(self._iter_layer_test_files(layer_path)):
+                rel = os.path.relpath(fp, BASE)
+                v = check_forbidden_imports(fp, forbidden)
+                if v:
+                    all_violations[rel] = v
+        self.assertEqual(
+            {},
+            all_violations,
+            "Forbidden imports found in core-layer tests:\n"
+            + "\n".join(
+                f"  {f}: {vs}" for f, vs in all_violations.items()
+            ),
         )
+
+    def test_domain_has_no_forbidden_imports(self):
+        """domain must not import frameworks, use cases, or outer app layers."""
+        self._check("domain", DOMAIN_FORBIDDEN_IMPORTS)
 
     def test_layer_scan_counts_are_non_zero(self):
         counts = {
@@ -393,8 +434,19 @@ class ImportRulesTest(unittest.TestCase):
             )
 
     def test_use_cases_has_no_forbidden_imports(self):
-        """use_cases layer must not import from app.models, django, rest_framework, or app.infrastructure."""
-        self._check("use_cases", ["app.models", "django", "rest_framework", "app.infrastructure"])
+        """use_cases must not import frameworks or outer app layers."""
+        self._check("use_cases", USE_CASE_FORBIDDEN_IMPORTS)
+
+    def test_core_layer_tests_have_no_framework_or_outer_layer_imports(self):
+        """Core tests stay plain unit tests without framework or adapter wiring."""
+        self._check_tests(
+            ["domain", "use_cases"],
+            [
+                "app.models",
+                *CORE_FRAMEWORK_IMPORTS,
+                *CORE_OUTER_APP_IMPORTS,
+            ],
+        )
 
     def test_core_layers_have_no_dynamic_import_calls(self):
         """Dynamic imports are disallowed in app layers guarded by import rules."""

--- a/backend/app/use_cases/chat/dto.py
+++ b/backend/app/use_cases/chat/dto.py
@@ -76,23 +76,11 @@ class ChatFeedbackResultDTO:
 
 
 @dataclass
-class SceneDistributionItemDTO:
-    """A scene entry in the analytics scene distribution."""
-
-    video_id: int
-    title: str
-    start_time: Optional[str]
-    end_time: Optional[str]
-    question_count: int
-
-
-@dataclass
 class ChatAnalyticsDTO:
     """Output of GetChatAnalyticsUseCase."""
 
     total_questions: int
     date_range: "DateRangeDTO"
-    scene_distribution: List[SceneDistributionItemDTO]
     time_series: List["TimeSeriesPointDTO"]
     feedback: "FeedbackSummaryDTO"
 

--- a/backend/app/use_cases/chat/dto.py
+++ b/backend/app/use_cases/chat/dto.py
@@ -95,7 +95,6 @@ class ChatAnalyticsDTO:
     scene_distribution: List[SceneDistributionItemDTO]
     time_series: List["TimeSeriesPointDTO"]
     feedback: "FeedbackSummaryDTO"
-    keywords: List["KeywordCountDTO"]
 
 
 @dataclass(frozen=True)

--- a/backend/app/use_cases/chat/get_analytics.py
+++ b/backend/app/use_cases/chat/get_analytics.py
@@ -2,7 +2,6 @@
 Use case: Build analytics dashboard data for a chat group.
 """
 
-from app.domain.chat.ports import KeywordExtractor
 from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
 from app.domain.chat.services import (
     GroupContextNotFound as _DomainGroupContextNotFound,
@@ -15,7 +14,6 @@ from app.use_cases.chat.dto import (
     ChatAnalyticsDTO,
     DateRangeDTO,
     FeedbackSummaryDTO,
-    KeywordCountDTO,
     SceneDistributionItemDTO,
     TimeSeriesPointDTO,
 )
@@ -23,22 +21,20 @@ from app.use_cases.shared.exceptions import ResourceNotFound
 
 
 class GetChatAnalyticsUseCase:
-    """Aggregate chat analytics: summary, scene distribution, time series, feedback, keywords."""
+    """Aggregate chat analytics: summary, scene distribution, time series, feedback."""
 
     def __init__(
         self,
         chat_repo: ChatRepository,
         group_query_repo: VideoGroupQueryRepository,
-        keyword_extractor: KeywordExtractor,
     ):
         self.chat_repo = chat_repo
         self.group_query_repo = group_query_repo
-        self.keyword_extractor = keyword_extractor
 
     def execute(self, group_id: int, user_id: int) -> ChatAnalyticsDTO:
         """
         Returns:
-            ChatAnalyticsDTO with summary, scene_distribution, time_series, feedback, keywords.
+            ChatAnalyticsDTO with summary, scene_distribution, time_series, feedback.
 
         Raises:
             ResourceNotFound: If the group does not exist.
@@ -71,8 +67,6 @@ class GetChatAnalyticsUseCase:
             for key, count in top_scenes
         ]
 
-        keywords = self.keyword_extractor.extract(raw.questions)
-
         return ChatAnalyticsDTO(
             total_questions=raw.total,
             date_range=date_range,
@@ -86,8 +80,4 @@ class GetChatAnalyticsUseCase:
                 bad=raw.feedback.bad,
                 none=raw.feedback.none,
             ),
-            keywords=[
-                KeywordCountDTO(word=item.word, count=item.count)
-                for item in keywords
-            ],
         )

--- a/backend/app/use_cases/chat/get_analytics.py
+++ b/backend/app/use_cases/chat/get_analytics.py
@@ -5,23 +5,19 @@ Use case: Build analytics dashboard data for a chat group.
 from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
 from app.domain.chat.services import (
     GroupContextNotFound as _DomainGroupContextNotFound,
-    aggregate_scenes,
-    filter_group_scenes,
-    member_video_id_set,
     require_group_context,
 )
 from app.use_cases.chat.dto import (
     ChatAnalyticsDTO,
     DateRangeDTO,
     FeedbackSummaryDTO,
-    SceneDistributionItemDTO,
     TimeSeriesPointDTO,
 )
 from app.use_cases.shared.exceptions import ResourceNotFound
 
 
 class GetChatAnalyticsUseCase:
-    """Aggregate chat analytics: summary, scene distribution, time series, feedback."""
+    """Aggregate chat analytics: summary, time series, feedback."""
 
     def __init__(
         self,
@@ -34,13 +30,13 @@ class GetChatAnalyticsUseCase:
     def execute(self, group_id: int, user_id: int) -> ChatAnalyticsDTO:
         """
         Returns:
-            ChatAnalyticsDTO with summary, scene_distribution, time_series, feedback.
+            ChatAnalyticsDTO with summary, time_series, feedback.
 
         Raises:
             ResourceNotFound: If the group does not exist.
         """
         try:
-            group = require_group_context(
+            require_group_context(
                 self.group_query_repo.get_with_members(group_id=group_id, user_id=user_id)
             )
         except _DomainGroupContextNotFound:
@@ -53,24 +49,9 @@ class GetChatAnalyticsUseCase:
             last=raw.last_date.isoformat() if raw.last_date else None,
         )
 
-        scene_counter, scene_info, _ = aggregate_scenes(raw.logs_for_scenes)
-        valid_video_ids = member_video_id_set(group)
-        top_scenes = filter_group_scenes(scene_counter, valid_video_ids)
-        scene_distribution = [
-            SceneDistributionItemDTO(
-                video_id=scene_info[key]["video_id"],
-                title=scene_info[key]["title"],
-                start_time=scene_info[key]["start_time"],
-                end_time=scene_info[key]["end_time"],
-                question_count=count,
-            )
-            for key, count in top_scenes
-        ]
-
         return ChatAnalyticsDTO(
             total_questions=raw.total,
             date_range=date_range,
-            scene_distribution=scene_distribution,
             time_series=[
                 TimeSeriesPointDTO(date=item.date, count=item.count)
                 for item in raw.time_series

--- a/backend/app/use_cases/chat/get_keywords.py
+++ b/backend/app/use_cases/chat/get_keywords.py
@@ -1,0 +1,51 @@
+"""
+Use case: Extract keywords from chat questions for a group.
+"""
+
+from typing import List
+
+from app.domain.chat.ports import KeywordExtractor
+from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
+from app.domain.chat.services import (
+    GroupContextNotFound as _DomainGroupContextNotFound,
+    require_group_context,
+)
+from app.use_cases.chat.dto import KeywordCountDTO
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+
+class GetChatKeywordsUseCase:
+    """Extract top keywords from chat questions for a group."""
+
+    def __init__(
+        self,
+        chat_repo: ChatRepository,
+        group_query_repo: VideoGroupQueryRepository,
+        keyword_extractor: KeywordExtractor,
+    ):
+        self.chat_repo = chat_repo
+        self.group_query_repo = group_query_repo
+        self.keyword_extractor = keyword_extractor
+
+    def execute(self, group_id: int, user_id: int) -> List[KeywordCountDTO]:
+        """
+        Returns:
+            List of KeywordCountDTO sorted by frequency.
+
+        Raises:
+            ResourceNotFound: If the group does not exist.
+        """
+        try:
+            require_group_context(
+                self.group_query_repo.get_with_members(group_id=group_id, user_id=user_id)
+            )
+        except _DomainGroupContextNotFound:
+            raise ResourceNotFound("Group")
+
+        raw = self.chat_repo.get_analytics_raw(group_id)
+        keywords = self.keyword_extractor.extract(raw.questions)
+
+        return [
+            KeywordCountDTO(word=item.word, count=item.count)
+            for item in keywords
+        ]

--- a/backend/app/use_cases/chat/get_keywords.py
+++ b/backend/app/use_cases/chat/get_keywords.py
@@ -42,8 +42,8 @@ class GetChatKeywordsUseCase:
         except _DomainGroupContextNotFound:
             raise ResourceNotFound("Group")
 
-        raw = self.chat_repo.get_analytics_raw(group_id)
-        keywords = self.keyword_extractor.extract(raw.questions)
+        questions = self.chat_repo.get_questions_for_group(group_id)
+        keywords = self.keyword_extractor.extract(questions)
 
         return [
             KeywordCountDTO(word=item.word, count=item.count)

--- a/backend/app/use_cases/chat/tests/test_get_analytics.py
+++ b/backend/app/use_cases/chat/tests/test_get_analytics.py
@@ -1,0 +1,115 @@
+"""Tests for GetChatAnalyticsUseCase — scene_distribution must not be present."""
+
+import unittest
+from datetime import datetime
+from typing import List, Optional
+
+from app.domain.chat.entities import ChatAnalyticsRaw, VideoGroupContextEntity
+from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
+from app.domain.chat.value_objects import FeedbackSummary, TimeSeriesPoint
+from app.use_cases.chat.get_analytics import GetChatAnalyticsUseCase
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+_SENTINEL = object()
+
+
+class _StubChatRepository(ChatRepository):
+    def __init__(self, raw: ChatAnalyticsRaw):
+        self._raw = raw
+        self.analytics_raw_call_count = 0
+
+    def get_analytics_raw(self, group_id: int) -> ChatAnalyticsRaw:
+        self.analytics_raw_call_count += 1
+        return self._raw
+
+    def get_logs_for_group(self, group_id, ascending=True):
+        raise NotImplementedError
+
+    def create_log(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_log_by_id(self, log_id):
+        raise NotImplementedError
+
+    def update_feedback(self, log, feedback):
+        raise NotImplementedError
+
+    def get_logs_values_for_group(self, group_id):
+        raise NotImplementedError
+
+    def get_questions_for_group(self, group_id):
+        raise NotImplementedError
+
+    def delete_logs_for_group(self, group_id):
+        raise NotImplementedError
+
+
+class _StubGroupRepository(VideoGroupQueryRepository):
+    def __init__(self, group: Optional[VideoGroupContextEntity]):
+        self._group = group
+
+    def get_with_members(self, group_id, user_id=None, share_token=None):
+        return self._group
+
+
+def _make_raw(total: int = 0) -> ChatAnalyticsRaw:
+    return ChatAnalyticsRaw(
+        total=total,
+        first_date=None,
+        last_date=None,
+        time_series=[],
+        feedback=FeedbackSummary(good=0, bad=0, none=0),
+    )
+
+
+def _make_group() -> VideoGroupContextEntity:
+    return VideoGroupContextEntity(id=1, user_id=42, name="g1")
+
+
+class GetChatAnalyticsUseCaseTests(unittest.TestCase):
+    def _make_use_case(self, raw=None, group=_SENTINEL):
+        resolved_group = _make_group() if group is _SENTINEL else group
+        return GetChatAnalyticsUseCase(
+            chat_repo=_StubChatRepository(raw or _make_raw()),
+            group_query_repo=_StubGroupRepository(resolved_group),
+        )
+
+    def test_dto_has_no_scene_distribution_field(self):
+        """ChatAnalyticsDTO must not expose scene_distribution."""
+        use_case = self._make_use_case()
+        dto = use_case.execute(group_id=1, user_id=42)
+        self.assertFalse(hasattr(dto, "scene_distribution"))
+
+    def test_dto_contains_expected_fields(self):
+        raw = ChatAnalyticsRaw(
+            total=5,
+            first_date=datetime(2026, 1, 1),
+            last_date=datetime(2026, 1, 5),
+            time_series=[TimeSeriesPoint(date="2026-01-01", count=3)],
+            feedback=FeedbackSummary(good=2, bad=1, none=2),
+        )
+        use_case = self._make_use_case(raw=raw)
+        dto = use_case.execute(group_id=1, user_id=42)
+
+        self.assertEqual(dto.total_questions, 5)
+        self.assertIn("2026-01-01", dto.date_range.first)
+        self.assertIn("2026-01-05", dto.date_range.last)
+        self.assertEqual(len(dto.time_series), 1)
+        self.assertEqual(dto.time_series[0].count, 3)
+        self.assertEqual(dto.feedback.good, 2)
+        self.assertEqual(dto.feedback.bad, 1)
+        self.assertEqual(dto.feedback.none, 2)
+
+    def test_raises_resource_not_found_when_group_missing(self):
+        use_case = self._make_use_case(group=None)
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(group_id=999, user_id=42)
+
+    def test_get_analytics_raw_is_called_once(self):
+        repo = _StubChatRepository(_make_raw())
+        use_case = GetChatAnalyticsUseCase(
+            chat_repo=repo,
+            group_query_repo=_StubGroupRepository(_make_group()),
+        )
+        use_case.execute(group_id=1, user_id=42)
+        self.assertEqual(repo.analytics_raw_call_count, 1)

--- a/backend/app/use_cases/chat/tests/test_get_history.py
+++ b/backend/app/use_cases/chat/tests/test_get_history.py
@@ -32,6 +32,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id: int):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         raise NotImplementedError
 

--- a/backend/app/use_cases/chat/tests/test_get_keywords.py
+++ b/backend/app/use_cases/chat/tests/test_get_keywords.py
@@ -1,0 +1,121 @@
+"""Tests for GetChatKeywordsUseCase."""
+
+import unittest
+from typing import List
+
+from app.domain.chat.entities import VideoGroupContextEntity, ChatAnalyticsRaw
+from app.domain.chat.ports import KeywordExtractor
+from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
+from app.domain.chat.value_objects import KeywordCount
+from app.use_cases.chat.get_keywords import GetChatKeywordsUseCase
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+
+class _StubChatRepository(ChatRepository):
+    def __init__(self, questions=None):
+        self._questions = questions or []
+
+    def get_analytics_raw(self, group_id: int):
+        raw = ChatAnalyticsRaw.__new__(ChatAnalyticsRaw)
+        raw.total = 0
+        raw.first_date = None
+        raw.last_date = None
+        raw.logs_for_scenes = []
+        raw.time_series = []
+        raw.feedback = None
+        raw.questions = self._questions
+        return raw
+
+    def get_logs_for_group(self, group_id, ascending=True):
+        raise NotImplementedError
+
+    def create_log(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_log_by_id(self, log_id):
+        raise NotImplementedError
+
+    def update_feedback(self, log, feedback):
+        raise NotImplementedError
+
+    def get_logs_values_for_group(self, group_id):
+        raise NotImplementedError
+
+    def delete_logs_for_group(self, group_id):
+        raise NotImplementedError
+
+
+class _StubGroupRepository(VideoGroupQueryRepository):
+    def __init__(self, group):
+        self._group = group
+
+    def get_with_members(self, group_id, user_id=None, share_token=None):
+        return self._group
+
+
+class _StubKeywordExtractor(KeywordExtractor):
+    def __init__(self, result: List[KeywordCount]):
+        self._result = result
+
+    def extract(self, questions: List[str], limit: int = 30) -> List[KeywordCount]:
+        return self._result
+
+
+class GetChatKeywordsUseCaseTests(unittest.TestCase):
+    def _make_group(self):
+        return VideoGroupContextEntity(id=1, user_id=42, name="g1")
+
+    def test_execute_returns_keyword_count_dto_list(self):
+        keywords = [KeywordCount(word="python", count=5), KeywordCount(word="flask", count=3)]
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=_StubChatRepository(questions=["What is python?"]),
+            group_query_repo=_StubGroupRepository(self._make_group()),
+            keyword_extractor=_StubKeywordExtractor(keywords),
+        )
+
+        result = use_case.execute(group_id=1, user_id=42)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].word, "python")
+        self.assertEqual(result[0].count, 5)
+        self.assertEqual(result[1].word, "flask")
+        self.assertEqual(result[1].count, 3)
+
+    def test_execute_raises_when_group_not_found(self):
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=_StubChatRepository(),
+            group_query_repo=_StubGroupRepository(None),
+            keyword_extractor=_StubKeywordExtractor([]),
+        )
+
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(group_id=999, user_id=42)
+
+    def test_execute_returns_empty_list_when_no_questions(self):
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=_StubChatRepository(questions=[]),
+            group_query_repo=_StubGroupRepository(self._make_group()),
+            keyword_extractor=_StubKeywordExtractor([]),
+        )
+
+        result = use_case.execute(group_id=1, user_id=42)
+
+        self.assertEqual(result, [])
+
+    def test_keyword_extractor_receives_questions_from_raw(self):
+        received = []
+
+        class _CapturingExtractor(KeywordExtractor):
+            def extract(self, questions, limit=30):
+                received.extend(questions)
+                return []
+
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=_StubChatRepository(questions=["q1", "q2"]),
+            group_query_repo=_StubGroupRepository(self._make_group()),
+            keyword_extractor=_CapturingExtractor(),
+        )
+
+        use_case.execute(group_id=1, user_id=42)
+
+        self.assertEqual(received, ["q1", "q2"])

--- a/backend/app/use_cases/chat/tests/test_get_keywords.py
+++ b/backend/app/use_cases/chat/tests/test_get_keywords.py
@@ -3,7 +3,7 @@
 import unittest
 from typing import List
 
-from app.domain.chat.entities import VideoGroupContextEntity, ChatAnalyticsRaw
+from app.domain.chat.entities import VideoGroupContextEntity
 from app.domain.chat.ports import KeywordExtractor
 from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
 from app.domain.chat.value_objects import KeywordCount
@@ -15,16 +15,11 @@ class _StubChatRepository(ChatRepository):
     def __init__(self, questions=None):
         self._questions = questions or []
 
+    def get_questions_for_group(self, group_id: int) -> List[str]:
+        return self._questions
+
     def get_analytics_raw(self, group_id: int):
-        raw = ChatAnalyticsRaw.__new__(ChatAnalyticsRaw)
-        raw.total = 0
-        raw.first_date = None
-        raw.last_date = None
-        raw.logs_for_scenes = []
-        raw.time_series = []
-        raw.feedback = None
-        raw.questions = self._questions
-        return raw
+        raise NotImplementedError
 
     def get_logs_for_group(self, group_id, ascending=True):
         raise NotImplementedError
@@ -102,7 +97,7 @@ class GetChatKeywordsUseCaseTests(unittest.TestCase):
 
         self.assertEqual(result, [])
 
-    def test_keyword_extractor_receives_questions_from_raw(self):
+    def test_keyword_extractor_receives_questions_from_repository(self):
         received = []
 
         class _CapturingExtractor(KeywordExtractor):
@@ -119,3 +114,23 @@ class GetChatKeywordsUseCaseTests(unittest.TestCase):
         use_case.execute(group_id=1, user_id=42)
 
         self.assertEqual(received, ["q1", "q2"])
+
+    def test_get_analytics_raw_is_not_called(self):
+        """get_questions_for_group must be used; get_analytics_raw must NOT be called."""
+        class _TrackingRepo(_StubChatRepository):
+            analytics_raw_called = False
+
+            def get_analytics_raw(self, group_id):
+                self.__class__.analytics_raw_called = True
+                raise AssertionError("get_analytics_raw should not be called")
+
+        repo = _TrackingRepo(questions=["q"])
+        use_case = GetChatKeywordsUseCase(
+            chat_repo=repo,
+            group_query_repo=_StubGroupRepository(self._make_group()),
+            keyword_extractor=_StubKeywordExtractor([]),
+        )
+
+        use_case.execute(group_id=1, user_id=42)
+
+        self.assertFalse(_TrackingRepo.analytics_raw_called)

--- a/backend/app/use_cases/chat/tests/test_reset_history.py
+++ b/backend/app/use_cases/chat/tests/test_reset_history.py
@@ -31,6 +31,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id: int):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         self.deleted_group_ids.append(group_id)
 

--- a/backend/app/use_cases/chat/tests/test_send_message.py
+++ b/backend/app/use_cases/chat/tests/test_send_message.py
@@ -31,6 +31,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id: int):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         raise NotImplementedError
 

--- a/backend/app/use_cases/chat/tests/test_stream_message.py
+++ b/backend/app/use_cases/chat/tests/test_stream_message.py
@@ -31,6 +31,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         raise NotImplementedError
 

--- a/backend/app/use_cases/chat/tests/test_submit_feedback.py
+++ b/backend/app/use_cases/chat/tests/test_submit_feedback.py
@@ -38,6 +38,9 @@ class _StubChatRepository(ChatRepository):
     def get_analytics_raw(self, group_id: int):
         raise NotImplementedError
 
+    def get_questions_for_group(self, group_id: int):
+        raise NotImplementedError
+
     def delete_logs_for_group(self, group_id: int) -> None:
         raise NotImplementedError
 

--- a/backend/app/use_cases/evaluation/evaluate_chat_log.py
+++ b/backend/app/use_cases/evaluation/evaluate_chat_log.py
@@ -29,7 +29,7 @@ class EvaluateChatLogUseCase:
     Fetches a ChatLog by ID, runs RAGAS evaluation, and saves the result.
 
     On any failure the evaluation is persisted with status='failed' and the
-    error message — the task never re-raises so the Celery worker does not retry.
+    error message without asking the task runner to retry.
     """
 
     def __init__(
@@ -57,7 +57,7 @@ class EvaluateChatLogUseCase:
 
         chat_log = self.chat_log_repo.get_by_id(chat_log_id)
         if chat_log is None:
-            # No FK exists → cannot persist. Log and return silently.
+            # No source record exists, so there is nothing to persist.
             logger.warning("ChatLog %s not found; skipping evaluation.", chat_log_id)
             pending.status = "failed"
             pending.error_message = f"ChatLog {chat_log_id} not found."

--- a/backend/app/use_cases/video/reindex_video_transcript.py
+++ b/backend/app/use_cases/video/reindex_video_transcript.py
@@ -1,6 +1,6 @@
 """
 Use case: Reindex a video's transcript in the vector store after a manual edit.
-Runs asynchronously via Celery after the transcript update is committed.
+Can run asynchronously after the transcript update is committed.
 """
 
 import logging

--- a/frontend/src/components/dashboard/AnalyticsDashboard.tsx
+++ b/frontend/src/components/dashboard/AnalyticsDashboard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import type { ChatAnalytics, EvaluationSummary } from '@/lib/api';
+import type { ChatAnalytics, ChatAnalyticsKeywords, EvaluationSummary } from '@/lib/api';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { DashboardEmptyState } from './DashboardEmptyState';
 import { QuestionTimeSeriesChart } from './QuestionTimeSeriesChart';
@@ -12,6 +12,8 @@ interface AnalyticsDashboardProps {
   evaluationSummary?: EvaluationSummary;
   isLoading: boolean;
   isEvaluationLoading?: boolean;
+  keywordsData?: ChatAnalyticsKeywords;
+  isKeywordsLoading?: boolean;
 }
 
 export function AnalyticsDashboard({
@@ -19,6 +21,8 @@ export function AnalyticsDashboard({
   evaluationSummary,
   isLoading,
   isEvaluationLoading = false,
+  keywordsData,
+  isKeywordsLoading = false,
 }: AnalyticsDashboardProps) {
   const { t } = useTranslation();
 
@@ -66,9 +70,15 @@ export function AnalyticsDashboard({
           />
         </div>
 
-        {data.keywords.length > 0 && (
+        {isKeywordsLoading && (
+          <div className="bg-white border border-gray-200 rounded-lg p-4 flex justify-center items-center" data-testid="keywords-loading">
+            <LoadingSpinner />
+          </div>
+        )}
+
+        {!isKeywordsLoading && keywordsData && keywordsData.keywords.length > 0 && (
           <div className="bg-white border border-gray-200 rounded-lg p-4">
-            <KeywordCloudChart data={data.keywords} />
+            <KeywordCloudChart data={keywordsData.keywords} />
           </div>
         )}
       </div>

--- a/frontend/src/components/dashboard/DashboardButton.tsx
+++ b/frontend/src/components/dashboard/DashboardButton.tsx
@@ -4,6 +4,7 @@ import { BarChart3 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useChatAnalytics } from '@/hooks/useChatAnalytics';
+import { useChatKeywords } from '@/hooks/useChatKeywords';
 import { useEvaluationSummary } from '@/hooks/useEvaluationSummary';
 import { AnalyticsDashboard } from './AnalyticsDashboard';
 
@@ -20,6 +21,10 @@ export function DashboardButton({ groupId, size = 'default' }: DashboardButtonPr
     data: evaluationSummary,
     isLoading: isEvaluationLoading,
   } = useEvaluationSummary(groupId, isOpen);
+  const {
+    data: keywordsData,
+    isLoading: isKeywordsLoading,
+  } = useChatKeywords(groupId, isOpen);
 
   return (
     <>
@@ -43,6 +48,8 @@ export function DashboardButton({ groupId, size = 'default' }: DashboardButtonPr
             evaluationSummary={evaluationSummary}
             isLoading={isLoading}
             isEvaluationLoading={isEvaluationLoading}
+            keywordsData={keywordsData}
+            isKeywordsLoading={isKeywordsLoading}
           />
         </DialogContent>
       </Dialog>

--- a/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import { AnalyticsDashboard } from '../AnalyticsDashboard'
-import type { ChatAnalytics, EvaluationSummary } from '@/lib/api'
+import type { ChatAnalytics, ChatAnalyticsKeywords, EvaluationSummary } from '@/lib/api'
+
+vi.mock('../KeywordCloudChart', () => ({
+  KeywordCloudChart: ({ data }: { data: { word: string; count: number }[] }) => (
+    <div data-testid="keyword-cloud">
+      {data.map((kw) => (
+        <span key={kw.word}>{kw.word}</span>
+      ))}
+    </div>
+  ),
+}))
 
 const analytics: ChatAnalytics = {
   summary: {
@@ -18,7 +28,6 @@ const analytics: ChatAnalytics = {
   ],
   time_series: [],
   feedback: { good: 1, bad: 0, none: 23 },
-  keywords: [],
 }
 
 const evaluationSummary: EvaluationSummary = {
@@ -27,6 +36,13 @@ const evaluationSummary: EvaluationSummary = {
   avg_faithfulness: 0.86,
   avg_answer_relevancy: 0.81,
   avg_context_precision: 0.78,
+}
+
+const keywordsData: ChatAnalyticsKeywords = {
+  keywords: [
+    { word: 'machine learning', count: 5 },
+    { word: 'python', count: 3 },
+  ],
 }
 
 describe('AnalyticsDashboard', () => {
@@ -59,5 +75,54 @@ describe('AnalyticsDashboard', () => {
     )
 
     expect(screen.getByText('dashboard.evaluation.empty')).toBeInTheDocument()
+  })
+
+  it('renders keyword cloud when keywords data is provided', () => {
+    render(
+      <AnalyticsDashboard
+        data={analytics}
+        evaluationSummary={evaluationSummary}
+        isLoading={false}
+        isEvaluationLoading={false}
+        keywordsData={keywordsData}
+        isKeywordsLoading={false}
+      />,
+    )
+
+    expect(screen.getByText('machine learning')).toBeInTheDocument()
+  })
+
+  it('shows keywords loading spinner independently when keywords are loading', () => {
+    render(
+      <AnalyticsDashboard
+        data={analytics}
+        evaluationSummary={evaluationSummary}
+        isLoading={false}
+        isEvaluationLoading={false}
+        isKeywordsLoading={true}
+      />,
+    )
+
+    // Main dashboard content should still be visible
+    expect(screen.getByText(/dashboard\.totalQuestions/)).toBeInTheDocument()
+    // Keywords spinner should appear inside keywords card area
+    expect(screen.getByTestId('keywords-loading')).toBeInTheDocument()
+  })
+
+  it('does not render keywords section when keywords data is undefined and not loading', () => {
+    render(
+      <AnalyticsDashboard
+        data={analytics}
+        evaluationSummary={evaluationSummary}
+        isLoading={false}
+        isEvaluationLoading={false}
+        isKeywordsLoading={false}
+      />,
+    )
+
+    // Main dashboard should be shown regardless
+    expect(screen.getByText(/dashboard\.totalQuestions/)).toBeInTheDocument()
+    // No keyword cloud when data is absent and not loading
+    expect(screen.queryByTestId('keywords-loading')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
@@ -17,15 +17,6 @@ const analytics: ChatAnalytics = {
     total_questions: 24,
     date_range: { first: '2026-04-01T00:00:00Z', last: '2026-04-22T00:00:00Z' },
   },
-  scene_distribution: [
-    {
-      video_id: 1,
-      title: 'Scene title',
-      start_time: '00:00:10',
-      end_time: '00:00:20',
-      question_count: 3,
-    },
-  ],
   time_series: [],
   feedback: { good: 1, bad: 0, none: 23 },
 }

--- a/frontend/src/hooks/useChatKeywords.ts
+++ b/frontend/src/hooks/useChatKeywords.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient, type ChatAnalyticsKeywords } from '@/lib/api';
+import { queryKeys } from '@/lib/queryKeys';
+
+export function useChatKeywords(groupId: number | null, enabled = true) {
+  return useQuery<ChatAnalyticsKeywords>({
+    queryKey: queryKeys.chat.keywords(groupId!),
+    queryFn: () => apiClient.getChatKeywords(groupId!),
+    enabled: enabled && groupId != null,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -143,6 +143,9 @@ export interface ChatAnalytics {
   }[];
   time_series: { date: string; count: number }[];
   feedback: { good: number; bad: number; none: number };
+}
+
+export interface ChatAnalyticsKeywords {
   keywords: { word: string; count: number }[];
 }
 
@@ -1168,6 +1171,10 @@ class ApiClient {
 
   async getChatAnalytics(groupId: number): Promise<ChatAnalytics> {
     return this.request<ChatAnalytics>(`/chat/groups/${groupId}/analytics/`);
+  }
+
+  async getChatKeywords(groupId: number): Promise<ChatAnalyticsKeywords> {
+    return this.request<ChatAnalyticsKeywords>(`/chat/groups/${groupId}/analytics/keywords/`);
   }
 
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,13 +134,6 @@ export interface ChatAnalytics {
     total_questions: number;
     date_range: { first?: string; last?: string };
   };
-  scene_distribution: {
-    video_id: number;
-    title: string;
-    start_time: string;
-    end_time: string;
-    question_count: number;
-  }[];
   time_series: { date: string; count: number }[];
   feedback: { good: number; bad: number; none: number };
 }

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -29,6 +29,7 @@ export const queryKeys = {
   chat: {
     history: (groupId: number | null, shareToken?: string) => ['chatHistory', groupId, shareToken ?? null] as const,
     analytics: (groupId: number) => ['chatAnalytics', groupId] as const,
+    keywords: (groupId: number) => ['chatAnalyticsKeywords', groupId] as const,
     evaluations: (groupId: number | null) => ['chatEvaluations', groupId] as const,
     evaluationSummary: (groupId: number | null) => ['evaluationSummary', groupId] as const,
   },


### PR DESCRIPTION
## Summary

Closes #706

- 初期 analytics 経路から `scene_distribution` 集計を完全に除去
- `get_analytics_raw()` 内の citations 全件スキャンループを削除
- `ChatAnalyticsRaw.logs_for_scenes`、`ChatAnalyticsDTO.scene_distribution`、`SceneDistributionItemDTO` を削除
- シリアライザ・ビューのレスポンスから `scene_distribution` フィールドを削除
- フロントエンドの `ChatAnalytics` 型・テストフィクスチャを更新

## Test plan

- [x] `test_get_analytics.py`（新規）: DTOに `scene_distribution` が存在しないこと、`get_analytics_raw` が1回だけ呼ばれること、グループ未存在時に `ResourceNotFound` が送出されること
- [x] `test_new_urls.py`: `scene_distribution` がレスポンスに含まれないことを追加アサート
- [x] `AnalyticsDashboard.test.tsx`: `scene_distribution` を除いたフィクスチャで全5テスト通過
- [x] バックエンド全体 1105テスト（既存の無関係な2件を除き全通過）
- [x] フロントエンド全体 533テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)