### PR TITLE
fix: タグフィルターの絞り込みロジックをANDからORに変更する

### DIFF
--- a/backend/app/infrastructure/repositories/django_video_repository.py
+++ b/backend/app/infrastructure/repositories/django_video_repository.py
@@ -167,8 +167,7 @@ class DjangoVideoRepository(VideoRepository):
             queryset = queryset.filter(status=search.status_filter)
 
         if search.tag_ids:
-            for tag_id in search.tag_ids:
-                queryset = queryset.filter(tags__id=tag_id)
+            queryset = queryset.filter(tags__id__in=search.tag_ids).distinct()
 
         ordering_map = {
             "uploaded_at_desc": "-uploaded_at",

--- a/backend/app/infrastructure/repositories/tests/test_django_video_repository.py
+++ b/backend/app/infrastructure/repositories/tests/test_django_video_repository.py
@@ -1,0 +1,67 @@
+"""Integration tests for DjangoVideoRepository tag filtering."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.domain.video.dto import VideoSearchCriteria
+from app.infrastructure.models import Tag, Video, VideoTag
+from app.infrastructure.repositories.django_video_repository import DjangoVideoRepository
+
+User = get_user_model()
+
+
+class DjangoVideoRepositoryTagFilterTests(TestCase):
+    """Tests for tag filtering behavior in list_for_user."""
+
+    def setUp(self):
+        self.repo = DjangoVideoRepository()
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+        self.tag_a = Tag.objects.create(user=self.user, name="TagA")
+        self.tag_b = Tag.objects.create(user=self.user, name="TagB")
+        self.tag_c = Tag.objects.create(user=self.user, name="TagC")
+
+        self.video_a = Video.objects.create(user=self.user, title="Video A", status="completed")
+        self.video_b = Video.objects.create(user=self.user, title="Video B", status="completed")
+        self.video_ab = Video.objects.create(user=self.user, title="Video AB", status="completed")
+
+        VideoTag.objects.create(video=self.video_a, tag=self.tag_a)
+        VideoTag.objects.create(video=self.video_b, tag=self.tag_b)
+        VideoTag.objects.create(video=self.video_ab, tag=self.tag_a)
+        VideoTag.objects.create(video=self.video_ab, tag=self.tag_b)
+
+    def test_single_tag_filter_returns_videos_with_that_tag(self):
+        criteria = VideoSearchCriteria(tag_ids=[self.tag_a.id])
+        results = self.repo.list_for_user(self.user.id, criteria)
+        titles = {v.title for v in results}
+        self.assertIn("Video A", titles)
+        self.assertIn("Video AB", titles)
+        self.assertNotIn("Video B", titles)
+
+    def test_multiple_tag_filter_returns_videos_with_any_tag_or_logic(self):
+        """複数タグ選択時はORロジック（いずれかのタグを持つ動画）で返すこと"""
+        criteria = VideoSearchCriteria(tag_ids=[self.tag_a.id, self.tag_b.id])
+        results = self.repo.list_for_user(self.user.id, criteria)
+        titles = {v.title for v in results}
+        self.assertIn("Video A", titles)
+        self.assertIn("Video B", titles)
+        self.assertIn("Video AB", titles)
+
+    def test_multiple_tag_filter_no_duplicates(self):
+        """ORロジックでも重複動画が返らないこと（distinct）"""
+        criteria = VideoSearchCriteria(tag_ids=[self.tag_a.id, self.tag_b.id])
+        results = self.repo.list_for_user(self.user.id, criteria)
+        ids = [v.id for v in results]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_tag_filter_with_no_matching_tag_returns_empty(self):
+        criteria = VideoSearchCriteria(tag_ids=[self.tag_c.id])
+        results = self.repo.list_for_user(self.user.id, criteria)
+        self.assertEqual(results, [])
+
+    def test_no_tag_filter_returns_all_videos(self):
+        results = self.repo.list_for_user(self.user.id, VideoSearchCriteria())
+        self.assertEqual(len(results), 3)


### PR DESCRIPTION
## 概要

動画一覧のタグ絞り込みが AND ロジックになっており、複数タグ選択時に「すべてのタグを持つ動画のみ」が返されていた問題を修正。
OR ロジック（いずれかのタグを持つ動画）に変更する。

Closes #730

## 変更内容

### `backend/app/infrastructure/repositories/django_video_repository.py`

```python
# Before (AND)
for tag_id in search.tag_ids:
    queryset = queryset.filter(tags__id=tag_id)

# After (OR)
queryset = queryset.filter(tags__id__in=search.tag_ids).distinct()
```

`.filter()` を重ねると Django ORM が JOIN を重ねて AND になる。
`__in` を使うことで OR になり、`.distinct()` で重複を除去。

## テスト

`backend/app/infrastructure/repositories/tests/test_django_video_repository.py` を新規追加（5件）。

- 単一タグフィルターで対象動画が返ること
- 複数タグ選択時に OR ロジックで動画が返ること（今回の主要テスト）
- OR ロジックでも重複動画が返らないこと（distinct の確認）
- 一致するタグがない場合に空リストが返ること
- タグ未指定時に全動画が返ること

## Test plan

- [x] `docker compose run --rm backend python manage.py test app.infrastructure.repositories.tests.test_django_video_repository --keepdb` が全件パスすること
- [x] 動画一覧画面で複数タグを選択し、いずれかのタグを持つ動画がすべて表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)