### PR TITLE
認証状態確認とチャットストリームの refresh 抜けを修正

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -455,7 +455,6 @@
       "badge": "Welcome back",
       "submit": "Sign in",
       "submitting": "Signing in...",
-      "rememberMe": "Stay signed in",
       "orDivider": "or",
       "footerQuestion": "Don't have an account?",
       "footerLink": "Register here",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -455,7 +455,6 @@
       "badge": "おかえりなさい",
       "submit": "ログイン",
       "submitting": "ログイン中...",
-      "rememberMe": "ログイン状態を保持",
       "orDivider": "または",
       "footerQuestion": "アカウントをお持ちでない方は",
       "footerLink": "こちらから登録",

--- a/frontend/src/lib/__tests__/api.stream.test.ts
+++ b/frontend/src/lib/__tests__/api.stream.test.ts
@@ -122,6 +122,41 @@ describe('apiClient.chatStream', () => {
     })).rejects.toThrow()
   })
 
+  it('refreshes once and retries the stream request when access token is expired', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { code: 'AUTHENTICATION_FAILED', message: 'Expired' } }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeSSEResponse([
+          'data: {"type":"content_chunk","text":"Recovered"}',
+          'data: {"type":"done","chat_log_id":7,"feedback":null}',
+        ]),
+      )
+
+    const events = await collectStreamEvents({
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+
+    expect(events).toEqual([
+      { type: 'content_chunk', text: 'Recovered' },
+      { type: 'done', chat_log_id: 7, feedback: null },
+    ])
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+    expect(fetchSpy.mock.calls[0][0]).toBe('http://localhost:8000/api/chat/messages/stream/')
+    expect(fetchSpy.mock.calls[1][0]).toBe('http://localhost:8000/api/auth/tokens/')
+    expect(fetchSpy.mock.calls[2][0]).toBe('http://localhost:8000/api/chat/messages/stream/')
+  })
+
   it('handles chunked SSE delivery across multiple reads', async () => {
     const encoder = new TextEncoder()
     // Split a single SSE line across two reads

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -213,6 +213,69 @@ describe('ApiClient', () => {
       expect(result).toEqual(mockUser);
     });
 
+    it('getMeOrNull should refresh once and retry when access token is expired', async () => {
+      const mockUser = { id: 1, username: 'test' };
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: () => Promise.resolve('{}'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: () => Promise.resolve('{}'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: () => Promise.resolve(JSON.stringify(mockUser)),
+        });
+
+      const result = await apiClient.getMeOrNull();
+
+      expect(result).toEqual(mockUser);
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        'http://localhost:8000/api/auth/me',
+        expect.objectContaining({ credentials: 'include' }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:8000/api/auth/tokens/',
+        expect.objectContaining({ method: 'POST', credentials: 'include' }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        'http://localhost:8000/api/auth/me',
+        expect.objectContaining({ credentials: 'include' }),
+      );
+    });
+
+    it('getMeOrNull should return null when refresh also fails', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: () => Promise.resolve('{}'),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: () => Promise.resolve('{}'),
+        });
+
+      const result = await apiClient.getMeOrNull();
+
+      expect(result).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
     it('getIntegrationApiKeys should return api key summaries', async () => {
       const mockKeys = [{ id: 1, name: 'integration', access_level: 'all', prefix: 'vq_123', last_used_at: null, created_at: '2026-03-02T00:00:00Z' }];
       fetchMock.mockResolvedValueOnce({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -644,11 +644,23 @@ class ApiClient {
     return this.request<User>('/auth/me');
   }
 
+  private fetchMe(): Promise<Response> {
+    const url = this.buildUrl('/auth/me');
+    const headers = this.buildHeaders();
+    return fetch(url, { credentials: 'include', headers });
+  }
+
   async getMeOrNull(): Promise<User | null> {
     try {
-      const url = this.buildUrl('/auth/me');
-      const headers = this.buildHeaders();
-      const response = await fetch(url, { credentials: 'include', headers });
+      let response = await this.fetchMe();
+      if (response.status === 401) {
+        try {
+          await this.refreshToken();
+        } catch {
+          return null;
+        }
+        response = await this.fetchMe();
+      }
       if (!response.ok) return null;
       return await this.parseJsonResponse<User>(response);
     } catch {
@@ -723,12 +735,26 @@ class ApiClient {
       headers['X-CSRFToken'] = csrfToken;
     }
 
-    const response = await fetch(url, {
+    const fetchStream = () => fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(bodyData),
       credentials: 'include',
     });
+
+    let response = await fetchStream();
+    if (response.status === 401) {
+      try {
+        await this.refreshToken();
+        response = await fetchStream();
+      } catch {
+        await this.handleAuthError();
+      }
+    }
+
+    if (response.status === 401) {
+      await this.handleAuthError();
+    }
 
     if (!response.ok) {
       await this.handleError(response);

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -88,16 +88,7 @@ export default function LoginPage() {
           </div>
         </div>
 
-        <div className="flex items-center justify-between py-1">
-          <label className="flex items-center gap-2 cursor-pointer group">
-            <input
-              type="checkbox"
-              className="w-4 h-4 rounded border-gray-300 text-[#00652c] focus:ring-[#00652c]/30 cursor-pointer accent-[#00652c]"
-            />
-            <span className="text-xs text-gray-500 group-hover:text-[#00652c] transition-colors">
-              {t('auth.login.rememberMe')}
-            </span>
-          </label>
+        <div className="flex justify-end py-1">
           <Link
             href="/forgot-password"
             className="text-xs font-bold text-[#00652c] hover:text-[#005323] transition-colors"

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -43,6 +43,12 @@ describe('LoginPage', () => {
     expect(forgotLink).toBeInTheDocument()
   })
 
+  it('should not render an inert stay signed in checkbox', () => {
+    render(<LoginPage />)
+
+    expect(screen.queryByText('auth.login.rememberMe')).not.toBeInTheDocument()
+  })
+
   it('should render signup link', () => {
     render(<LoginPage />)
 


### PR DESCRIPTION
## Summary
- `getMeOrNull()` で `/auth/me` が 401 の場合に一度だけ refresh して再取得するよう修正
- `chatStream()` で初回 401 時に refresh 後、ストリームリクエストを一度だけ再実行
- 実装されていない「ログイン状態を保持」チェックボックスと未使用翻訳キーを削除

## Tests
- `npm test -- src/lib/__tests__/api.test.ts src/lib/__tests__/api.stream.test.ts src/pages/__tests__/LoginPage.test.tsx`
- `npm test -- src/hooks/__tests__/useAuth.test.ts src/components/layout/__tests__/AppNav.test.tsx src/pages/__tests__/HomePage.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm test`

Closes #736