### PR TITLE
refactor: 教育改善ダッシュボード初期表示で未使用の scene_distribution 集計を止める (#706)

### DIFF
--- a/backend/app/domain/chat/entities.py
+++ b/backend/app/domain/chat/entities.py
@@ -12,7 +12,6 @@ from typing import List, Optional
 from app.domain.chat.dtos import CitationDTO
 from app.domain.chat.exceptions import FeedbackAccessDenied, InvalidFeedbackValue
 from app.domain.chat.value_objects import (
-    ChatSceneLog,
     FeedbackSummary,
     TimeSeriesPoint,
 )
@@ -82,12 +81,10 @@ class ChatLogEntity:
 class ChatAnalyticsRaw:
     """
     Raw data bundle collected from the persistence layer for analytics computation.
-    The use case applies domain services (keyword extraction, scene aggregation) on top of this.
     """
 
     total: int
     first_date: Optional[datetime]
     last_date: Optional[datetime]
-    logs_for_scenes: List[ChatSceneLog]
     time_series: List[TimeSeriesPoint]
     feedback: FeedbackSummary

--- a/backend/app/infrastructure/repositories/django_chat_repository.py
+++ b/backend/app/infrastructure/repositories/django_chat_repository.py
@@ -176,23 +176,6 @@ class DjangoChatRepository(ChatRepository):
                 .first()
             )
 
-        raw_rows = list(qs.values("question", "citations"))
-        logs_for_scenes = []
-        for row in raw_rows:
-            refs = [
-                SceneReference(
-                    video_id=rv.get("video_id"),
-                    title=rv.get("title", ""),
-                    start_time=rv.get("start_time"),
-                    end_time=rv.get("end_time"),
-                )
-                for rv in (row["citations"] or [])
-                if rv.get("video_id") and rv.get("start_time")
-            ]
-            logs_for_scenes.append(
-                ChatSceneLog(question=row["question"], citations=refs)
-            )
-
         time_series_qs = (
             qs.annotate(date=TruncDate("created_at"))
             .values("date")
@@ -224,7 +207,6 @@ class DjangoChatRepository(ChatRepository):
             total=total,
             first_date=first_date,
             last_date=last_date,
-            logs_for_scenes=logs_for_scenes,
             time_series=time_series,
             feedback=feedback,
         )

--- a/backend/app/presentation/chat/serializers.py
+++ b/backend/app/presentation/chat/serializers.py
@@ -87,14 +87,6 @@ class ChatAnalyticsSummarySerializer(serializers.Serializer):
     date_range = serializers.DictField(child=serializers.CharField(allow_null=True))
 
 
-class ChatAnalyticsSceneSerializer(serializers.Serializer):
-    video_id = serializers.IntegerField()
-    title = serializers.CharField()
-    start_time = serializers.CharField()
-    end_time = serializers.CharField()
-    question_count = serializers.IntegerField()
-
-
 class ChatAnalyticsTimeSeriesSerializer(serializers.Serializer):
     date = serializers.CharField()
     count = serializers.IntegerField()
@@ -113,7 +105,6 @@ class ChatAnalyticsKeywordSerializer(serializers.Serializer):
 
 class ChatAnalyticsResponseSerializer(serializers.Serializer):
     summary = ChatAnalyticsSummarySerializer()
-    scene_distribution = ChatAnalyticsSceneSerializer(many=True)
     time_series = ChatAnalyticsTimeSeriesSerializer(many=True)
     feedback = ChatAnalyticsFeedbackSerializer()
 

--- a/backend/app/presentation/chat/tests/test_new_urls.py
+++ b/backend/app/presentation/chat/tests/test_new_urls.py
@@ -207,6 +207,13 @@ class ChatGroupAnalyticsViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotIn("keywords", response.data)
 
+    def test_get_analytics_does_not_include_scene_distribution(self):
+        """GET /api/chat/groups/{group_id}/analytics/ must NOT return scene_distribution."""
+        url = reverse("chat-group-analytics", kwargs={"group_id": self.group.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("scene_distribution", response.data)
+
     def test_get_analytics_nonexistent_group_returns_404(self):
         url = reverse("chat-group-analytics", kwargs={"group_id": 99999})
         response = self.client.get(url)

--- a/backend/app/presentation/chat/views.py
+++ b/backend/app/presentation/chat/views.py
@@ -304,16 +304,6 @@ class ChatGroupAnalyticsView(DependencyResolverMixin, APIView):
                     "last": dto.date_range.last,
                 },
             },
