### PR TITLE
feat: 動画一覧の「もっと見る」ボタンを無限スクロールに変更する

### DIFF
--- a/frontend/src/hooks/__tests__/useVideos.test.ts
+++ b/frontend/src/hooks/__tests__/useVideos.test.ts
@@ -236,6 +236,88 @@ describe('useVideos', () => {
   })
 })
 
+describe('useVideos - sentinelRef', () => {
+  let capturedCallback: IntersectionObserverCallback | undefined
+  const mockObserve = vi.fn()
+  const mockDisconnect = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedCallback = undefined
+    mockObserve.mockClear()
+    mockDisconnect.mockClear()
+
+    Object.defineProperty(window, 'IntersectionObserver', {
+      writable: true,
+      configurable: true,
+      value: vi.fn((callback: IntersectionObserverCallback) => {
+        capturedCallback = callback
+        return { observe: mockObserve, unobserve: vi.fn(), disconnect: mockDisconnect }
+      }),
+    })
+  })
+
+  it('should return a sentinelRef function', async () => {
+    ;(apiClient.getVideos as any).mockResolvedValue(mockPaginatedResponse([]))
+    const { result } = renderHook(() => useVideos())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(typeof result.current.sentinelRef).toBe('function')
+  })
+
+  it('should observe the sentinel element when attached', async () => {
+    ;(apiClient.getVideos as any).mockResolvedValue(mockPaginatedResponse([]))
+    const { result } = renderHook(() => useVideos())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const div = document.createElement('div')
+    await act(async () => { result.current.sentinelRef(div) })
+
+    expect(mockObserve).toHaveBeenCalledWith(div)
+  })
+
+  it('should fetch next page when sentinel enters the viewport', async () => {
+    const page1 = Array.from({ length: 24 }, (_, i) => ({
+      id: i + 1,
+      title: `Video ${i + 1}`,
+      user: 1,
+      file: '',
+      uploaded_at: '',
+      status: 'completed' as const,
+    }))
+    const page2 = [{ id: 25, title: 'Video 25', user: 1, file: '', uploaded_at: '', status: 'completed' as const }]
+
+    ;(apiClient.getVideos as any)
+      .mockResolvedValueOnce(mockPaginatedResponse(page1, 25, '/api/videos/?limit=24&offset=24'))
+      .mockResolvedValueOnce(mockPaginatedResponse(page2, 25, null))
+
+    const { result } = renderHook(() => useVideos())
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true))
+
+    const div = document.createElement('div')
+    await act(async () => { result.current.sentinelRef(div) })
+
+    act(() => {
+      capturedCallback!([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver)
+    })
+
+    await waitFor(() => {
+      expect(result.current.videos).toHaveLength(25)
+    })
+  })
+
+  it('should disconnect observer when sentinel is detached', async () => {
+    ;(apiClient.getVideos as any).mockResolvedValue(mockPaginatedResponse([]))
+    const { result } = renderHook(() => useVideos())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const div = document.createElement('div')
+    await act(async () => { result.current.sentinelRef(div) })
+    await act(async () => { result.current.sentinelRef(null) })
+
+    expect(mockDisconnect).toHaveBeenCalled()
+  })
+})
+
 describe('useVideo', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/frontend/src/hooks/__tests__/useVideos.test.ts
+++ b/frontend/src/hooks/__tests__/useVideos.test.ts
@@ -305,6 +305,57 @@ describe('useVideos - sentinelRef', () => {
     })
   })
 
