### PR TITLE
feat: 動画詳細とグループ詳細の編集・削除UI/挙動を統一する

### DIFF
--- a/frontend/src/hooks/useVideoDetailPageData.ts
+++ b/frontend/src/hooks/useVideoDetailPageData.ts
@@ -5,6 +5,7 @@ import { queryKeys } from '@/lib/queryKeys';
 interface UseVideoDetailPageMutationsParams {
   videoId: number | null;
   onDeleteSuccess: () => void;
+  onDeleteError?: (err: unknown) => void;
   onUpdate: () => Promise<void>;
   onUpdateSuccess: () => void;
 }
@@ -12,6 +13,7 @@ interface UseVideoDetailPageMutationsParams {
 export function useVideoDetailPageMutations({
   videoId,
   onDeleteSuccess,
+  onDeleteError,
   onUpdate,
   onUpdateSuccess,
 }: UseVideoDetailPageMutationsParams) {
@@ -34,6 +36,9 @@ export function useVideoDetailPageMutations({
       await queryClient.invalidateQueries({ queryKey: ['popularScenes'] });
       onDeleteSuccess();
     },
+    onError: (err) => {
+      onDeleteError?.(err);
+    },
   });
 
   const updateMutation = useMutation({
@@ -44,6 +49,9 @@ export function useVideoDetailPageMutations({
       onUpdateSuccess();
       if (videoId) {
         await queryClient.invalidateQueries({ queryKey: queryKeys.videos.detail(videoId) });
+        await queryClient.invalidateQueries({ queryKey: queryKeys.videos.all });
+        await queryClient.invalidateQueries({ queryKey: ['videoGroup'] });
+        await queryClient.invalidateQueries({ queryKey: ['sharedVideoGroup'] });
       }
     },
   });

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -17,7 +17,7 @@ import { queryKeys } from '@/lib/queryKeys';
 import type { Tag } from '@/lib/api';
 import { AppNav } from '@/components/layout/AppNav';
 import {
-  ArrowLeft, Calendar, CheckCircle, Search, ChevronRight,
+  ArrowLeft, Calendar, CheckCircle, Search,
   Trash2, Pencil, X, Save, Video as VideoIcon,
   Play, AlignLeft,
 } from 'lucide-react';
@@ -351,30 +351,9 @@ export default function VideoDetailPage() {
         {/* ── Header ───────────────────────────────────────────────────────── */}
         <AppNav activePage="videos" />
 
-        {/* ── Sub-header: Breadcrumb + Actions ─────────────────────────────── */}
-        <div className="fixed top-16 w-full z-40 bg-white border-b border-stone-100">
-          <div className="max-w-screen-xl mx-auto w-full px-6 lg:px-8 flex justify-between items-center h-14">
-            <div className="flex items-center gap-2 min-w-0">
-              <button
-                onClick={() => navigate('/videos')}
-                className="p-1 rounded-lg hover:bg-stone-100 transition-all shrink-0"
-              >
-                <ArrowLeft className="w-4 h-4 text-[#3f493f]" />
-              </button>
-              <Link href="/videos" className="text-sm text-stone-400 hover:text-[#00652c] transition-colors shrink-0">
-                {t('videos.detail.videosBreadcrumb')}
-              </Link>
-              <ChevronRight className="w-3.5 h-3.5 text-stone-300 shrink-0" />
-              <span className="text-sm font-bold text-[#00652c] truncate">
-                {video.title}
-              </span>
-            </div>
-          </div>
-        </div>
-
         {/* ── Mobile tabs ───────────────────────────────────────────────────── */}
         {isMobile && (
-          <div className="mt-[112px] flex border-b border-stone-200 bg-white shrink-0">
+          <div className="mt-16 flex border-b border-stone-200 bg-white shrink-0">
             <button
               onClick={() => setMobileTab('video')}
               className={`flex-1 flex items-center justify-center gap-2 py-3 text-sm font-semibold transition-colors ${
@@ -402,10 +381,11 @@ export default function VideoDetailPage() {
 
         {/* ── Main Content ──────────────────────────────────────────────────── */}
         <main
-          className={`flex-grow max-w-screen-xl mx-auto w-full px-6 lg:px-8 py-6 grid grid-cols-1 lg:grid-cols-12 gap-6 ${
-            isMobile ? 'mt-0' : 'mt-[112px]'
+          className={`flex-grow max-w-screen-xl mx-auto w-full px-6 lg:px-8 py-6 flex flex-col gap-6 ${
+            isMobile ? 'mt-0' : 'mt-16'
           }`}
         >
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
           {/* ── Left Column: Video + Info ──────────────────────────────────── */}
           <div
             className={`lg:col-span-8 flex flex-col gap-4 ${
@@ -567,7 +547,7 @@ export default function VideoDetailPage() {
           {/* ── Right Column: Transcript ───────────────────────────────────── */}
           <div
             className={`lg:col-span-4 flex flex-col bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] ${
-              isMobile ? 'min-h-[500px]' : 'h-[calc(100vh-120px)] sticky top-[120px]'
+              isMobile ? 'min-h-[500px]' : 'h-[calc(100vh-64px)] sticky top-16'
             } ${isMobile && mobileTab !== 'transcript' ? 'hidden' : ''}`}
           >
             {/* Transcript Header */}
@@ -693,6 +673,7 @@ export default function VideoDetailPage() {
                 )}
               </div>
             )}
+          </div>
           </div>
         </main>
 

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -168,6 +168,11 @@ export default function VideoDetailPage() {
   const isUpdating = updateMutation.isPending;
   const updateError = updateMutation.error instanceof Error ? updateMutation.error.message : null;
 
+  const handleCancelEdit = useCallback(() => {
+    cancelEditing();
+    updateMutation.reset();
+  }, [cancelEditing, updateMutation]);
+
   const transcriptUpdateMutation = useMutation({
     mutationFn: async () => {
       if (!videoId) return;
@@ -273,7 +278,7 @@ export default function VideoDetailPage() {
         <AppNav activePage="videos" />
 
         {/* ── Edit Modal ───────────────────────────────────────────────────── */}
-        <Dialog open={isEditing} onOpenChange={(open) => !open && cancelEditing()}>
+        <Dialog open={isEditing} onOpenChange={(open) => !open && handleCancelEdit()}>
           <DialogContent className="max-w-md">
             <DialogHeader>
               <DialogTitle>{t('videos.detail.editButton')}</DialogTitle>
@@ -321,7 +326,7 @@ export default function VideoDetailPage() {
             </div>
             <DialogFooter>
               <button
-                onClick={cancelEditing}
+                onClick={handleCancelEdit}
                 disabled={isUpdating}
                 className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] rounded-xl text-sm font-bold hover:bg-[#f2f4ef] transition-colors disabled:opacity-50"
               >

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -16,6 +16,7 @@ import { useVideoDetailPageMutations } from '@/hooks/useVideoDetailPageData';
 import { queryKeys } from '@/lib/queryKeys';
 import type { Tag } from '@/lib/api';
 import { AppNav } from '@/components/layout/AppNav';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import {
   ArrowLeft, Calendar, CheckCircle, Search,
   Trash2, Pencil, X, Save, Video as VideoIcon,
@@ -81,89 +82,6 @@ function getStatusClassName(status: string): string {
     case 'processing':return 'bg-[#ffdcc3] text-[#2f1500]';
     default:          return 'bg-gray-100 text-gray-500';
   }
-}
-
-// ── Inline edit form ──────────────────────────────────────────────────────────
-
-interface InlineEditFormProps {
-  editedTitle: string;
-  editedDescription: string;
-  editedTagIds: number[];
-  tags: Tag[];
-  isUpdating: boolean;
-  onTitleChange: (v: string) => void;
-  onDescriptionChange: (v: string) => void;
-  onTagToggle: (id: number) => void;
-  onCreateTag: () => void;
-  onSave: () => void;
-  onCancel: () => void;
-}
-
-function InlineEditForm({
-  editedTitle, editedDescription, editedTagIds, tags, isUpdating,
-  onTitleChange, onDescriptionChange, onTagToggle, onCreateTag, onSave, onCancel,
-}: InlineEditFormProps) {
-  const { t } = useTranslation();
-  return (
-    <div className="bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] p-6 flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <span className="text-xs font-bold text-[#6f7a6e] uppercase tracking-widest">{t('videos.detail.editMode')}</span>
-        <button onClick={onCancel} className="text-[#6f7a6e] hover:text-[#191c19] transition-colors">
-          <X className="w-4 h-4" />
-        </button>
-      </div>
-
-      <div className="space-y-1">
-        <label className="text-xs font-bold text-[#3f493f]">{t('videos.detail.editTitleLabel')}</label>
-        <input
-          type="text"
-          value={editedTitle}
-          onChange={(e) => onTitleChange(e.target.value)}
-          disabled={isUpdating}
-          className="w-full px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all"
-        />
-      </div>
-
-      <div className="space-y-1">
-        <label className="text-xs font-bold text-[#3f493f]">{t('videos.detail.editDescriptionLabel')}</label>
-        <textarea
-          value={editedDescription}
-          onChange={(e) => onDescriptionChange(e.target.value)}
-          disabled={isUpdating}
-          rows={4}
-          className="w-full px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all resize-none"
-        />
-      </div>
-
-      <div className="space-y-1">
-        <TagSelector
-          tags={tags}
-          selectedTagIds={editedTagIds}
-          onToggle={onTagToggle}
-          onCreateNew={onCreateTag}
-          disabled={isUpdating}
-        />
-      </div>
-
-      <div className="flex gap-2 pt-2">
-        <button
-          onClick={onSave}
-          disabled={isUpdating || !editedTitle.trim()}
-          className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-[#00652c] text-white text-sm font-bold rounded-xl hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {isUpdating ? <InlineSpinner className="w-3.5 h-3.5" /> : <Save className="w-3.5 h-3.5" />}
-          {isUpdating ? t('videos.detail.saving') : t('videos.detail.save')}
-        </button>
-        <button
-          onClick={onCancel}
-          disabled={isUpdating}
-          className="px-4 py-2.5 border border-[#e1e3de] text-[#3f493f] text-sm font-bold rounded-xl hover:bg-[#f2f4ef] transition-colors disabled:opacity-50"
-        >
-          {t('videos.detail.cancel')}
-        </button>
-      </div>
-    </div>
-  );
 }
 
 // ── Main page ─────────────────────────────────────────────────────────────────
@@ -237,15 +155,19 @@ export default function VideoDetailPage() {
 
   const youtubeStartSeconds = manualYoutubeStartSeconds ?? queryYoutubeStartSeconds;
 
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
   const { deleteMutation, updateMutation } = useVideoDetailPageMutations({
     videoId,
     onDeleteSuccess: () => navigate('/videos'),
     onUpdate: handleUpdateVideo,
     onUpdateSuccess: cancelEditing,
+    onDeleteError: (err) => setDeleteError(err instanceof Error ? err.message : String(err)),
   });
 
   const isDeleting = deleteMutation.isPending;
   const isUpdating = updateMutation.isPending;
+  const updateError = updateMutation.error instanceof Error ? updateMutation.error.message : null;
 
   const transcriptUpdateMutation = useMutation({
     mutationFn: async () => {
@@ -351,6 +273,74 @@ export default function VideoDetailPage() {
         {/* ── Header ───────────────────────────────────────────────────────── */}
         <AppNav activePage="videos" />
 
+        {/* ── Edit Modal ───────────────────────────────────────────────────── */}
+        <Dialog open={isEditing} onOpenChange={(open) => !open && cancelEditing()}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t('videos.detail.editButton')}</DialogTitle>
+              <DialogDescription>
+                {t('videos.detail.editDescriptionLabel')}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-2">
+              {updateError && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">{updateError}</div>
+              )}
+              <div className="space-y-1">
+                <label className="text-xs font-bold text-[#3f493f]">{t('videos.detail.editTitleLabel')}</label>
+                <input
+                  type="text"
+                  value={editedTitle}
+                  onChange={(e) => setEditedTitle(e.target.value)}
+                  disabled={isUpdating}
+                  className="w-full px-3 py-2.5 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all"
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-bold text-[#3f493f]">{t('videos.detail.editDescriptionLabel')}</label>
+                <textarea
+                  value={editedDescription}
+                  onChange={(e) => setEditedDescription(e.target.value)}
+                  disabled={isUpdating}
+                  rows={4}
+                  className="w-full px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all resize-none"
+                />
+              </div>
+              <div className="space-y-1">
+                <TagSelector
+                  tags={tags}
+                  selectedTagIds={editedTagIds}
+                  onToggle={(tagId) =>
+                    setEditedTagIds((prev) =>
+                      prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId],
+                    )
+                  }
+                  onCreateNew={() => setIsCreateDialogOpen(true)}
+                  disabled={isUpdating}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <button
+                onClick={cancelEditing}
+                disabled={isUpdating}
+                className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] rounded-xl text-sm font-bold hover:bg-[#f2f4ef] transition-colors disabled:opacity-50"
+              >
+                <X className="w-3.5 h-3.5" />
+                {t('common.actions.cancel')}
+              </button>
+              <button
+                onClick={() => updateMutation.mutate()}
+                disabled={isUpdating || !editedTitle.trim()}
+                className="flex items-center gap-1.5 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                {isUpdating ? <InlineSpinner className="w-3.5 h-3.5" /> : <Save className="w-3.5 h-3.5" />}
+                {isUpdating ? t('common.actions.saving') : t('common.actions.save')}
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
         {/* ── Mobile tabs ───────────────────────────────────────────────────── */}
         {isMobile && (
           <div className="mt-16 flex border-b border-stone-200 bg-white shrink-0">
@@ -421,127 +411,115 @@ export default function VideoDetailPage() {
               )}
             </div>
 
-            {/* Info Card / Edit Form */}
-            {isEditing ? (
-              <InlineEditForm
-                editedTitle={editedTitle}
-                editedDescription={editedDescription}
-                editedTagIds={editedTagIds}
-                tags={tags}
-                isUpdating={isUpdating}
-                onTitleChange={setEditedTitle}
-                onDescriptionChange={setEditedDescription}
-                onTagToggle={(tagId) =>
-                  setEditedTagIds((prev) =>
-                    prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId],
-                  )
-                }
-                onCreateTag={() => setIsCreateDialogOpen(true)}
-                onSave={() => void updateMutation.mutateAsync()}
-                onCancel={cancelEditing}
-              />
-            ) : (
-              <div className="bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] p-6 flex flex-col gap-4">
-                {/* Title + Status */}
-                <div className="flex justify-between items-start gap-4">
-                  <div>
-                    <h1 className="font-bold text-xl text-[#191c19] leading-tight mb-1">
-                      {video.title}
-                    </h1>
-                    <div className="flex items-center gap-2 text-sm text-[#6f7a6e]">
-                      <Calendar className="w-3.5 h-3.5 shrink-0" />
-                      <span>{formatDate(video.uploaded_at, 'full', locale)}</span>
-                    </div>
+            {/* Info Card */}
+            <div className="bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] p-6 flex flex-col gap-4">
+              {/* Title + Status */}
+              <div className="flex justify-between items-start gap-4">
+                <div>
+                  <h1 className="font-bold text-xl text-[#191c19] leading-tight mb-1">
+                    {video.title}
+                  </h1>
+                  <div className="flex items-center gap-2 text-sm text-[#6f7a6e]">
+                    <Calendar className="w-3.5 h-3.5 shrink-0" />
+                    <span>{formatDate(video.uploaded_at, 'full', locale)}</span>
                   </div>
-                  <span className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-bold ${statusClassName}`}>
-                    {video.status === 'completed' && <CheckCircle className="w-3 h-3" />}
-                    {t(`common.status.${video.status}`, video.status)}
-                  </span>
                 </div>
-
-                {/* Tags */}
-                {video.tags && video.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {video.tags.map((tag) => (
-                      <span
-                        key={tag.id}
-                        className="px-3 py-1 rounded-full text-[11px] font-bold uppercase"
-                        style={{ backgroundColor: `${tag.color}20`, color: tag.color }}
-                      >
-                        {tag.name}
-                      </span>
-                    ))}
-                  </div>
-                )}
-
-                {/* Status Pipeline (horizontal) */}
-                <div className="border-t border-[#e1e3de]/50 pt-4 flex items-center gap-3 flex-wrap">
-                  <span className="text-xs font-bold text-[#6f7a6e] uppercase tracking-widest shrink-0">
-                    {t('videos.detail.statusSection')}
-                  </span>
-                  {pipelineSteps.map(({ key, label, doneStatuses }, idx) => {
-                    const done = doneStatuses.includes(video.status);
-                    return (
-                      <div key={key} className="flex items-center gap-2">
-                        {idx > 0 && <div className="w-6 h-px bg-[#e1e3de]" />}
-                        <div className="flex items-center gap-1.5">
-                          <div
-                            className={`w-5 h-5 rounded-full flex items-center justify-center shrink-0 ${
-                              done ? 'bg-[#15803d]' : 'bg-[#e1e3de]'
-                            }`}
-                          >
-                            {done ? (
-                              <CheckCircle className="w-3 h-3 text-white" />
-                            ) : (
-                              <div className="w-1.5 h-1.5 rounded-full bg-[#becabc]" />
-                            )}
-                          </div>
-                          <span className={`text-xs font-semibold ${done ? 'text-[#191c19]' : 'text-[#becabc]'}`}>
-                            {label}
-                          </span>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-
-                {/* Error message */}
-                {video.error_message && (
-                  <div className="p-3 bg-red-50 border border-red-200 rounded-xl">
-                    <p className="text-xs text-red-700 leading-relaxed">{video.error_message}</p>
-                  </div>
-                )}
-
-                {/* Description */}
-                {video.description && (
-                  <div className="border-t border-[#e1e3de]/50 pt-4">
-                    <p className="text-sm text-[#3f493f] leading-relaxed">{video.description}</p>
-                  </div>
-                )}
-
-                {/* Actions */}
-                <div className="border-t border-[#e1e3de]/50 pt-4 flex items-center gap-2">
-                  <button
-                    onClick={startEditing}
-                    className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] text-[#3f493f] text-sm font-bold rounded-xl hover:bg-[#f2f4ef] transition-colors"
-                  >
-                    <Pencil className="w-3.5 h-3.5" />
-                    {t('videos.detail.editButton')}
-                  </button>
-                  <button
-                    onClick={() => {
-                      if (!window.confirm(t('confirmations.deleteVideo'))) return;
-                      void deleteMutation.mutateAsync();
-                    }}
-                    disabled={isDeleting}
-                    className="flex items-center gap-1.5 px-4 py-2 text-red-600 text-sm font-bold rounded-xl hover:bg-red-50 transition-colors disabled:opacity-50"
-                  >
-                    {isDeleting ? <InlineSpinner className="w-3.5 h-3.5" /> : <Trash2 className="w-3.5 h-3.5" />}
-                    {isDeleting ? t('common.actions.deleting') : t('videos.detail.deleteButton')}
-                  </button>
-                </div>
+                <span className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-bold ${statusClassName}`}>
+                  {video.status === 'completed' && <CheckCircle className="w-3 h-3" />}
+                  {t(`common.status.${video.status}`, video.status)}
+                </span>
               </div>
-            )}
+
+              {/* Tags */}
+              {video.tags && video.tags.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {video.tags.map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="px-3 py-1 rounded-full text-[11px] font-bold uppercase"
+                      style={{ backgroundColor: `${tag.color}20`, color: tag.color }}
+                    >
+                      {tag.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Status Pipeline (horizontal) */}
+              <div className="border-t border-[#e1e3de]/50 pt-4 flex items-center gap-3 flex-wrap">
+                <span className="text-xs font-bold text-[#6f7a6e] uppercase tracking-widest shrink-0">
+                  {t('videos.detail.statusSection')}
+                </span>
+                {pipelineSteps.map(({ key, label, doneStatuses }, idx) => {
+                  const done = doneStatuses.includes(video.status);
+                  return (
+                    <div key={key} className="flex items-center gap-2">
+                      {idx > 0 && <div className="w-6 h-px bg-[#e1e3de]" />}
+                      <div className="flex items-center gap-1.5">
+                        <div
+                          className={`w-5 h-5 rounded-full flex items-center justify-center shrink-0 ${
+                            done ? 'bg-[#15803d]' : 'bg-[#e1e3de]'
+                          }`}
+                        >
+                          {done ? (
+                            <CheckCircle className="w-3 h-3 text-white" />
+                          ) : (
+                            <div className="w-1.5 h-1.5 rounded-full bg-[#becabc]" />
+                          )}
+                        </div>
+                        <span className={`text-xs font-semibold ${done ? 'text-[#191c19]' : 'text-[#becabc]'}`}>
+                          {label}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Video error message */}
+              {video.error_message && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded-xl">
+                  <p className="text-xs text-red-700 leading-relaxed">{video.error_message}</p>
+                </div>
+              )}
+
+              {/* Description */}
+              {video.description && (
+                <div className="border-t border-[#e1e3de]/50 pt-4">
+                  <p className="text-sm text-[#3f493f] leading-relaxed">{video.description}</p>
+                </div>
+              )}
+
+              {/* Delete error */}
+              {deleteError && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded-xl">
+                  <p className="text-xs text-red-700 leading-relaxed">{deleteError}</p>
+                </div>
+              )}
+
+              {/* Actions */}
+              <div className="border-t border-[#e1e3de]/50 pt-4 flex items-center gap-2">
+                <button
+                  onClick={startEditing}
+                  className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] text-[#3f493f] text-sm font-bold rounded-xl hover:bg-[#f2f4ef] transition-colors"
+                >
+                  <Pencil className="w-3.5 h-3.5" />
+                  {t('videos.detail.editButton')}
+                </button>
+                <button
+                  onClick={() => {
+                    if (!window.confirm(t('confirmations.deleteVideo'))) return;
+                    setDeleteError(null);
+                    deleteMutation.mutate();
+                  }}
+                  disabled={isDeleting}
+                  className="flex items-center gap-1.5 px-4 py-2 text-red-600 text-sm font-bold rounded-xl hover:bg-red-50 transition-colors disabled:opacity-50"
+                >
+                  {isDeleting ? <InlineSpinner className="w-3.5 h-3.5" /> : <Trash2 className="w-3.5 h-3.5" />}
+                  {isDeleting ? t('common.actions.deleting') : t('videos.detail.deleteButton')}
+                </button>
+              </div>
+            </div>
           </div>
 
           {/* ── Right Column: Transcript ───────────────────────────────────── */}

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -14,7 +14,6 @@ import { useTags } from '@/hooks/useTags';
 import { useVideoEditing } from '@/hooks/useVideoEditing';
 import { useVideoDetailPageMutations } from '@/hooks/useVideoDetailPageData';
 import { queryKeys } from '@/lib/queryKeys';
-import type { Tag } from '@/lib/api';
 import { AppNav } from '@/components/layout/AppNav';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import {

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -438,18 +438,27 @@ export default function VideoGroupDetailPage() {
 
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  const [selectedVideo, setSelectedVideo] = useState<SelectedVideo | null>(null);
+  const [selectedVideoId, setSelectedVideoId] = useState<number | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [editedName, setEditedName] = useState('');
   const [editedDescription, setEditedDescription] = useState('');
+
+  const selectedVideo = useMemo<SelectedVideo | null>(() => {
+    const videos = group?.videos;
+    if (!videos || videos.length === 0) return null;
+    if (selectedVideoId !== null) {
+      const found = videos.find((v) => v.id === selectedVideoId);
+      if (found) return convertVideoInGroupToSelectedVideo(found);
+    }
+    return convertVideoInGroupToSelectedVideo(videos[0]);
+  }, [group?.videos, selectedVideoId]);
 
   const { mobileTab, setMobileTab, isMobile } = useMobileTab();
   const { shareLink, isGeneratingLink, isCopied, generateShareLink, deleteShareLink, copyShareLink } = useShareLink(group);
 
   const handleVideoSelect = useCallback((videoId: number) => {
-    const v = group?.videos?.find((vv) => vv.id === videoId);
-    if (v) setSelectedVideo(convertVideoInGroupToSelectedVideo(v));
-  }, [group?.videos]);
+    setSelectedVideoId(videoId);
+  }, []);
 
   const { videoRef, handleVideoCanPlay, handleVideoPlayFromTime, youtubeStartSeconds } = useVideoPlayback({
     selectedVideo,
@@ -469,29 +478,14 @@ export default function VideoGroupDetailPage() {
       onUpdateSuccess: () => setIsEditing(false),
     });
 
-  useEffect(() => {
-    if (group) {
-      setEditedName(group.name);
-      setEditedDescription(group.description || '');
-    }
-  }, [group]);
 
-  useEffect(() => {
-    const videos = group?.videos;
-    if (!videos || videos.length === 0) {
-      if (selectedVideo) setSelectedVideo(null);
-      return;
-    }
-    const exists = selectedVideo ? videos.some((v) => v.id === selectedVideo.id) : false;
-    if (!exists) setSelectedVideo(convertVideoInGroupToSelectedVideo(videos[0]));
-  }, [group?.videos, selectedVideo]);
 
 
   const handleRemoveVideo = async (videoId: number) => {
     if (!confirm(t('videos.groupDetail.removeVideoConfirm')) || !groupId) return;
     try {
       await removeVideoMutation.mutateAsync(videoId);
-      if (selectedVideo?.id === videoId) setSelectedVideo(null);
+      if (selectedVideoId === videoId) setSelectedVideoId(null);
     } catch (err) {
       handleAsyncError(err, t('videos.groupDetail.removeVideoError'), () => {});
     }
@@ -674,7 +668,11 @@ export default function VideoGroupDetailPage() {
                     <span className="hidden sm:inline">{t('videos.groupDetail.add')}</span>
                   </button>
                   <button
-                    onClick={() => setIsEditing(true)}
+                    onClick={() => {
+                      setEditedName(group.name);
+                      setEditedDescription(group.description || '');
+                      setIsEditing(true);
+                    }}
                     className="p-1.5 text-[#3f493f] hover:bg-stone-100 rounded-lg transition-colors"
                     title={t('videos.groupDetail.editTitle')}
                   >

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -657,7 +657,7 @@ export default function VideoGroupDetailPage() {
           <aside className={`lg:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
             <div className="bg-white rounded-xl flex flex-col h-full overflow-hidden shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
               <div className="p-4 border-b border-stone-100 flex items-center justify-between gap-2 shrink-0">
-                <h2 className="font-extrabold text-[#191c19] truncate">{group.name}</h2>
+                <h2 className="font-extrabold text-[#191c19] truncate flex-1 min-w-0">{group.name}</h2>
                 <div className="flex items-center gap-2 shrink-0">
                   <span className="text-xs bg-[#f2f4ef] px-2 py-0.5 rounded-full text-[#6f7a6e] font-medium">
                     {t('videos.groupDetail.videoCount', { count: group.videos?.length ?? 0 })}

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -447,12 +447,16 @@ export default function VideoGroupDetailPage() {
   const [editedName, setEditedName] = useState('');
   const [editedDescription, setEditedDescription] = useState('');
 
-  // Initialize autoVideoId once when the first video becomes available.
-  // Calling setState during render is intentional here: React immediately
-  // re-renders with the updated state before committing to the DOM, so no
-  // extra paint occurs.
-  const firstVideoId = group?.videos?.[0]?.id ?? null;
-  if (autoVideoId === null && firstVideoId !== null) {
+  // Keep autoVideoId in sync with the current video list using React's "derived state" pattern
+  // (react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).
+  // We update autoVideoId when:
+  //   - It is null (initial load)
+  //   - It refers to a video that is no longer in the list (e.g. after deletion or group change)
+  // This prevents the player from switching to videos[0] during reorders when autoVideoId is stale.
+  const currentVideos = group?.videos;
+  const firstVideoId = currentVideos?.[0]?.id ?? null;
+  const autoVideoInList = autoVideoId !== null && (currentVideos?.some((v) => v.id === autoVideoId) ?? false);
+  if (!autoVideoInList && firstVideoId !== null) {
     setAutoVideoId(firstVideoId);
   }
 
@@ -464,10 +468,13 @@ export default function VideoGroupDetailPage() {
       const found = videos.find((v) => v.id === selectedVideoId);
       if (found) return convertVideoInGroupToSelectedVideo(found);
     }
-    // Fallback to auto-selected video (stable across reorders)
-    const targetId = autoVideoId ?? videos[0].id;
-    const found = videos.find((v) => v.id === targetId);
-    return convertVideoInGroupToSelectedVideo(found ?? videos[0]);
+    // Fall back to auto-selected video (stable across reorders thanks to autoVideoId)
+    const targetId = autoVideoId;
+    if (targetId !== null) {
+      const found = videos.find((v) => v.id === targetId);
+      if (found) return convertVideoInGroupToSelectedVideo(found);
+    }
+    return convertVideoInGroupToSelectedVideo(videos[0]);
   }, [group?.videos, selectedVideoId, autoVideoId]);
 
   const { mobileTab, setMobileTab, isMobile } = useMobileTab();

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -45,7 +45,7 @@ import {
 import { TagFilterPanel } from '@/components/video/TagFilterPanel';
 import { AppNav } from '@/components/layout/AppNav';
 import {
-  ArrowLeft, ChevronRight, Plus, GripVertical,
+  ArrowLeft, Plus, GripVertical,
   CheckCircle, Clock, AlertCircle, Copy, Trash2,
   Pencil, List, Play,
   Save, X,
@@ -582,51 +582,6 @@ export default function VideoGroupDetailPage() {
       {/* ── Header ───────────────────────────────────────────────────────── */}
       <AppNav activePage="groups" />
 
-      {/* ── Sub-header: Breadcrumb + Actions ─────────────────────────────── */}
-      <div className="fixed top-16 w-full z-40 bg-white border-b border-stone-100">
-        <div className="max-w-screen-xl mx-auto w-full px-6 lg:px-8 flex justify-between items-center h-14">
-          <div className="flex items-center gap-2 min-w-0">
-            <button
-              onClick={() => navigate('/videos/groups')}
-              className="p-1 rounded-lg hover:bg-stone-100 transition-all shrink-0"
-            >
-              <ArrowLeft className="w-4 h-4 text-[#3f493f]" />
-            </button>
-            <Link href="/videos/groups" className="text-sm text-stone-400 hover:text-[#00652c] transition-colors shrink-0">
-              {t('videos.groupDetail.breadcrumbGroups')}
-            </Link>
-            <ChevronRight className="w-3.5 h-3.5 text-stone-300 shrink-0" />
-            <span className="text-sm font-bold text-[#00652c] truncate">
-              {group.name}
-            </span>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <button
-              onClick={() => setIsAddModalOpen(true)}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-white border border-[#e1e3de] hover:bg-[#f2f4ef] transition-colors text-[#191c19] text-xs font-bold shadow-sm"
-            >
-              <Plus className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">{t('videos.groupDetail.addVideoButton')}</span>
-            </button>
-            <button
-              onClick={() => setIsEditing(true)}
-              className="p-2 text-[#3f493f] hover:bg-stone-100 rounded-full transition-colors"
-              title={t('videos.groupDetail.editTitle')}
-            >
-              <Pencil className="w-4 h-4" />
-            </button>
-            <button
-              onClick={handleDelete}
-              disabled={isDeleting}
-              className="p-2 text-red-500 hover:bg-red-50 rounded-full transition-colors disabled:opacity-50"
-              title={t('videos.groupDetail.delete')}
-            >
-              {isDeleting ? <InlineSpinner className="w-4 h-4" /> : <Trash2 className="w-4 h-4" />}
-            </button>
-          </div>
-        </div>
-      </div>
-
       {/* ── Edit Dialog ──────────────────────────────────────────────────── */}
       <Dialog open={isEditing} onOpenChange={(open) => !open && handleCancelEdit()}>
         <DialogContent className="max-w-md">
@@ -683,7 +638,7 @@ export default function VideoGroupDetailPage() {
       </Dialog>
 
       {/* ── Main ─────────────────────────────────────────────────────────── */}
-      <main className="mt-[112px] flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-4 lg:h-[calc(100dvh-112px)] lg:overflow-hidden">
+      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-4 lg:h-[calc(100dvh-64px)] lg:overflow-hidden">
         {/* Share link panel */}
         <ShareLinkPanel
           shareSlug={group.share_slug ?? ''}
@@ -702,11 +657,33 @@ export default function VideoGroupDetailPage() {
           <aside className={`lg:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
             <div className="bg-white rounded-xl flex flex-col h-full overflow-hidden shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
               <div className="p-4 border-b border-stone-100 flex items-center justify-between gap-2 shrink-0">
-                <h2 className="font-extrabold text-[#191c19]">{t('videos.groupDetail.videoListTitle')}</h2>
+                <h2 className="font-extrabold text-[#191c19] truncate">{group.name}</h2>
                 <div className="flex items-center gap-2 shrink-0">
                   <span className="text-xs bg-[#f2f4ef] px-2 py-0.5 rounded-full text-[#6f7a6e] font-medium">
                     {t('videos.groupDetail.videoCount', { count: group.videos?.length ?? 0 })}
                   </span>
+                  <button
+                    onClick={() => setIsAddModalOpen(true)}
+                    className="flex items-center gap-1 px-2 py-1 rounded-lg bg-white border border-[#e1e3de] hover:bg-[#f2f4ef] transition-colors text-[#191c19] text-xs font-bold shadow-sm"
+                  >
+                    <Plus className="w-3.5 h-3.5" />
+                    <span className="hidden sm:inline">{t('videos.groupDetail.add')}</span>
+                  </button>
+                  <button
+                    onClick={() => setIsEditing(true)}
+                    className="p-1.5 text-[#3f493f] hover:bg-stone-100 rounded-lg transition-colors"
+                    title={t('videos.groupDetail.editTitle')}
+                  >
+                    <Pencil className="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    onClick={handleDelete}
+                    disabled={isDeleting}
+                    className="p-1.5 text-red-500 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+                    title={t('videos.groupDetail.delete')}
+                  >
+                    {isDeleting ? <InlineSpinner className="w-3.5 h-3.5" /> : <Trash2 className="w-3.5 h-3.5" />}
+                  </button>
                 </div>
               </div>
               <div className="flex-1 overflow-y-auto p-2 space-y-1">

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -439,19 +439,36 @@ export default function VideoGroupDetailPage() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [selectedVideoId, setSelectedVideoId] = useState<number | null>(null);
+  // autoVideoId stores the ID of the first-shown video for stability during reorders.
+  // Initialized once when group data first arrives using React's "derived state" pattern
+  // (react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).
+  const [autoVideoId, setAutoVideoId] = useState<number | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [editedName, setEditedName] = useState('');
   const [editedDescription, setEditedDescription] = useState('');
 
+  // Initialize autoVideoId once when the first video becomes available.
+  // Calling setState during render is intentional here: React immediately
+  // re-renders with the updated state before committing to the DOM, so no
+  // extra paint occurs.
+  const firstVideoId = group?.videos?.[0]?.id ?? null;
+  if (autoVideoId === null && firstVideoId !== null) {
+    setAutoVideoId(firstVideoId);
+  }
+
   const selectedVideo = useMemo<SelectedVideo | null>(() => {
     const videos = group?.videos;
     if (!videos || videos.length === 0) return null;
+    // Explicit user selection takes priority
     if (selectedVideoId !== null) {
       const found = videos.find((v) => v.id === selectedVideoId);
       if (found) return convertVideoInGroupToSelectedVideo(found);
     }
-    return convertVideoInGroupToSelectedVideo(videos[0]);
-  }, [group?.videos, selectedVideoId]);
+    // Fallback to auto-selected video (stable across reorders)
+    const targetId = autoVideoId ?? videos[0].id;
+    const found = videos.find((v) => v.id === targetId);
+    return convertVideoInGroupToSelectedVideo(found ?? videos[0]);
+  }, [group?.videos, selectedVideoId, autoVideoId]);
 
   const { mobileTab, setMobileTab, isMobile } = useMobileTab();
   const { shareLink, isGeneratingLink, isCopied, generateShareLink, deleteShareLink, copyShareLink } = useShareLink(group);
@@ -519,6 +536,7 @@ export default function VideoGroupDetailPage() {
 
   const handleCancelEdit = () => {
     setIsEditing(false);
+    updateGroupMutation.reset();
     if (group) {
       setEditedName(group.name);
       setEditedDescription(group.description || '');
@@ -619,7 +637,7 @@ export default function VideoGroupDetailPage() {
               {t('common.actions.cancel')}
             </button>
             <button
-              onClick={() => void updateGroupMutation.mutateAsync({ name: editedName, description: editedDescription })}
+              onClick={() => updateGroupMutation.mutate({ name: editedName, description: editedDescription })}
               disabled={isUpdating || !editedName.trim()}
               className="flex items-center gap-1.5 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
             >

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -436,7 +436,7 @@ export default function VideoGroupDetailPage() {
   const { group, isLoading: groupIsLoading, isFetching: groupIsFetching, errorMessage: error } =
     useVideoGroupDetailQuery(groupId);
 
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [selectedVideo, setSelectedVideo] = useState<SelectedVideo | null>(null);
   const [isEditing, setIsEditing] = useState(false);
@@ -515,13 +515,11 @@ export default function VideoGroupDetailPage() {
 
   const handleDelete = async () => {
     if (!groupId || !confirm(t('confirmations.deleteGroup'))) return;
+    setDeleteError(null);
     try {
-      setIsDeleting(true);
       await deleteGroupMutation.mutateAsync();
     } catch (err) {
-      handleAsyncError(err, t('videos.groupDetail.deleteError'), () => {});
-    } finally {
-      setIsDeleting(false);
+      handleAsyncError(err, t('videos.groupDetail.deleteError'), setDeleteError);
     }
   };
 
@@ -534,6 +532,7 @@ export default function VideoGroupDetailPage() {
   };
 
   const isLoading = groupIsLoading || groupIsFetching;
+  const isDeleting = deleteGroupMutation.isPending;
   const isUpdating = updateGroupMutation.isPending;
   const updateError = updateGroupMutation.error instanceof Error ? updateGroupMutation.error.message : null;
 
@@ -656,6 +655,11 @@ export default function VideoGroupDetailPage() {
           {/* LEFT: Video list */}
           <aside className={`lg:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
             <div className="bg-white rounded-xl flex flex-col h-full overflow-hidden shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
+              {deleteError && (
+                <div className="px-4 pt-3 shrink-0">
+                  <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">{deleteError}</div>
+                </div>
+              )}
               <div className="p-4 border-b border-stone-100 flex items-center justify-between gap-2 shrink-0">
                 <h2 className="font-extrabold text-[#191c19] truncate flex-1 min-w-0">{group.name}</h2>
                 <div className="flex items-center gap-2 shrink-0">

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -110,13 +110,25 @@ describe('VideoDetailPage', () => {
     expect(screen.getByText(/Hello world/)).toBeInTheDocument()
   })
 
-  it('should enter edit mode when edit button is clicked', () => {
+  it('should open edit modal when edit button is clicked', () => {
     render(<VideoDetailPage />)
 
     fireEvent.click(screen.getByText('videos.detail.editButton'))
 
-    expect(screen.getByText('videos.detail.save')).toBeInTheDocument()
-    expect(screen.getByText('videos.detail.cancel')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('common.actions.save')).toBeInTheDocument()
+    expect(screen.getByText('common.actions.cancel')).toBeInTheDocument()
+  })
+
+  it('should not replace info card with inline form when edit button is clicked', () => {
+    render(<VideoDetailPage />)
+
+    fireEvent.click(screen.getByText('videos.detail.editButton'))
+
+    // Info card should still be visible (title appears in card + in modal dialog)
+    expect(screen.getAllByText('Test Video').length).toBeGreaterThan(0)
+    // The dialog should be open
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
   it('should not manually load video on mount (query handles initial fetch)', () => {
@@ -131,6 +143,67 @@ describe('VideoDetailPage', () => {
     expect(subHeader).toBeNull()
   })
 
+})
+
+describe('VideoDetailPage - Edit modal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should show update error in modal when save fails', async () => {
+    ;(apiClient.updateVideo as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Update failed'),
+    )
+
+    render(<VideoDetailPage />)
+
+    fireEvent.click(screen.getByText('videos.detail.editButton'))
+    fireEvent.click(screen.getByText('common.actions.save'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Update failed')).toBeInTheDocument()
+    })
+  })
+
+  it('should close modal and clear error on cancel', async () => {
+    ;(apiClient.updateVideo as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Update failed'),
+    )
+
+    render(<VideoDetailPage />)
+
+    fireEvent.click(screen.getByText('videos.detail.editButton'))
+    fireEvent.click(screen.getByText('common.actions.save'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Update failed')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('common.actions.cancel'))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('VideoDetailPage - Delete error', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should show delete error when delete fails', async () => {
+    window.confirm = vi.fn(() => true)
+    ;(apiClient.deleteVideo as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Delete failed'),
+    )
+
+    render(<VideoDetailPage />)
+
+    fireEvent.click(screen.getByText('videos.detail.deleteButton'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete failed')).toBeInTheDocument()
+    })
+  })
 })
 
 describe('VideoDetailPage - Transcript save error', () => {

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -97,12 +97,6 @@ describe('VideoDetailPage', () => {
     expect(screen.getByText('videos.detail.deleteButton')).toBeInTheDocument()
   })
 
-  it('should not render a back to list button', () => {
-    render(<VideoDetailPage />)
-
-    expect(screen.queryByLabelText('common.actions.backToList')).not.toBeInTheDocument()
-  })
-
   it('should not render breadcrumb text', () => {
     render(<VideoDetailPage />)
 

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -97,10 +97,16 @@ describe('VideoDetailPage', () => {
     expect(screen.getByText('videos.detail.deleteButton')).toBeInTheDocument()
   })
 
-  it('should render back to list button', () => {
+  it('should not render a back to list button', () => {
     render(<VideoDetailPage />)
 
-    expect(screen.getByText('videos.detail.videosBreadcrumb')).toBeInTheDocument()
+    expect(screen.queryByLabelText('common.actions.backToList')).not.toBeInTheDocument()
+  })
+
+  it('should not render breadcrumb text', () => {
+    render(<VideoDetailPage />)
+
+    expect(screen.queryByText('videos.detail.videosBreadcrumb')).not.toBeInTheDocument()
   })
 
   it('should render transcript when available', () => {
@@ -125,6 +131,11 @@ describe('VideoDetailPage', () => {
     expect(mockLoadVideo).not.toHaveBeenCalled()
   })
 
+  it('should not render a fixed sub-header below the nav', () => {
+    const { container } = render(<VideoDetailPage />)
+    const subHeader = container.querySelector('.fixed.top-16.z-40')
+    expect(subHeader).toBeNull()
+  })
 
 })
 

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -165,7 +165,7 @@ describe('VideoDetailPage - Edit modal', () => {
     })
   })
 
-  it('should close modal and clear error on cancel', async () => {
+  it('should close modal on cancel', async () => {
     ;(apiClient.updateVideo as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error('Update failed'),
     )
@@ -182,6 +182,29 @@ describe('VideoDetailPage - Edit modal', () => {
     fireEvent.click(screen.getByText('common.actions.cancel'))
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('should clear error when modal is reopened after cancel', async () => {
+    ;(apiClient.updateVideo as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Update failed'),
+    )
+
+    render(<VideoDetailPage />)
+
+    // Open → save → error appears
+    fireEvent.click(screen.getByText('videos.detail.editButton'))
+    fireEvent.click(screen.getByText('common.actions.save'))
+    await waitFor(() => {
+      expect(screen.getByText('Update failed')).toBeInTheDocument()
+    })
+
+    // Cancel closes modal
+    fireEvent.click(screen.getByText('common.actions.cancel'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    // Reopen → error should NOT be visible
+    fireEvent.click(screen.getByText('videos.detail.editButton'))
+    expect(screen.queryByText('Update failed')).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -276,6 +276,24 @@ describe('VideoGroupDetailPage - Delete', () => {
     })
   })
 
+  it('should show delete error when delete fails', async () => {
+    ;(apiClient.deleteVideoGroup as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Delete failed'),
+    )
+
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTitle('videos.groupDetail.delete')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTitle('videos.groupDetail.delete'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete failed')).toBeInTheDocument()
+    })
+  })
+
   it('should remove the video from the group list when removal is confirmed', async () => {
     render(<VideoGroupDetailPage />)
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -103,16 +103,28 @@ describe('VideoGroupDetailPage', () => {
     render(<VideoGroupDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('videos.groupDetail.addVideoButton')).toBeInTheDocument()
+      expect(screen.getByText('videos.groupDetail.add')).toBeInTheDocument()
     })
   })
 
-  it('should render back to list button', async () => {
+  it('should not render a back to list button', async () => {
     render(<VideoGroupDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('videos.groupDetail.breadcrumbGroups')).toBeInTheDocument()
+      expect(screen.getByText('Test Group')).toBeInTheDocument()
     })
+
+    expect(screen.queryByLabelText('common.actions.backToList')).not.toBeInTheDocument()
+  })
+
+  it('should not render breadcrumb text', async () => {
+    render(<VideoGroupDetailPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Group')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('videos.groupDetail.breadcrumbGroups')).not.toBeInTheDocument()
   })
 
   it('should render delete button', async () => {
@@ -167,6 +179,15 @@ describe('VideoGroupDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByText('common.actions.save')).toBeInTheDocument()
     })
+  })
+
+  it('should not render a fixed sub-header below the nav', async () => {
+    const { container } = render(<VideoGroupDetailPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Test Group')).toBeInTheDocument()
+    })
+    const subHeader = container.querySelector('.fixed.top-16.z-40')
+    expect(subHeader).toBeNull()
   })
 
   it('should not autoplay youtube video on initial render', async () => {

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -107,16 +107,6 @@ describe('VideoGroupDetailPage', () => {
     })
   })
 
-  it('should not render a back to list button', async () => {
-    render(<VideoGroupDetailPage />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Test Group')).toBeInTheDocument()
-    })
-
-    expect(screen.queryByLabelText('common.actions.backToList')).not.toBeInTheDocument()
-  })
-
   it('should not render breadcrumb text', async () => {
     render(<VideoGroupDetailPage />)
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -366,4 +366,56 @@ describe('VideoGroupDetailPage - Delete', () => {
     // Video 2 should now be shown in the list (and become the new auto-selected)
     expect(screen.getAllByText('Video 2').length).toBeGreaterThan(0)
   })
+
+  it('should keep player on Video 2 after deleting Video 1 (auto-selected) and then receiving a reordered list [Video 3, Video 2]', async () => {
+    // Regression: after deletion shifts autoVideoId to V2, a subsequent reorder
+    // that puts V3 first must NOT override autoVideoId with V3.
+
+    // Override to 3-video group for this test
+    const video3 = { id: 3, title: 'Video 3', description: 'Desc 3', status: 'completed', file: 'video3.mp4', source_type: 'uploaded', order: 2 }
+    currentGroup = { ...mockGroup, videos: [...mockGroup.videos, video3] }
+    ;(apiClient.updateVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue({})
+
+    const { container } = render(<VideoGroupDetailPage />)
+
+    // Wait for all 3 remove buttons (initial load with V1, V2, V3)
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })).toHaveLength(3)
+    })
+
+    // Step 1: Delete Video 1 (auto-selected)
+    // removeVideoFromGroup mock mutates currentGroup → [V2, V3]
+    // syncGroupDetail → invalidateQueries → refetch returns [V2, V3]
+    // autoVideoId: V1 stale → resets to V2 (first in new list)
+    const [firstRemoveButton] = screen.getAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
+    fireEvent.click(firstRemoveButton)
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('Video 1')).toHaveLength(0)
+    })
+
+    // Step 2: Simulate an external reorder — V3 moves before V2
+    // Override currentGroup so the next refetch returns [V3, V2]
+    currentGroup = {
+      ...currentGroup,
+      videos: [
+        { id: 3, title: 'Video 3', description: 'Desc 3', status: 'completed', file: 'video3.mp4', source_type: 'uploaded', order: 0 },
+        { id: 2, title: 'Video 2', description: 'Desc 2', status: 'processing', file: 'video2.mp4', source_type: 'uploaded', order: 1 },
+      ],
+    }
+
+    // Trigger a refetch by saving the edit modal (updateGroupMutation.onSuccess → syncGroupDetail)
+    fireEvent.click(screen.getByTitle('videos.groupDetail.editTitle'))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByText('common.actions.save'))
+
+    // After re-render with [V3, V2]:
+    //   autoVideoId is still V2 (V2 is in the list → no reset)
+    //   selectedVideo → V2 (from autoVideoId)
+    //   Player must show video2.mp4, NOT video3.mp4
+    await waitFor(() => {
+      const videoEl = container.querySelector('video')
+      expect(videoEl?.getAttribute('src')).toBe('video2.mp4')
+    })
+  })
 })

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -346,4 +346,24 @@ describe('VideoGroupDetailPage - Delete', () => {
       expect(screen.getAllByText('Video 2').length).toBeGreaterThan(0)
     })
   })
+
+  it('should reset autoVideoId when the auto-selected video is removed from the group', async () => {
+    // After Video 1 (initially auto-selected) is removed, autoVideoId should
+    // update to Video 2. Subsequent title queries confirm Video 2 is now tracked.
+    render(<VideoGroupDetailPage />)
+
+    // Wait for initial render with Video 1 auto-selected
+    await screen.findAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
+
+    // Remove Video 1 (the auto-selected one)
+    const [firstRemoveButton] = screen.getAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
+    fireEvent.click(firstRemoveButton)
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('Video 1')).toHaveLength(0)
+    })
+
+    // Video 2 should now be shown in the list (and become the new auto-selected)
+    expect(screen.getAllByText('Video 2').length).toBeGreaterThan(0)
+  })
 })

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import VideoGroupDetailPage from '../VideoGroupDetailPage'
 import { apiClient } from '@/lib/api'
 
@@ -208,6 +208,42 @@ describe('VideoGroupDetailPage', () => {
   })
 
 
+})
+
+describe('VideoGroupDetailPage - Edit modal error', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockResolvedValue(mockGroup)
+    ;(apiClient.updateVideoGroup as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Update failed'),
+    )
+  })
+
+  it('should clear update error when modal is reopened after cancel', async () => {
+    render(<VideoGroupDetailPage />)
+
+    // Open edit modal
+    await waitFor(() => {
+      expect(screen.getByTitle('videos.groupDetail.editTitle')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTitle('videos.groupDetail.editTitle'))
+
+    const dialog = await screen.findByRole('dialog')
+
+    // Try to save → error appears
+    fireEvent.click(within(dialog).getByText('common.actions.save'))
+    await waitFor(() => {
+      expect(within(dialog).getByText('Update failed')).toBeInTheDocument()
+    })
+
+    // Cancel closes modal
+    fireEvent.click(within(dialog).getByText('common.actions.cancel'))
+
+    // Reopen → error should NOT be visible
+    fireEvent.click(screen.getByTitle('videos.groupDetail.editTitle'))
+    const dialog2 = await screen.findByRole('dialog')
+    expect(within(dialog2).queryByText('Update failed')).not.toBeInTheDocument()
+  })
 })
 
 describe('VideoGroupDetailPage - Share Link', () => {


### PR DESCRIPTION
## 概要

Closes #724

動画詳細画面とグループ詳細画面で、編集・削除操作の見た目と挙動を統一します。

## 変更内容

### VideoDetailPage
- **編集 UI をモーダルに変更**: インライン編集フォームを `Dialog` モーダルに置き換え、グループ詳細と同じ編集体験に統一
- **更新エラー表示**: 保存失敗時にモーダル内にエラーメッセージを表示
- **削除エラー表示**: 削除失敗時に情報カード内にエラーメッセージを表示
- **キャッシュ invalidation 拡充**: 動画更新後に `videos.all` / `videoGroup` / `sharedVideoGroup` も invalidate し、関連一覧・グループ表示へ即時反映

### VideoGroupDetailPage
- **ローカル `isDeleting` state を削除**: `deleteGroupMutation.isPending` を直接使用し、loading 状態管理を統一
- **削除エラー表示**: 削除失敗時にリスト上部にエラーメッセージを表示

### テスト
- 編集ボタンでモーダルが開くことを確認するテストを追加
- 更新エラーがモーダル内に表示されることを確認するテストを追加
- 削除エラーが UI に表示されることを確認するテストを追加（両画面）

## 受け入れ条件の確認

- [x] 動画詳細とグループ詳細で、編集・削除操作の見た目と配置ルールが一貫している
- [x] 編集開始、保存、キャンセル、保存中、失敗時の挙動が両画面で揃っている
- [x] 削除確認、削除中表示、失敗時の表示が両画面で揃っている
- [x] 動画またはグループを更新・削除した後、関連する一覧・詳細・グループ表示のキャッシュが正しく更新される
- [x] 既存テストを更新し、編集・削除の主要フローを確認できる

## テスト

```
Test Files  55 passed (55)
     Tests  543 passed (543)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)