### PR TITLE
fix: 詳細画面の再取得時に全画面ローディングへ戻る挙動を改善する

### DIFF
--- a/frontend/src/hooks/__tests__/useAuth.test.ts
+++ b/frontend/src/hooks/__tests__/useAuth.test.ts
@@ -116,6 +116,32 @@ describe('useAuth', () => {
     expect(onAuthError).toHaveBeenCalled()
   })
 
+  it('should keep isLoading false when background-refetching cached user', async () => {
+    const mockUser = { id: 1, username: 'testuser' }
+    ;(apiClient.getMe as any).mockResolvedValueOnce(mockUser)
+
+    const { result } = renderHook(() => useAuth())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.user).toEqual(mockUser)
+    })
+
+    // Hang the next fetch to simulate background refetch with cached data
+    ;(apiClient.getMe as any).mockReturnValueOnce(new Promise(() => {}))
+
+    void result.current.refetch()
+
+    // Wait for the refetch to have started (API called twice)
+    await waitFor(() => {
+      expect(apiClient.getMe).toHaveBeenCalledTimes(2)
+    })
+
+    // isLoading should remain false — cached data is displayed, no full-screen spinner
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.user).toEqual(mockUser)
+  })
+
   it('should refetch user data', async () => {
     const mockUser = { id: 1, username: 'testuser' }
     ;(apiClient.getMe as any).mockResolvedValue(mockUser)

--- a/frontend/src/hooks/__tests__/useVideos.test.ts
+++ b/frontend/src/hooks/__tests__/useVideos.test.ts
@@ -19,6 +19,34 @@ describe('useVideos', () => {
     window.history.pushState({}, '', '/')
   })
 
+  it('should keep isLoading false when background-refetching cached video list', async () => {
+    const mockVideos = [
+      { id: 1, title: 'Video 1', user: 1, file: '', uploaded_at: '', status: 'completed' as const },
+    ]
+    ;(apiClient.getVideos as any).mockResolvedValueOnce(mockVideos)
+
+    const { result } = renderHook(() => useVideos())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.videos).toEqual(mockVideos)
+    })
+
+    // Hang the next fetch to simulate background refetch with cached data
+    ;(apiClient.getVideos as any).mockReturnValueOnce(new Promise(() => {}))
+
+    void result.current.refetch()
+
+    // Wait for the refetch to have started (API called twice)
+    await waitFor(() => {
+      expect(apiClient.getVideos).toHaveBeenCalledTimes(2)
+    })
+
+    // isLoading should remain false — cached data is displayed, no full-screen spinner
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.videos).toEqual(mockVideos)
+  })
+
   it('should initialize with empty videos array', () => {
     ;(apiClient.getVideos as any).mockReturnValue(new Promise(() => {}))
     const { result } = renderHook(() => useVideos())
@@ -73,6 +101,41 @@ describe('useVideo', () => {
     vi.clearAllMocks()
     ;(globalThis as any).__setMockPathname?.('/')
     window.history.pushState({}, '', '/')
+  })
+
+  it('should keep isLoading false when background-refetching cached video', async () => {
+    const mockVideo = {
+      id: 1,
+      title: 'Test Video',
+      user: 1,
+      file: '',
+      uploaded_at: '',
+      status: 'completed' as const,
+    }
+    ;(apiClient.isAuthenticated as any).mockResolvedValue(true)
+    ;(apiClient.getVideo as any).mockResolvedValueOnce(mockVideo)
+
+    const { result } = renderHook(() => useVideo(1))
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.video).toEqual(mockVideo)
+    })
+
+    // Hang the next fetch to simulate background refetch with cached data
+    ;(apiClient.isAuthenticated as any).mockResolvedValue(true)
+    ;(apiClient.getVideo as any).mockReturnValueOnce(new Promise(() => {}))
+
+    void result.current.refetch()
+
+    // Wait for the refetch to have started (API called twice)
+    await waitFor(() => {
+      expect(apiClient.getVideo).toHaveBeenCalledTimes(2)
+    })
+
+    // isLoading should remain false — cached data is displayed, no full-screen spinner
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.video).toEqual(mockVideo)
   })
 
   it('should initialize with null video', () => {

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -82,7 +82,7 @@ export function useAuth(options: UseAuthOptions = {}): UseAuthReturn {
 
   return {
     user: authRequired ? authQuery.data ?? null : null,
-    isLoading: authRequired ? (authQuery.isLoading || authQuery.isFetching) : false,
+    isLoading: authRequired ? authQuery.isLoading : false,
     refetch: checkAuth,
   };
 }

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -36,7 +36,7 @@ export function useVideos(tagIds?: number[]): UseVideosReturn {
 
   return {
     videos: videosQuery.data || [],
-    isLoading: videosQuery.isLoading || videosQuery.isFetching,
+    isLoading: videosQuery.isLoading,
     error: videosQuery.error instanceof Error ? videosQuery.error.message : null,
     loadVideos: handleRefetch,
     refetch: handleRefetch,
@@ -99,7 +99,7 @@ export function useVideo(videoId: number | null): UseVideoReturn {
 
   return {
     video: videoQuery.data || null,
-    isLoading: (!!videoId && authQuery.isLoading) || videoQuery.isLoading || videoQuery.isFetching,
+    isLoading: (!!videoId && authQuery.isLoading) || videoQuery.isLoading,
     error: videoQuery.error instanceof Error ? videoQuery.error.message : null,
     loadVideo: handleLoadVideo,
     refetch: handleLoadVideo,

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -92,7 +92,7 @@ export default function SharePage() {
   const groupQuery = useSharedGroupQuery(shareToken);
   const group = groupQuery.data ?? null;
   const error = groupQuery.error ? t('common.messages.shareLoadFailed') : null;
-  const isLoading = groupQuery.isLoading || groupQuery.isFetching;
+  const isLoading = groupQuery.isLoading;
 
   const handleVideoSelect = useCallback((videoId: number) => {
     setSelectedVideoId(videoId);

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -433,7 +433,7 @@ export default function VideoGroupDetailPage() {
 
   useAuth();
 
-  const { group, isLoading: groupIsLoading, isFetching: groupIsFetching, errorMessage: error } =
+  const { group, isLoading: groupIsLoading, errorMessage: error } =
     useVideoGroupDetailQuery(groupId);
 
   const [isDeleting, setIsDeleting] = useState(false);

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -533,7 +533,7 @@ export default function VideoGroupDetailPage() {
     }
   };
 
-  const isLoading = groupIsLoading || groupIsFetching;
+  const isLoading = groupIsLoading;
   const isUpdating = updateGroupMutation.isPending;
   const updateError = updateGroupMutation.error instanceof Error ? updateGroupMutation.error.message : null;
 

--- a/frontend/src/pages/__tests__/SharePage.background.test.tsx
+++ b/frontend/src/pages/__tests__/SharePage.background.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import SharePage from '../SharePage'
+import { useSharedGroupQuery } from '@/hooks/useSharePageData'
+
+const mockGroup = {
+  id: 1,
+  name: 'Shared Group',
+  description: 'Shared Description',
+  videos: [
+    { id: 1, title: 'Shared Video 1', description: '', status: 'completed', file: 'video1.mp4', source_type: 'uploaded' as const, order: 0 },
+  ],
+}
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ token: 'test-share-token' }),
+  }
+})
+
+vi.mock('@/hooks/useSharePageData', () => ({
+  useSharedGroupQuery: vi.fn(),
+}))
+
+vi.mock('@/components/chat/ChatPanel', () => ({
+  ChatPanel: () => null,
+}))
+
+describe('SharePage - background refetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
+  it('should show content (not full-screen spinner) when isFetching=true but isLoading=false', async () => {
+    // Simulate background refetch: cached data available but fetch in progress
+    ;(useSharedGroupQuery as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: mockGroup,
+      isLoading: false,
+      isFetching: true,
+      error: null,
+    })
+
+    render(<SharePage />)
+
+    // Content should be visible — not replaced by full-screen spinner
+    await waitFor(() => {
+      expect(screen.getByText('Shared Group')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.background.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.background.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import VideoGroupDetailPage from '../VideoGroupDetailPage'
+import { useVideoGroupDetailQuery } from '@/hooks/useVideoGroupDetailData'
+
+const mockGroup = {
+  id: 1,
+  name: 'Test Group',
+  description: 'Test Description',
+  share_slug: null,
+  videos: [],
+}
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ id: '1' }),
+  }
+})
+
+vi.mock('@/hooks/useVideoGroupDetailData', async (importActual) => {
+  const actual = await importActual<typeof import('@/hooks/useVideoGroupDetailData')>()
+  return {
+    ...actual,
+    useVideoGroupDetailQuery: vi.fn(),
+  }
+})
+
+vi.mock('@/hooks/useTags', () => ({
+  useTags: () => ({ tags: [] }),
+}))
+
+vi.mock('@/components/chat/ChatPanel', () => ({
+  ChatPanel: () => null,
+}))
+
+vi.mock('@/components/video/TagFilterPanel', () => ({
+  TagFilterPanel: () => null,
+}))
+
+vi.mock('@/components/video/TagManagementModal', () => ({
+  TagManagementModal: () => null,
+}))
+
+describe('VideoGroupDetailPage - background refetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    globalThis.__setMockLanguage('en')
+  })
+
+  it('should show content (not full-screen spinner) when isFetching=true but isLoading=false', async () => {
+    // Simulate background refetch: cached data available but fetch in progress
+    ;(useVideoGroupDetailQuery as ReturnType<typeof vi.fn>).mockReturnValue({
+      group: mockGroup,
+      isLoading: false,
+      isFetching: true,
+      errorMessage: null,
+    })
+
+    render(<VideoGroupDetailPage />)
+
+    // Group name should be visible — content preserved, no full-screen spinner
+    await waitFor(() => {
+      expect(screen.getByText('Test Group')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
closes #721

## Summary

- `isFetching` を `isLoading` に混入していたため、バックグラウンド再取得のたびに全画面スピナーが表示される問題を修正
- `isLoading` は「表示できるデータがまだない初回ロード」のみに絞り、再取得中はキャッシュ済みコンテンツを維持するよう統一

## Changes

| ファイル | 修正内容 |
|---|---|
| `hooks/useVideos.ts` | `useVideos` / `useVideo` の `isLoading` から `isFetching` を除去 |
| `hooks/useAuth.ts` | `isLoading` から `isFetching` を除去 |
| `pages/VideoGroupDetailPage.tsx` | `groupIsLoading \|\| groupIsFetching` → `groupIsLoading` |
| `pages/SharePage.tsx` | `groupQuery.isLoading \|\| groupQuery.isFetching` → `groupQuery.isLoading` |

## Test plan

- [ ] `useVideos` / `useVideo` hookテスト: キャッシュ済みデータ + 再取得中でも `isLoading=false` を維持することを確認
- [ ] `useAuth` hookテスト: 同上
- [ ] `VideoGroupDetailPage.background.test.tsx`: `isFetching=true, isLoading=false` の時にグループ名が表示される（全画面スピナーにならない）ことを確認
- [ ] `SharePage.background.test.tsx`: 同上
- [ ] 既存テスト 543件すべてパス (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)