+  it('should not make duplicate API requests on rapid intersections while fetching', async () => {
+    const page1 = Array.from({ length: 24 }, (_, i) => ({
+      id: i + 1,
+      title: `Video ${i + 1}`,
+      user: 1,
+      file: '',
+      uploaded_at: '',
+      status: 'completed' as const,
+    }))
+
+    let resolvePage2!: (value: any) => void
+    const page2Promise = new Promise<any>(resolve => { resolvePage2 = resolve })
+
+    ;(apiClient.getVideos as any)
+      .mockResolvedValueOnce(mockPaginatedResponse(page1, 25, '/api/videos/?limit=24&offset=24'))
+      .mockReturnValueOnce(page2Promise)
+
+    const { result } = renderHook(() => useVideos())
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true))
+
+    const div = document.createElement('div')
+    await act(async () => { result.current.sentinelRef(div) })
+
+    // First intersection — starts page 2 fetch
+    act(() => {
+      capturedCallback!([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver)
+    })
+
+    // Wait for isFetchingNextPage to become true (effect re-runs → new observer with guard)
+    await waitFor(() => expect(result.current.isFetchingNextPage).toBe(true))
+
+    // Second intersection while still fetching — guard should prevent duplicate
+    act(() => {
+      capturedCallback!([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver)
+    })
+
+    // Resolve page 2
+    await act(async () => {
+      resolvePage2(mockPaginatedResponse(
+        [{ id: 25, title: 'Video 25', user: 1, file: '', uploaded_at: '', status: 'completed' as const }],
+        25,
+        null,
+      ))
+    })
+
+    await waitFor(() => expect(result.current.isFetchingNextPage).toBe(false))
+
+    // initial fetch (1) + page 2 (1) = 2 total — no duplicate page 2 request
+    expect(apiClient.getVideos).toHaveBeenCalledTimes(2)
+  })
+
   it('should disconnect observer when sentinel is detached', async () => {
     ;(apiClient.getVideos as any).mockResolvedValue(mockPaginatedResponse([]))
     const { result } = renderHook(() => useVideos())

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -90,13 +90,13 @@ export function useVideos(params?: UseVideosParams): UseVideosReturn {
   useEffect(() => {
     if (!sentinelNode) return;
     const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) {
+      if (entries[0].isIntersecting && videosQuery.hasNextPage && !videosQuery.isFetchingNextPage) {
         fetchNextPageRef.current();
       }
     });
     observer.observe(sentinelNode);
     return () => observer.disconnect();
-  }, [sentinelNode]);
+  }, [sentinelNode, videosQuery.hasNextPage, videosQuery.isFetchingNextPage]);
 
   return {
     videos,

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useEffect } from 'react';
+import { useCallback, useMemo, useEffect, useState, useRef } from 'react';
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { apiClient, type Video, type VideoList as VideoListType } from '@/lib/api';
 import { useI18nNavigate } from '@/lib/i18n';
@@ -27,6 +27,7 @@ interface UseVideosReturn {
   totalCount: number;
   loadVideos: () => Promise<void>;
   refetch: () => Promise<void>;
+  sentinelRef: React.RefCallback<HTMLElement>;
 }
 
 export function useVideos(params?: UseVideosParams): UseVideosReturn {
@@ -74,6 +75,29 @@ export function useVideos(params?: UseVideosParams): UseVideosReturn {
     void videosQuery.fetchNextPage();
   }, [videosQuery]);
 
+  // Keep a ref to the latest fetchNextPage so the observer is not recreated on every render
+  const fetchNextPageRef = useRef(fetchNextPage);
+  useEffect(() => {
+    fetchNextPageRef.current = fetchNextPage;
+  });
+
+  const [sentinelNode, setSentinelNode] = useState<HTMLElement | null>(null);
+
+  const sentinelRef: React.RefCallback<HTMLElement> = useCallback((node) => {
+    setSentinelNode(node);
+  }, []);
+
+  useEffect(() => {
+    if (!sentinelNode) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        fetchNextPageRef.current();
+      }
+    });
+    observer.observe(sentinelNode);
+    return () => observer.disconnect();
+  }, [sentinelNode]);
+
   return {
     videos,
     isLoading: videosQuery.isLoading,
@@ -84,6 +108,7 @@ export function useVideos(params?: UseVideosParams): UseVideosReturn {
     totalCount,
     loadVideos: handleRefetch,
     refetch: handleRefetch,
+    sentinelRef,
   };
 }
 

