### PR TITLE
fix: 動画一覧のページサイズを20から24に変更する

### DIFF
--- a/frontend/src/hooks/__tests__/useVideos.test.ts
+++ b/frontend/src/hooks/__tests__/useVideos.test.ts
@@ -53,7 +53,7 @@ describe('useVideos', () => {
   })
 
   it('should set hasNextPage to true when next is not null', async () => {
-    const mockVideos = Array.from({ length: 20 }, (_, i) => ({
+    const mockVideos = Array.from({ length: 24 }, (_, i) => ({
       id: i + 1,
       title: `Video ${i + 1}`,
       user: 1,
@@ -62,7 +62,7 @@ describe('useVideos', () => {
       status: 'completed' as const,
     }))
     ;(apiClient.getVideos as any).mockResolvedValue(
-      mockPaginatedResponse(mockVideos, 25, '/api/videos/?limit=20&offset=20'),
+      mockPaginatedResponse(mockVideos, 25, '/api/videos/?limit=24&offset=24'),
     )
 
     const { result } = renderHook(() => useVideos())
@@ -135,7 +135,7 @@ describe('useVideos', () => {
   })
 
   it('should load next page when fetchNextPage is called', async () => {
-    const page1 = Array.from({ length: 20 }, (_, i) => ({
+    const page1 = Array.from({ length: 24 }, (_, i) => ({
       id: i + 1,
       title: `Video ${i + 1}`,
       user: 1,
@@ -144,30 +144,30 @@ describe('useVideos', () => {
       status: 'completed' as const,
     }))
     const page2 = [
-      { id: 21, title: 'Video 21', user: 1, file: '', uploaded_at: '', status: 'completed' as const },
+      { id: 25, title: 'Video 25', user: 1, file: '', uploaded_at: '', status: 'completed' as const },
     ]
 
     ;(apiClient.getVideos as any)
       .mockResolvedValueOnce(
-        mockPaginatedResponse(page1, 21, '/api/videos/?limit=20&offset=20'),
+        mockPaginatedResponse(page1, 25, '/api/videos/?limit=24&offset=24'),
       )
-      .mockResolvedValueOnce(mockPaginatedResponse(page2, 21, null))
+      .mockResolvedValueOnce(mockPaginatedResponse(page2, 25, null))
 
     const { result } = renderHook(() => useVideos())
 
-    await waitFor(() => expect(result.current.videos).toHaveLength(20))
+    await waitFor(() => expect(result.current.videos).toHaveLength(24))
 
     await act(async () => {
       result.current.fetchNextPage()
     })
 
     await waitFor(() => {
-      expect(result.current.videos).toHaveLength(21)
+      expect(result.current.videos).toHaveLength(25)
     })
   })
 
   it('should flatten videos from multiple pages', async () => {
-    const page1 = Array.from({ length: 20 }, (_, i) => ({
+    const page1 = Array.from({ length: 24 }, (_, i) => ({
       id: i + 1,
       title: `Video ${i + 1}`,
       user: 1,
@@ -176,8 +176,8 @@ describe('useVideos', () => {
       status: 'completed' as const,
     }))
     const page2 = Array.from({ length: 5 }, (_, i) => ({
-      id: i + 21,
-      title: `Video ${i + 21}`,
+      id: i + 25,
+      title: `Video ${i + 25}`,
       user: 1,
       file: '',
       uploaded_at: '',
@@ -186,22 +186,22 @@ describe('useVideos', () => {
 
     ;(apiClient.getVideos as any)
       .mockResolvedValueOnce(
-        mockPaginatedResponse(page1, 25, '/api/videos/?limit=20&offset=20'),
+        mockPaginatedResponse(page1, 29, '/api/videos/?limit=24&offset=24'),
       )
-      .mockResolvedValueOnce(mockPaginatedResponse(page2, 25, null))
+      .mockResolvedValueOnce(mockPaginatedResponse(page2, 29, null))
 
     const { result } = renderHook(() => useVideos())
 
-    await waitFor(() => expect(result.current.videos).toHaveLength(20))
+    await waitFor(() => expect(result.current.videos).toHaveLength(24))
 
     await act(async () => {
       result.current.fetchNextPage()
     })
 
     await waitFor(() => {
-      expect(result.current.videos).toHaveLength(25)
+      expect(result.current.videos).toHaveLength(29)
       expect(result.current.videos[0].id).toBe(1)
-      expect(result.current.videos[20].id).toBe(21)
+      expect(result.current.videos[24].id).toBe(25)
     })
   })
 

--- a/frontend/src/hooks/__tests__/useVideos.test.ts
+++ b/frontend/src/hooks/__tests__/useVideos.test.ts
@@ -134,6 +134,18 @@ describe('useVideos', () => {
     })
   })
 
+  it('should pass limit=24 and offset=0 to API on first page', async () => {
+    ;(apiClient.getVideos as any).mockResolvedValue(mockPaginatedResponse([]))
+
+    renderHook(() => useVideos())
+
+    await waitFor(() => {
+      expect(apiClient.getVideos).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 24, offset: 0 }),
+      )
+    })
+  })
+
   it('should load next page when fetchNextPage is called', async () => {
     const page1 = Array.from({ length: 24 }, (_, i) => ({
       id: i + 1,
@@ -163,6 +175,12 @@ describe('useVideos', () => {
 
     await waitFor(() => {
       expect(result.current.videos).toHaveLength(25)
+      expect(apiClient.getVideos).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 24, offset: 0 }),
+      )
+      expect(apiClient.getVideos).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 24, offset: 24 }),
+      )
     })
   })
 

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -4,7 +4,7 @@ import { apiClient, type Video, type VideoList as VideoListType } from '@/lib/ap
 import { useI18nNavigate } from '@/lib/i18n';
 import { queryKeys } from '@/lib/queryKeys';
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 24;
 
 export type VideosOrdering = 'uploaded_at_desc' | 'uploaded_at_asc' | 'title_asc' | 'title_desc';
 


### PR DESCRIPTION
## Summary

- `PAGE_SIZE` を `20` → `24`（8行 × 3列）に変更
- 3列表示の動画一覧で最終行が中途半端にならないよう調整
- テスト内のハードコードされた `limit=20` / 配列長 / video ID をすべて `24` ベースに修正

## Test plan

- [ ] `useVideos` テスト 16件すべてパスすることを確認
- [ ] 動画一覧画面で1ページ24件表示されることを確認
- [ ] 次ページ読み込み（infinite scroll）が正常に動作することを確認

closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)