-            "scene_distribution": [
-                {
-                    "video_id": s.video_id,
-                    "title": s.title,
-                    "start_time": s.start_time,
-                    "end_time": s.end_time,
-                    "question_count": s.question_count,
-                }
-                for s in dto.scene_distribution
-            ],
             "time_series": [
                 {"date": item.date, "count": item.count}
                 for item in dto.time_series

--- a/backend/app/use_cases/chat/dto.py
+++ b/backend/app/use_cases/chat/dto.py
@@ -76,23 +76,11 @@ class ChatFeedbackResultDTO:
 
 
 @dataclass
-class SceneDistributionItemDTO:
-    """A scene entry in the analytics scene distribution."""
-
-    video_id: int
-    title: str
-    start_time: Optional[str]
-    end_time: Optional[str]
-    question_count: int
-
-
-@dataclass
 class ChatAnalyticsDTO:
     """Output of GetChatAnalyticsUseCase."""
 
     total_questions: int
     date_range: "DateRangeDTO"
-    scene_distribution: List[SceneDistributionItemDTO]
     time_series: List["TimeSeriesPointDTO"]
     feedback: "FeedbackSummaryDTO"
 

--- a/backend/app/use_cases/chat/get_analytics.py
+++ b/backend/app/use_cases/chat/get_analytics.py
@@ -5,23 +5,19 @@ Use case: Build analytics dashboard data for a chat group.
 from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
 from app.domain.chat.services import (
     GroupContextNotFound as _DomainGroupContextNotFound,
-    aggregate_scenes,
-    filter_group_scenes,
-    member_video_id_set,
     require_group_context,
 )
 from app.use_cases.chat.dto import (
     ChatAnalyticsDTO,
     DateRangeDTO,
     FeedbackSummaryDTO,
-    SceneDistributionItemDTO,
     TimeSeriesPointDTO,
 )
 from app.use_cases.shared.exceptions import ResourceNotFound
 
 
 class GetChatAnalyticsUseCase:
-    """Aggregate chat analytics: summary, scene distribution, time series, feedback."""
+    """Aggregate chat analytics: summary, time series, feedback."""
 
     def __init__(
         self,
@@ -34,13 +30,13 @@ class GetChatAnalyticsUseCase:
     def execute(self, group_id: int, user_id: int) -> ChatAnalyticsDTO:
         """
         Returns:
-            ChatAnalyticsDTO with summary, scene_distribution, time_series, feedback.
+            ChatAnalyticsDTO with summary, time_series, feedback.
 
         Raises:
             ResourceNotFound: If the group does not exist.
         """
         try:
-            group = require_group_context(
+            require_group_context(
                 self.group_query_repo.get_with_members(group_id=group_id, user_id=user_id)
             )
         except _DomainGroupContextNotFound:
@@ -53,24 +49,9 @@ class GetChatAnalyticsUseCase:
             last=raw.last_date.isoformat() if raw.last_date else None,
         )
 
-        scene_counter, scene_info, _ = aggregate_scenes(raw.logs_for_scenes)
-        valid_video_ids = member_video_id_set(group)
-        top_scenes = filter_group_scenes(scene_counter, valid_video_ids)
-        scene_distribution = [
-            SceneDistributionItemDTO(
-                video_id=scene_info[key]["video_id"],
-                title=scene_info[key]["title"],
-                start_time=scene_info[key]["start_time"],
-                end_time=scene_info[key]["end_time"],
-                question_count=count,
-            )
-            for key, count in top_scenes
-        ]
-
         return ChatAnalyticsDTO(
             total_questions=raw.total,
             date_range=date_range,
-            scene_distribution=scene_distribution,
             time_series=[
                 TimeSeriesPointDTO(date=item.date, count=item.count)
                 for item in raw.time_series

--- a/backend/app/use_cases/chat/tests/test_get_analytics.py
+++ b/backend/app/use_cases/chat/tests/test_get_analytics.py
@@ -2,7 +2,7 @@
 
 import unittest
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
 from app.domain.chat.entities import ChatAnalyticsRaw, VideoGroupContextEntity
 from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository

--- a/backend/app/use_cases/chat/tests/test_get_analytics.py
+++ b/backend/app/use_cases/chat/tests/test_get_analytics.py
@@ -1,0 +1,115 @@
+"""Tests for GetChatAnalyticsUseCase — scene_distribution must not be present."""
+
+import unittest
+from datetime import datetime
+from typing import List, Optional
+
+from app.domain.chat.entities import ChatAnalyticsRaw, VideoGroupContextEntity
+from app.domain.chat.repositories import ChatRepository, VideoGroupQueryRepository
+from app.domain.chat.value_objects import FeedbackSummary, TimeSeriesPoint
+from app.use_cases.chat.get_analytics import GetChatAnalyticsUseCase
+from app.use_cases.shared.exceptions import ResourceNotFound
+
+_SENTINEL = object()
+
+
+class _StubChatRepository(ChatRepository):
+    def __init__(self, raw: ChatAnalyticsRaw):
+        self._raw = raw
+        self.analytics_raw_call_count = 0
+
+    def get_analytics_raw(self, group_id: int) -> ChatAnalyticsRaw:
+        self.analytics_raw_call_count += 1
+        return self._raw
+
+    def get_logs_for_group(self, group_id, ascending=True):
+        raise NotImplementedError
+
+    def create_log(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_log_by_id(self, log_id):
+        raise NotImplementedError
+
+    def update_feedback(self, log, feedback):
+        raise NotImplementedError
+
+    def get_logs_values_for_group(self, group_id):
+        raise NotImplementedError
+
+    def get_questions_for_group(self, group_id):
+        raise NotImplementedError
+
+    def delete_logs_for_group(self, group_id):
+        raise NotImplementedError
+
+
+class _StubGroupRepository(VideoGroupQueryRepository):
+    def __init__(self, group: Optional[VideoGroupContextEntity]):
+        self._group = group
+
+    def get_with_members(self, group_id, user_id=None, share_token=None):
+        return self._group
+
+
+def _make_raw(total: int = 0) -> ChatAnalyticsRaw:
+    return ChatAnalyticsRaw(
+        total=total,
+        first_date=None,
+        last_date=None,
+        time_series=[],
+        feedback=FeedbackSummary(good=0, bad=0, none=0),
+    )
+
+
+def _make_group() -> VideoGroupContextEntity:
+    return VideoGroupContextEntity(id=1, user_id=42, name="g1")
+
+
+class GetChatAnalyticsUseCaseTests(unittest.TestCase):
+    def _make_use_case(self, raw=None, group=_SENTINEL):
+        resolved_group = _make_group() if group is _SENTINEL else group
+        return GetChatAnalyticsUseCase(
+            chat_repo=_StubChatRepository(raw or _make_raw()),
+            group_query_repo=_StubGroupRepository(resolved_group),
+        )
+
+    def test_dto_has_no_scene_distribution_field(self):
+        """ChatAnalyticsDTO must not expose scene_distribution."""
+        use_case = self._make_use_case()
+        dto = use_case.execute(group_id=1, user_id=42)
+        self.assertFalse(hasattr(dto, "scene_distribution"))
+
+    def test_dto_contains_expected_fields(self):
+        raw = ChatAnalyticsRaw(
+            total=5,
+            first_date=datetime(2026, 1, 1),
+            last_date=datetime(2026, 1, 5),
+            time_series=[TimeSeriesPoint(date="2026-01-01", count=3)],
+            feedback=FeedbackSummary(good=2, bad=1, none=2),
+        )
+        use_case = self._make_use_case(raw=raw)
+        dto = use_case.execute(group_id=1, user_id=42)
+
+        self.assertEqual(dto.total_questions, 5)
+        self.assertIn("2026-01-01", dto.date_range.first)
+        self.assertIn("2026-01-05", dto.date_range.last)
+        self.assertEqual(len(dto.time_series), 1)
+        self.assertEqual(dto.time_series[0].count, 3)
+        self.assertEqual(dto.feedback.good, 2)
+        self.assertEqual(dto.feedback.bad, 1)
+        self.assertEqual(dto.feedback.none, 2)
+
+    def test_raises_resource_not_found_when_group_missing(self):
+        use_case = self._make_use_case(group=None)
+        with self.assertRaises(ResourceNotFound):
+            use_case.execute(group_id=999, user_id=42)
+
+    def test_get_analytics_raw_is_called_once(self):
+        repo = _StubChatRepository(_make_raw())
+        use_case = GetChatAnalyticsUseCase(
+            chat_repo=repo,
+            group_query_repo=_StubGroupRepository(_make_group()),
+        )
+        use_case.execute(group_id=1, user_id=42)
+        self.assertEqual(repo.analytics_raw_call_count, 1)

--- a/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AnalyticsDashboard.test.tsx
@@ -17,15 +17,6 @@ const analytics: ChatAnalytics = {
     total_questions: 24,
     date_range: { first: '2026-04-01T00:00:00Z', last: '2026-04-22T00:00:00Z' },
   },
-  scene_distribution: [
-    {
-      video_id: 1,
-      title: 'Scene title',
-      start_time: '00:00:10',
-      end_time: '00:00:20',
-      question_count: 3,
-    },
-  ],
   time_series: [],
   feedback: { good: 1, bad: 0, none: 23 },
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,13 +134,6 @@ export interface ChatAnalytics {
     total_questions: number;
     date_range: { first?: string; last?: string };
   };
-  scene_distribution: {
-    video_id: number;
-    title: string;
-    start_time: string;
-    end_time: string;
-    question_count: number;
-  }[];
   time_series: { date: string; count: number }[];
   feedback: { good: number; bad: number; none: number };
 }


### PR DESCRIPTION
## Summary

Closes #706

- 初期 analytics 経路から `scene_distribution` 集計を完全に除去
- `get_analytics_raw()` 内の citations 全件スキャンループを削除
- `ChatAnalyticsRaw.logs_for_scenes`、`ChatAnalyticsDTO.scene_distribution`、`SceneDistributionItemDTO` を削除
- シリアライザ・ビューのレスポンスから `scene_distribution` フィールドを削除
- フロントエンドの `ChatAnalytics` 型・テストフィクスチャを更新

## Test plan

- [x] `test_get_analytics.py`（新規）: DTOに `scene_distribution` が存在しないこと、`get_analytics_raw` が1回だけ呼ばれること、グループ未存在時に `ResourceNotFound` が送出されること
- [x] `test_new_urls.py`: `scene_distribution` がレスポンスに含まれないことを追加アサート
- [x] `AnalyticsDashboard.test.tsx`: `scene_distribution` を除いたフィクスチャで全5テスト通過
- [x] バックエンド全体 1105テスト（既存の無関係な2件を除き全通過）
- [x] フロントエンド全体 533テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)