--- a/frontend/src/pages/VideosPage.tsx
+++ b/frontend/src/pages/VideosPage.tsx
@@ -27,10 +27,9 @@ export default function VideosPage() {
     videos,
     isLoading,
     error,
-    hasNextPage,
-    fetchNextPage,
     isFetchingNextPage,
     totalCount,
+    sentinelRef,
     refetch: refetchVideos,
   } = useVideos({
     tagIds: selectedTagIds,
@@ -233,18 +232,11 @@ export default function VideosPage() {
               </div>
             )}
 
-            {(hasNextPage || isFetchingNextPage) && (
-              <div className="flex justify-center mt-8">
-                {isFetchingNextPage ? (
-                  <span className="text-sm text-[#3f493f]">{t('videos.list.loadingMore')}</span>
-                ) : (
-                  <button
-                    onClick={fetchNextPage}
-                    className="px-6 py-2.5 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm font-semibold text-[#3f493f] hover:bg-[#e7e9e4] transition-colors"
-                  >
-                    {t('videos.list.loadMore')}
-                  </button>
-                )}
+            <div ref={sentinelRef} data-testid="infinite-scroll-sentinel" />
+
+            {isFetchingNextPage && (
+              <div className="flex justify-center mt-4">
+                <span className="text-sm text-[#3f493f]">{t('videos.list.loadingMore')}</span>
               </div>
             )}
           </>

--- a/frontend/src/pages/__tests__/VideosPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideosPage.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@/hooks/useVideos', () => ({
     totalCount: mockTotalCount,
     loadVideos: mockLoadVideos,
     refetch: mockLoadVideos,
+    sentinelRef: vi.fn(),
   }),
 }))
 
@@ -159,47 +160,23 @@ describe('VideosPage', () => {
     expect(statCards.length).toBeGreaterThan(0)
   })
 
-  it('should not render load more button when hasNextPage is false', () => {
-    mockHasNextPage = false
+  it('should not render load more button', () => {
     render(<VideosPage />)
 
     expect(screen.queryByText('videos.list.loadMore')).not.toBeInTheDocument()
   })
 
-  it('should render load more button when hasNextPage is true', () => {
-    mockHasNextPage = true
+  it('should render infinite scroll sentinel element', () => {
     render(<VideosPage />)
 
-    expect(screen.getByText('videos.list.loadMore')).toBeInTheDocument()
-  })
-
-  it('should call fetchNextPage when load more button is clicked', async () => {
-    mockHasNextPage = true
-    render(<VideosPage />)
-
-    const loadMoreButton = screen.getByText('videos.list.loadMore')
-    fireEvent.click(loadMoreButton)
-
-    expect(mockFetchNextPage).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('infinite-scroll-sentinel')).toBeInTheDocument()
   })
 
   it('should show loading text when isFetchingNextPage is true', () => {
-    mockHasNextPage = true
     mockIsFetchingNextPage = true
     render(<VideosPage />)
 
     expect(screen.getByText('videos.list.loadingMore')).toBeInTheDocument()
-  })
-
-  it('should show load more button even when status filter results in empty list', () => {
-    mockHasNextPage = true
-    render(<VideosPage />)
-
-    // error フィルタを選択 — mockVideos に error ステータスはないので空になる
-    fireEvent.click(screen.getByText('videos.list.filter.error'))
-
-    // 絞り込み結果が空でも hasNextPage があるので load more は表示される
-    expect(screen.getByText('videos.list.loadMore')).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Summary

- `useVideos` に `sentinelRef` を追加し、`IntersectionObserver` でリスト末尾のセンチネル要素を監視
- センチネルがビューポートに入ったタイミングで `fetchNextPage` を自動呼び出し（無限スクロール）
- `VideosPage` の「もっと見る」ボタンを廃止し、センチネル要素に置き換え
- `isFetchingNextPage` 時のローディング表示は維持

Closes #733

## Test plan

- [ ] `useVideos - sentinelRef` テスト 4件がすべて通過すること
- [ ] `VideosPage` テストがすべて通過すること（ボタン関連テスト削除、センチネル要素テスト追加）
- [ ] 動画一覧ページでスクロールすると次ページが自動読み込みされること
- [ ] 最終ページに達した後は追加読み込みが発生しないこと
- [ ] 読み込み中は「読み込み中...」インジケーターが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)