### PR TITLE
fix: AppNav の認証状態取得をページ依存から切り離す (#714)

### DIFF
--- a/frontend/src/components/layout/AppNav.tsx
+++ b/frontend/src/components/layout/AppNav.tsx
@@ -23,7 +23,7 @@ export function AppNav({ activePage }: AppNavProps) {
 
   const authQuery = useQuery<User | null>({
     queryKey: queryKeys.auth.me,
-    queryFn: async () => (await apiClient.getMe()) ?? null,
+    queryFn: async () => await apiClient.getMeOrNull(),
     retry: false,
   });
   const isAuthenticated = !!authQuery.data;

--- a/frontend/src/components/layout/AppNav.tsx
+++ b/frontend/src/components/layout/AppNav.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 import { GraduationCap, LogOut, Menu, X, LogIn } from 'lucide-react';
 import { Link, useI18nNavigate } from '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient, type User } from '@/lib/api';
 import { APP_CONTAINER_CLASS } from '@/components/layout/layoutTokens';
 import { queryKeys } from '@/lib/queryKeys';
@@ -21,8 +21,12 @@ export function AppNav({ activePage }: AppNavProps) {
   const queryClient = useQueryClient();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
-  const cachedUser = queryClient.getQueryData<User | null>(queryKeys.auth.me);
-  const isAuthenticated = !!cachedUser;
+  const authQuery = useQuery<User | null>({
+    queryKey: queryKeys.auth.me,
+    queryFn: async () => (await apiClient.getMe()) ?? null,
+    retry: false,
+  });
+  const isAuthenticated = !!authQuery.data;
 
   const logoutMutation = useMutation({
     mutationFn: async () => await apiClient.logout(),

--- a/frontend/src/components/layout/__tests__/AppNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppNav.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/queryKeys'
+import { apiClient } from '@/lib/api'
 
 // Unmock AppNav so we can test the real implementation
 vi.unmock('@/components/layout/AppNav')
@@ -76,5 +77,25 @@ describe('AppNav - authenticated user (cache populated)', () => {
   it('shows docs nav link', () => {
     renderWithUser(<AppNav />)
     expect(screen.getByText('navigation.docs')).toBeInTheDocument()
+  })
+})
+
+describe('AppNav - auth cache uninitialized (fetches from API)', () => {
+  it('shows authenticated menu after fetching user from API when cache is empty', async () => {
+    ;(apiClient.getMe as ReturnType<typeof vi.fn>).mockResolvedValue({ id: '1', username: 'testuser' })
+    render(<AppNav />)
+    await waitFor(() => {
+      expect(screen.getByText('navigation.videosNav')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('auth.login.submit')).not.toBeInTheDocument()
+  })
+
+  it('shows login button when API returns null and cache is empty', async () => {
+    ;(apiClient.getMe as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+    render(<AppNav />)
+    await waitFor(() => {
+      expect(screen.getByText('auth.login.submit')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('navigation.videosNav')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/layout/__tests__/AppNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppNav.test.tsx
@@ -81,8 +81,17 @@ describe('AppNav - authenticated user (cache populated)', () => {
 })
 
 describe('AppNav - auth cache uninitialized (fetches from API)', () => {
+  it('uses getMeOrNull (no redirect side effects) instead of getMe', async () => {
+    render(<AppNav />)
+    await waitFor(() => {
+      expect(screen.getByText('navigation.videosNav')).toBeInTheDocument()
+    })
+    expect(apiClient.getMe).not.toHaveBeenCalled()
+    expect(apiClient.getMeOrNull).toHaveBeenCalled()
+  })
+
   it('shows authenticated menu after fetching user from API when cache is empty', async () => {
-    ;(apiClient.getMe as ReturnType<typeof vi.fn>).mockResolvedValue({ id: '1', username: 'testuser' })
+    ;(apiClient.getMeOrNull as ReturnType<typeof vi.fn>).mockResolvedValue({ id: '1', username: 'testuser' })
     render(<AppNav />)
     await waitFor(() => {
       expect(screen.getByText('navigation.videosNav')).toBeInTheDocument()
@@ -91,7 +100,7 @@ describe('AppNav - auth cache uninitialized (fetches from API)', () => {
   })
 
   it('shows login button when API returns null and cache is empty', async () => {
-    ;(apiClient.getMe as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+    ;(apiClient.getMeOrNull as ReturnType<typeof vi.fn>).mockResolvedValue(null)
     render(<AppNav />)
     await waitFor(() => {
       expect(screen.getByText('auth.login.submit')).toBeInTheDocument()


### PR DESCRIPTION
## 背景

PR #713 で `VideoGroupDetailPage` に `AppNav` を導入した際、直リンク/リロード時に `queryKeys.auth.me` のキャッシュが未初期化だと、認証済みCookieがあっても `AppNav` が未ログイン扱いになる問題がありました。
暫定対応として各ページが `useAuth()` を呼んでキャッシュを埋める構造になっており、ページが増えるほど再発しやすい状態でした。

## 変更内容

### `AppNav.tsx`

| | 変更前 | 変更後 |
|---|---|---|
| auth 状態の取得 | `queryClient.getQueryData()` (同期キャッシュ読み取りのみ) | `useQuery` + `getMeOrNull()` で自前 fetch・購読 |
| 未認証時の挙動 | キャッシュが空なら未ログイン表示（fetch なし） | `getMeOrNull()` が `null` を返すだけ（リダイレクト副作用なし） |

- `getMe()` ではなく `getMeOrNull()` を使用することで、公開ページで未ログインユーザーが `/login` に飛ばされる回帰を防止

### `AppNav.test.tsx`

- `AppNav - auth cache uninitialized` describe を追加
  - `getMeOrNull` が呼ばれること・`getMe` が呼ばれないことを検証
  - キャッシュ未初期化でも API から取得後に認証済みメニューが表示されることをカバー
  - API が `null` を返した場合は Login ボタンを表示することをカバー

## 受け入れ条件の充足

- [x] 認証済みユーザーが `/videos/groups/:id` などの `AppNav` 使用ページを直リンク/リロードしても、`AppNav` が認証済みメニューを表示する
- [x] 各ページが `AppNav` のためだけに `useAuth()` を呼ぶ必要がない
- [x] 未認証ユーザー向けのリダイレクト挙動は既存仕様を維持（`useAuth()` 側は変更なし）
- [x] `AppNav` のテストで auth cache 未初期化時の表示がカバーされている

## テスト

```
✓ src/components/layout/__tests__/AppNav.test.tsx (13 tests)
✓ Test Files 55 passed | Tests 536 passed
```

Closes #714