### PR TITLE
動画詳細・グループ詳細画面のUIを整理する

### DIFF
--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -17,7 +17,7 @@ import { queryKeys } from '@/lib/queryKeys';
 import type { Tag } from '@/lib/api';
 import { AppNav } from '@/components/layout/AppNav';
 import {
-  ArrowLeft, Calendar, CheckCircle, Search, ChevronRight,
+  ArrowLeft, Calendar, CheckCircle, Search,
   Trash2, Pencil, X, Save, Video as VideoIcon,
   Play, AlignLeft,
 } from 'lucide-react';
@@ -351,30 +351,9 @@ export default function VideoDetailPage() {
         {/* ── Header ───────────────────────────────────────────────────────── */}
         <AppNav activePage="videos" />
 
-        {/* ── Sub-header: Breadcrumb + Actions ─────────────────────────────── */}
-        <div className="fixed top-16 w-full z-40 bg-white border-b border-stone-100">
-          <div className="max-w-screen-xl mx-auto w-full px-6 lg:px-8 flex justify-between items-center h-14">
-            <div className="flex items-center gap-2 min-w-0">
-              <button
-                onClick={() => navigate('/videos')}
-                className="p-1 rounded-lg hover:bg-stone-100 transition-all shrink-0"
-              >
-                <ArrowLeft className="w-4 h-4 text-[#3f493f]" />
-              </button>
-              <Link href="/videos" className="text-sm text-stone-400 hover:text-[#00652c] transition-colors shrink-0">
-                {t('videos.detail.videosBreadcrumb')}
-              </Link>
-              <ChevronRight className="w-3.5 h-3.5 text-stone-300 shrink-0" />
-              <span className="text-sm font-bold text-[#00652c] truncate">
-                {video.title}
-              </span>
-            </div>
-          </div>
-        </div>
-
         {/* ── Mobile tabs ───────────────────────────────────────────────────── */}
         {isMobile && (
-          <div className="mt-[112px] flex border-b border-stone-200 bg-white shrink-0">
+          <div className="mt-16 flex border-b border-stone-200 bg-white shrink-0">
             <button
               onClick={() => setMobileTab('video')}
               className={`flex-1 flex items-center justify-center gap-2 py-3 text-sm font-semibold transition-colors ${
@@ -402,10 +381,11 @@ export default function VideoDetailPage() {
 
         {/* ── Main Content ──────────────────────────────────────────────────── */}
         <main
-          className={`flex-grow max-w-screen-xl mx-auto w-full px-6 lg:px-8 py-6 grid grid-cols-1 lg:grid-cols-12 gap-6 ${
-            isMobile ? 'mt-0' : 'mt-[112px]'
+          className={`flex-grow max-w-screen-xl mx-auto w-full px-6 lg:px-8 py-6 flex flex-col gap-6 ${
+            isMobile ? 'mt-0' : 'mt-16'
           }`}
         >
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
           {/* ── Left Column: Video + Info ──────────────────────────────────── */}
           <div
             className={`lg:col-span-8 flex flex-col gap-4 ${
@@ -567,7 +547,7 @@ export default function VideoDetailPage() {
           {/* ── Right Column: Transcript ───────────────────────────────────── */}
           <div
             className={`lg:col-span-4 flex flex-col bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] ${
-              isMobile ? 'min-h-[500px]' : 'h-[calc(100vh-120px)] sticky top-[120px]'
+              isMobile ? 'min-h-[500px]' : 'h-[calc(100vh-64px)] sticky top-16'
             } ${isMobile && mobileTab !== 'transcript' ? 'hidden' : ''}`}
           >
             {/* Transcript Header */}
@@ -693,6 +673,7 @@ export default function VideoDetailPage() {
                 )}
               </div>
             )}
+          </div>
           </div>
         </main>
 

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -657,7 +657,7 @@ export default function VideoGroupDetailPage() {
           <aside className={`lg:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
             <div className="bg-white rounded-xl flex flex-col h-full overflow-hidden shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
               <div className="p-4 border-b border-stone-100 flex items-center justify-between gap-2 shrink-0">
-                <h2 className="font-extrabold text-[#191c19] truncate">{group.name}</h2>
+                <h2 className="font-extrabold text-[#191c19] truncate flex-1 min-w-0">{group.name}</h2>
                 <div className="flex items-center gap-2 shrink-0">
                   <span className="text-xs bg-[#f2f4ef] px-2 py-0.5 rounded-full text-[#6f7a6e] font-medium">
                     {t('videos.groupDetail.videoCount', { count: group.videos?.length ?? 0 })}

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -45,7 +45,7 @@ import {
 import { TagFilterPanel } from '@/components/video/TagFilterPanel';
 import { AppNav } from '@/components/layout/AppNav';
 import {
-  ArrowLeft, ChevronRight, Plus, GripVertical,
+  ArrowLeft, Plus, GripVertical,
   CheckCircle, Clock, AlertCircle, Copy, Trash2,
   Pencil, List, Play,
   Save, X,
@@ -582,51 +582,6 @@ export default function VideoGroupDetailPage() {
       {/* ── Header ───────────────────────────────────────────────────────── */}
       <AppNav activePage="groups" />
 
-      {/* ── Sub-header: Breadcrumb + Actions ─────────────────────────────── */}
-      <div className="fixed top-16 w-full z-40 bg-white border-b border-stone-100">
-        <div className="max-w-screen-xl mx-auto w-full px-6 lg:px-8 flex justify-between items-center h-14">
-          <div className="flex items-center gap-2 min-w-0">
-            <button
-              onClick={() => navigate('/videos/groups')}
-              className="p-1 rounded-lg hover:bg-stone-100 transition-all shrink-0"
-            >
-              <ArrowLeft className="w-4 h-4 text-[#3f493f]" />
-            </button>
-            <Link href="/videos/groups" className="text-sm text-stone-400 hover:text-[#00652c] transition-colors shrink-0">
-              {t('videos.groupDetail.breadcrumbGroups')}
-            </Link>
-            <ChevronRight className="w-3.5 h-3.5 text-stone-300 shrink-0" />
-            <span className="text-sm font-bold text-[#00652c] truncate">
-              {group.name}
-            </span>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <button
-              onClick={() => setIsAddModalOpen(true)}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-white border border-[#e1e3de] hover:bg-[#f2f4ef] transition-colors text-[#191c19] text-xs font-bold shadow-sm"
-            >
-              <Plus className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">{t('videos.groupDetail.addVideoButton')}</span>
-            </button>
-            <button
-              onClick={() => setIsEditing(true)}
-              className="p-2 text-[#3f493f] hover:bg-stone-100 rounded-full transition-colors"
-              title={t('videos.groupDetail.editTitle')}
-            >
-              <Pencil className="w-4 h-4" />
-            </button>
-            <button
-              onClick={handleDelete}
-              disabled={isDeleting}
-              className="p-2 text-red-500 hover:bg-red-50 rounded-full transition-colors disabled:opacity-50"
-              title={t('videos.groupDetail.delete')}
-            >
-              {isDeleting ? <InlineSpinner className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
-            </button>
-          </div>
-        </div>
-      </div>
-
       {/* ── Edit Dialog ──────────────────────────────────────────────────── */}
       <Dialog open={isEditing} onOpenChange={(open) => !open && handleCancelEdit()}>
         <DialogContent className="max-w-md">
@@ -683,7 +638,7 @@ export default function VideoGroupDetailPage() {
       </Dialog>
 
       {/* ── Main ─────────────────────────────────────────────────────────── */}
-      <main className="mt-[112px] flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-4 lg:h-[calc(100dvh-112px)] lg:overflow-hidden">
+      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-4 lg:h-[calc(100dvh-64px)] lg:overflow-hidden">
         {/* Share link panel */}
         <ShareLinkPanel
           shareSlug={group.share_slug ?? ''}
@@ -702,11 +657,33 @@ export default function VideoGroupDetailPage() {
           <aside className={`lg:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
             <div className="bg-white rounded-xl flex flex-col h-full overflow-hidden shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
               <div className="p-4 border-b border-stone-100 flex items-center justify-between gap-2 shrink-0">
-                <h2 className="font-extrabold text-[#191c19]">{t('videos.groupDetail.videoListTitle')}</h2>
+                <h2 className="font-extrabold text-[#191c19] truncate">{group.name}</h2>
                 <div className="flex items-center gap-2 shrink-0">
                   <span className="text-xs bg-[#f2f4ef] px-2 py-0.5 rounded-full text-[#6f7a6e] font-medium">
                     {t('videos.groupDetail.videoCount', { count: group.videos?.length ?? 0 })}
                   </span>
+                  <button
+                    onClick={() => setIsAddModalOpen(true)}
+                    className="flex items-center gap-1 px-2 py-1 rounded-lg bg-white border border-[#e1e3de] hover:bg-[#f2f4ef] transition-colors text-[#191c19] text-xs font-bold shadow-sm"
+                  >
+                    <Plus className="w-3.5 h-3.5" />
+                    <span className="hidden sm:inline">{t('videos.groupDetail.add')}</span>
+                  </button>
+                  <button
+                    onClick={() => setIsEditing(true)}
+                    className="p-1.5 text-[#3f493f] hover:bg-stone-100 rounded-lg transition-colors"
+                    title={t('videos.groupDetail.editTitle')}
+                  >
+                    <Pencil className="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    onClick={handleDelete}
+                    disabled={isDeleting}
+                    className="p-1.5 text-red-500 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+                    title={t('videos.groupDetail.delete')}
+                  >
+                    {isDeleting ? <InlineSpinner className="w-3.5 h-3.5" /> : <Trash2 className="w-3.5 h-3.5" />}
+                  </button>
                 </div>
               </div>
               <div className="flex-1 overflow-y-auto p-2 space-y-1">

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -97,12 +97,6 @@ describe('VideoDetailPage', () => {
     expect(screen.getByText('videos.detail.deleteButton')).toBeInTheDocument()
   })
 
-  it('should not render a back to list button', () => {
-    render(<VideoDetailPage />)
-
-    expect(screen.queryByLabelText('common.actions.backToList')).not.toBeInTheDocument()
-  })
-
   it('should not render breadcrumb text', () => {
     render(<VideoDetailPage />)
 

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -97,10 +97,16 @@ describe('VideoDetailPage', () => {
     expect(screen.getByText('videos.detail.deleteButton')).toBeInTheDocument()
   })
 
-  it('should render back to list button', () => {
+  it('should not render a back to list button', () => {
     render(<VideoDetailPage />)
 
-    expect(screen.getByText('videos.detail.videosBreadcrumb')).toBeInTheDocument()
+    expect(screen.queryByLabelText('common.actions.backToList')).not.toBeInTheDocument()
+  })
+
+  it('should not render breadcrumb text', () => {
+    render(<VideoDetailPage />)
+
+    expect(screen.queryByText('videos.detail.videosBreadcrumb')).not.toBeInTheDocument()
   })
 
   it('should render transcript when available', () => {
@@ -125,6 +131,11 @@ describe('VideoDetailPage', () => {
     expect(mockLoadVideo).not.toHaveBeenCalled()
   })
 
+  it('should not render a fixed sub-header below the nav', () => {
+    const { container } = render(<VideoDetailPage />)
+    const subHeader = container.querySelector('.fixed.top-16.z-40')
+    expect(subHeader).toBeNull()
+  })
 
 })
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -103,16 +103,28 @@ describe('VideoGroupDetailPage', () => {
     render(<VideoGroupDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('videos.groupDetail.addVideoButton')).toBeInTheDocument()
+      expect(screen.getByText('videos.groupDetail.add')).toBeInTheDocument()
     })
   })
 
-  it('should render back to list button', async () => {
+  it('should not render a back to list button', async () => {
     render(<VideoGroupDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('videos.groupDetail.breadcrumbGroups')).toBeInTheDocument()
+      expect(screen.getByText('Test Group')).toBeInTheDocument()
     })
+
+    expect(screen.queryByLabelText('common.actions.backToList')).not.toBeInTheDocument()
+  })
+
+  it('should not render breadcrumb text', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Group')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('videos.groupDetail.breadcrumbGroups')).not.toBeInTheDocument()
   })
 
   it('should render delete button', async () => {
@@ -167,6 +179,15 @@ describe('VideoGroupDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByText('common.actions.save')).toBeInTheDocument()
     })
+  })
+
+  it('should not render a fixed sub-header below the nav', async () => {
+    const { container } = render(<VideoGroupDetailPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Test Group')).toBeInTheDocument()
+    })
+    const subHeader = container.querySelector('.fixed.top-16.z-40')
+    expect(subHeader).toBeNull()
   })
 
   it('should not autoplay youtube video on initial render', async () => {

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -107,16 +107,6 @@ describe('VideoGroupDetailPage', () => {
     })
   })
 
-  it('should not render a back to list button', async () => {
-    render(<VideoGroupDetailPage />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Test Group')).toBeInTheDocument()
-    })
-
-    expect(screen.queryByLabelText('common.actions.backToList')).not.toBeInTheDocument()
-  })
-
   it('should not render breadcrumb text', async () => {
     render(<VideoGroupDetailPage />)
 


### PR DESCRIPTION
## Summary
- 動画詳細画面をAppNavベースのレイアウトに統一し、動画情報・編集フォーム・文字起こしパネルの配置を整理
- グループ詳細画面の独自ヘッダーを廃止し、追加・編集・削除操作を動画一覧ヘッダーへ集約
- AppNavが認証キャッシュ未初期化時にも現在ユーザーを取得するようにして、公開ページからの遷移時の表示回帰を修正

## Tests
- npm test -- AppNav.test.tsx VideoDetailPage.test.tsx VideoGroupDetailPage.test.tsx