### PR TITLE
refactor(video-groups): 動画追加ボタンのラベルを短縮

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -412,7 +412,7 @@
       "videoListEmpty": "No videos yet",
       "videoCount": "{{count}} videos",
       "nextVideo": "Next video:",
-      "addVideoButton": "Add video",
+      "addVideoButton": "Add",
       "backToGroups": "Back to groups",
       "editTitle": "Edit group",
       "editDescription": "Update the group name and description.",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -412,7 +412,7 @@
       "videoListEmpty": "動画がありません",
       "videoCount": "全{{count}}本",
       "nextVideo": "次の動画:",
-      "addVideoButton": "動画を追加",
+      "addVideoButton": "追加",
       "backToGroups": "グループ一覧",
       "editTitle": "グループを編集",
       "editDescription": "グループ名と説明を更新します。",


### PR DESCRIPTION
## Summary
- グループ詳細画面の「動画を追加」/「Add video」ボタンのラベルを「追加」/「Add」に短縮
- 同ボタンは + アイコン付きで、グループ詳細画面というコンテキストから「動画を」は自明なため冗長性を解消

## Test plan
- [ ] グループ詳細画面でデスクトップ表示: + アイコン + 「追加」/「Add」が表示される
- [ ] モバイル表示: アイコンのみ表示される (`hidden sm:inline` の挙動は変更なし)
- [ ] ja / en それぞれで表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)