### PR TITLE
fix: 詳細画面のローディングでヘッダーごと消える挙動を改善する (#725)

### DIFF
--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -99,7 +99,7 @@ export function useVideo(videoId: number | null): UseVideoReturn {
 
   return {
     video: videoQuery.data || null,
-    isLoading: (!!videoId && authQuery.isLoading) || videoQuery.isLoading || videoQuery.isFetching,
+    isLoading: (!!videoId && authQuery.isLoading) || videoQuery.isLoading,
     error: videoQuery.error instanceof Error ? videoQuery.error.message : null,
     loadVideo: handleLoadVideo,
     refetch: handleLoadVideo,

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -229,38 +229,8 @@ export default function VideoDetailPage() {
     setActiveSegmentIdx(idx);
   };
 
-  // ── Loading / error states ───────────────────────────────────────────────
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-[#f8faf5]">
-        <LoadingSpinner />
-      </div>
-    );
-  }
-
-  if (error && !video) {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-[#f8faf5] gap-4">
-        <p className="text-red-500">{error}</p>
-        <Link href="/videos" className="text-[#00652c] font-bold hover:underline flex items-center gap-1">
-          <ArrowLeft className="w-4 h-4" />
-          {t('common.actions.backToList')}
-        </Link>
-      </div>
-    );
-  }
-
-  if (!video) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-[#f8faf5]">
-        <p className="text-[#3f493f]">{t('common.messages.videoNotFound')}</p>
-      </div>
-    );
-  }
-
-  const statusClassName = getStatusClassName(video.status);
-  const isPlainTextTranscript = video.transcript?.trim() && !isSRTFormat(video.transcript);
+  const statusClassName = video ? getStatusClassName(video.status) : '';
+  const isPlainTextTranscript = video?.transcript?.trim() && !isSRTFormat(video.transcript ?? '');
 
   const pipelineSteps = [
     { key: 'upload',     label: t('videos.detail.pipeline.upload'),     doneStatuses: ['processing', 'indexing', 'completed', 'error'] },
@@ -277,6 +247,25 @@ export default function VideoDetailPage() {
         {/* ── Header ───────────────────────────────────────────────────────── */}
         <AppNav activePage="videos" />
 
+        {/* ── Loading / error states ─────────────────────────────────────── */}
+        {isLoading ? (
+          <div className="flex-1 flex items-center justify-center">
+            <LoadingSpinner />
+          </div>
+        ) : error && !video ? (
+          <div className="flex-1 flex flex-col items-center justify-center gap-4">
+            <p className="text-red-500">{error}</p>
+            <Link href="/videos" className="text-[#00652c] font-bold hover:underline flex items-center gap-1">
+              <ArrowLeft className="w-4 h-4" />
+              {t('common.actions.backToList')}
+            </Link>
+          </div>
+        ) : !video ? (
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-[#3f493f]">{t('common.messages.videoNotFound')}</p>
+          </div>
+        ) : (
+          <>
         {/* ── Edit Modal ───────────────────────────────────────────────────── */}
         <Dialog open={isEditing} onOpenChange={(open) => !open && handleCancelEdit()}>
           <DialogContent className="max-w-md">
@@ -664,6 +653,8 @@ export default function VideoDetailPage() {
           onClose={() => setIsCreateDialogOpen(false)}
           onCreate={handleCreateTag}
         />
+          </>
+        )}
       </div>
     </>
   );

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -572,11 +572,11 @@ export default function VideoGroupDetailPage() {
 
       {/* ── Loading / error states ─────────────────────────────────────── */}
       {isLoading ? (
-        <div className="flex-1 flex items-center justify-center">
+        <div className="mt-16 min-h-[calc(100dvh-64px)] flex items-center justify-center">
           <LoadingSpinner />
         </div>
       ) : error && !group ? (
-        <div className="flex-1 flex flex-col items-center justify-center gap-4">
+        <div className="mt-16 min-h-[calc(100dvh-64px)] flex flex-col items-center justify-center gap-4">
           <p className="text-red-500">{error}</p>
           <Link href="/videos/groups" className="text-[#00652c] font-bold hover:underline flex items-center gap-1">
             <ArrowLeft className="w-4 h-4" />
@@ -584,7 +584,7 @@ export default function VideoGroupDetailPage() {
           </Link>
         </div>
       ) : !group ? (
-        <div className="flex-1 flex items-center justify-center">
+        <div className="mt-16 min-h-[calc(100dvh-64px)] flex items-center justify-center">
           <p className="text-[#3f493f]">{t('common.messages.groupNotFound')}</p>
         </div>
       ) : (

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -433,7 +433,7 @@ export default function VideoGroupDetailPage() {
 
   useAuth();
 
-  const { group, isLoading: groupIsLoading, isFetching: groupIsFetching, errorMessage: error } =
+  const { group, isLoading: groupIsLoading, errorMessage: error } =
     useVideoGroupDetailQuery(groupId);
 
   const [deleteError, setDeleteError] = useState<string | null>(null);

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -550,40 +550,10 @@ export default function VideoGroupDetailPage() {
     }
   };
 
-  const isLoading = groupIsLoading || groupIsFetching;
+  const isLoading = groupIsLoading;
   const isDeleting = deleteGroupMutation.isPending;
   const isUpdating = updateGroupMutation.isPending;
   const updateError = updateGroupMutation.error instanceof Error ? updateGroupMutation.error.message : null;
-
-  // ── Loading / error states ───────────────────────────────────────────────
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-[#f8faf5]">
-        <LoadingSpinner />
-      </div>
-    );
-  }
-
-  if (error && !group) {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-[#f8faf5] gap-4">
-        <p className="text-red-500">{error}</p>
-        <Link href="/videos/groups" className="text-[#00652c] font-bold hover:underline flex items-center gap-1">
-          <ArrowLeft className="w-4 h-4" />
-          {t('common.actions.backToList')}
-        </Link>
-      </div>
-    );
-  }
-
-  if (!group) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-[#f8faf5]">
-        <p className="text-[#3f493f]">{t('common.messages.groupNotFound')}</p>
-      </div>
-    );
-  }
 
   const mobileTabIcon: Record<MobileTab, typeof List> = { videos: List, player: Play };
   const mobileTabLabel: Record<MobileTab, string> = {
@@ -600,6 +570,25 @@ export default function VideoGroupDetailPage() {
       {/* ── Header ───────────────────────────────────────────────────────── */}
       <AppNav activePage="groups" />
 
+      {/* ── Loading / error states ─────────────────────────────────────── */}
+      {isLoading ? (
+        <div className="flex-1 flex items-center justify-center">
+          <LoadingSpinner />
+        </div>
+      ) : error && !group ? (
+        <div className="flex-1 flex flex-col items-center justify-center gap-4">
+          <p className="text-red-500">{error}</p>
+          <Link href="/videos/groups" className="text-[#00652c] font-bold hover:underline flex items-center gap-1">
+            <ArrowLeft className="w-4 h-4" />
+            {t('common.actions.backToList')}
+          </Link>
+        </div>
+      ) : !group ? (
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-[#3f493f]">{t('common.messages.groupNotFound')}</p>
+        </div>
+      ) : (
+        <>
       {/* ── Edit Dialog ──────────────────────────────────────────────────── */}
       <Dialog open={isEditing} onOpenChange={(open) => !open && handleCancelEdit()}>
         <DialogContent className="max-w-md">
@@ -836,6 +825,8 @@ export default function VideoGroupDetailPage() {
         groupId={groupId}
         group={group}
       />
+        </>
+      )}
       </div>
     </>
   );

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -17,6 +17,13 @@ const mockVideo = {
 
 const mockLoadVideo = vi.fn()
 
+let mockUseVideoReturn = {
+  video: mockVideo as typeof mockVideo | null,
+  isLoading: false,
+  error: null as string | null,
+  loadVideo: mockLoadVideo,
+}
+
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
   return {
@@ -27,12 +34,11 @@ vi.mock('react-router-dom', async () => {
 })
 
 vi.mock('@/hooks/useVideos', () => ({
-  useVideo: () => ({
-    video: mockVideo,
-    isLoading: false,
-    error: null,
-    loadVideo: mockLoadVideo,
-  }),
+  useVideo: () => mockUseVideoReturn,
+}))
+
+vi.mock('@/components/layout/AppNav', () => ({
+  AppNav: () => <nav data-testid="app-nav" />,
 }))
 
 vi.mock('@/hooks/useTags', () => ({
@@ -60,6 +66,7 @@ vi.mock('@/lib/api', async (importOriginal) => {
 describe('VideoDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseVideoReturn = { video: mockVideo, isLoading: false, error: null, loadVideo: mockLoadVideo }
   })
 
   afterEach(() => {
@@ -148,6 +155,7 @@ describe('VideoDetailPage', () => {
 describe('VideoDetailPage - Edit modal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseVideoReturn = { video: mockVideo, isLoading: false, error: null, loadVideo: mockLoadVideo }
   })
 
   it('should show update error in modal when save fails', async () => {
@@ -211,6 +219,7 @@ describe('VideoDetailPage - Edit modal', () => {
 describe('VideoDetailPage - Delete error', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseVideoReturn = { video: mockVideo, isLoading: false, error: null, loadVideo: mockLoadVideo }
   })
 
   it('should show delete error when delete fails', async () => {
@@ -232,6 +241,7 @@ describe('VideoDetailPage - Delete error', () => {
 describe('VideoDetailPage - Transcript save error', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseVideoReturn = { video: mockVideo, isLoading: false, error: null, loadVideo: mockLoadVideo }
   })
 
   it('should show error message when transcript save returns API error', async () => {
@@ -286,6 +296,61 @@ describe('VideoDetailPage - Transcript save error', () => {
     fireEvent.click(screen.getByText('videos.detail.editTranscriptButton'))
 
     expect(screen.queryByText('Transcript must be in valid SRT format.')).not.toBeInTheDocument()
+  })
+})
+
+describe('VideoDetailPage - Loading state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseVideoReturn = { video: null, isLoading: true, error: null, loadVideo: vi.fn() }
+  })
+
+  afterEach(() => {
+    mockUseVideoReturn = { video: mockVideo, isLoading: false, error: null, loadVideo: mockLoadVideo }
+  })
+
+  it('should render AppNav during initial loading', () => {
+    render(<VideoDetailPage />)
+    expect(screen.getByTestId('app-nav')).toBeInTheDocument()
+  })
+
+  it('should not show full-screen loading overlay (AppNav is separate)', () => {
+    const { container } = render(<VideoDetailPage />)
+    // The outer wrapper should NOT be the sole full-screen centering container
+    const loadingWrapper = container.querySelector('.min-h-screen.flex.items-center.justify-center')
+    expect(loadingWrapper).toBeNull()
+  })
+})
+
+describe('VideoDetailPage - Error state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseVideoReturn = { video: null, isLoading: false, error: 'Network error', loadVideo: vi.fn() }
+  })
+
+  afterEach(() => {
+    mockUseVideoReturn = { video: mockVideo, isLoading: false, error: null, loadVideo: mockLoadVideo }
+  })
+
+  it('should render AppNav when there is an error', () => {
+    render(<VideoDetailPage />)
+    expect(screen.getByTestId('app-nav')).toBeInTheDocument()
+  })
+})
+
+describe('VideoDetailPage - Not found state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseVideoReturn = { video: null, isLoading: false, error: null, loadVideo: vi.fn() }
+  })
+
+  afterEach(() => {
+    mockUseVideoReturn = { video: mockVideo, isLoading: false, error: null, loadVideo: mockLoadVideo }
+  })
+
+  it('should render AppNav when video is not found', () => {
+    render(<VideoDetailPage />)
+    expect(screen.getByTestId('app-nav')).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -43,6 +43,10 @@ vi.mock('@/hooks/useTags', () => ({
   }),
 }))
 
+vi.mock('@/components/layout/AppNav', () => ({
+  AppNav: () => <nav data-testid="app-nav" />,
+}))
+
 vi.mock('@/components/chat/ChatPanel', () => ({
   ChatPanel: () => <div data-testid="chat-panel">Chat Panel</div>,
 }))
@@ -260,6 +264,25 @@ describe('VideoGroupDetailPage - Share Link', () => {
       expect(screen.getByText('videos.groupDetail.copyButton')).toBeInTheDocument()
       expect(screen.getByText('videos.groupDetail.disable')).toBeInTheDocument()
     })
+  })
+})
+
+describe('VideoGroupDetailPage - Loading state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Never-resolving promise simulates initial loading
+    ;(apiClient.getVideoGroup as ReturnType<typeof vi.fn>).mockImplementation(() => new Promise(() => {}))
+  })
+
+  it('should render AppNav during initial loading', async () => {
+    render(<VideoGroupDetailPage />)
+    expect(screen.getByTestId('app-nav')).toBeInTheDocument()
+  })
+
+  it('should not show full-screen loading overlay (AppNav is separate)', async () => {
+    const { container } = render(<VideoGroupDetailPage />)
+    const loadingWrapper = container.querySelector('.min-h-screen.flex.items-center.justify-center')
+    expect(loadingWrapper).toBeNull()
   })
 })
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -279,10 +279,14 @@ describe('VideoGroupDetailPage - Loading state', () => {
     expect(screen.getByTestId('app-nav')).toBeInTheDocument()
   })
 
-  it('should not show full-screen loading overlay (AppNav is separate)', async () => {
+  it('should show loading spinner in content area below nav (not full-screen overlay)', async () => {
     const { container } = render(<VideoGroupDetailPage />)
-    const loadingWrapper = container.querySelector('.min-h-screen.flex.items-center.justify-center')
-    expect(loadingWrapper).toBeNull()
+    // Must NOT be a standalone full-screen wrapper (old behavior without AppNav)
+    const fullScreenWrapper = container.querySelector('.min-h-screen.flex.items-center.justify-center')
+    expect(fullScreenWrapper).toBeNull()
+    // Must be positioned below the nav with viewport-filling height
+    const contentArea = container.querySelector('.mt-16.flex.items-center.justify-center')
+    expect(contentArea).not.toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

- 動画詳細・グループ詳細の初回ロード中、`AppNav` が常時表示されるよう修正
- 再フェッチ中に既存画面全体がローディング表示へ差し替わる問題を修正
- TDD（Red → Green）で実装し、各状態での `AppNav` 残存をテストで担保

## Changes

### `VideoDetailPage.tsx`
- `isLoading` / `error && !video` / `!video` の早期 `return` を削除
- `AppNav` の直下に条件分岐を配置し、ヘッダーはロード状態に依存せず常時レンダリング

### `VideoGroupDetailPage.tsx`
- 同様に早期 `return` を削除し AppNav 直下へ条件分岐を移動
- `const isLoading = groupIsLoading || groupIsFetching` → `const isLoading = groupIsLoading`
  - `isFetching` を含めていたため再フェッチ中も全画面ローディングに戻っていた問題を解消

### `hooks/useVideos.ts`
- `useVideo` の `isLoading` から `videoQuery.isFetching` を除去
  - 再フェッチ時に動画詳細が全画面ローディング表示になる問題を解消

### テスト
- `VideoDetailPage.test.tsx`: Loading / Error / Not-found の各状態で `AppNav` が描画されることを確認するテストを追加
- `VideoGroupDetailPage.test.tsx`: 初回ロード中に `AppNav` が描画されることを確認するテストを追加
- 両ファイルで `AppNav` を `<nav data-testid="app-nav" />` を返すモックに上書きして検証

## Test plan

- [ ] `npx vitest run` — 全553テストがパスすること
- [ ] 動画詳細画面を開いた際、ローディング中もヘッダーが表示されること
- [ ] グループ詳細画面を開いた際、ローディング中もヘッダーが表示されること
- [ ] グループ詳細でビデオ追加・削除・並び替え後の再フェッチ中にヘッダーが消えないこと

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)