### PR TITLE
feat: React Query の cache key と invalidation を一元化する

### DIFF
--- a/frontend/src/hooks/useVideoDetailPageData.ts
+++ b/frontend/src/hooks/useVideoDetailPageData.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api';
-import { queryKeys } from '@/lib/queryKeys';
+import {
+  invalidateAfterVideoDelete,
+  invalidateAfterVideoUpdate,
+} from '@/lib/cacheInvalidation';
 
 interface UseVideoDetailPageMutationsParams {
   videoId: number | null;
@@ -28,12 +31,8 @@ export function useVideoDetailPageMutations({
     },
     onSuccess: async () => {
       if (videoId) {
-        queryClient.removeQueries({ queryKey: queryKeys.videos.detail(videoId) });
+        await invalidateAfterVideoDelete(queryClient, videoId);
       }
-      await queryClient.invalidateQueries({ queryKey: queryKeys.videos.all });
-      await queryClient.invalidateQueries({ queryKey: ['videoGroup'] });
-      await queryClient.invalidateQueries({ queryKey: ['sharedVideoGroup'] });
-      await queryClient.invalidateQueries({ queryKey: ['popularScenes'] });
       onDeleteSuccess();
     },
     onError: (err) => {
@@ -48,10 +47,7 @@ export function useVideoDetailPageMutations({
     onSuccess: async () => {
       onUpdateSuccess();
       if (videoId) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.videos.detail(videoId) });
-        await queryClient.invalidateQueries({ queryKey: queryKeys.videos.all });
-        await queryClient.invalidateQueries({ queryKey: ['videoGroup'] });
-        await queryClient.invalidateQueries({ queryKey: ['sharedVideoGroup'] });
+        await invalidateAfterVideoUpdate(queryClient, videoId);
       }
     },
   });

--- a/frontend/src/hooks/useVideoGroupDetailData.ts
+++ b/frontend/src/hooks/useVideoGroupDetailData.ts
@@ -2,6 +2,10 @@ import { useCallback } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient, type VideoGroup, type VideoList } from '@/lib/api';
 import { queryKeys } from '@/lib/queryKeys';
+import {
+  invalidateAfterGroupDelete,
+  invalidateAfterGroupVideoRemove,
+} from '@/lib/cacheInvalidation';
 import { createVideoIdSet } from '@/lib/utils/videoConversion';
 
 interface UseVideoGroupDetailQueryResult {
@@ -138,9 +142,8 @@ export function useVideoGroupDetailMutations({
       return videoId;
     },
     onSuccess: async () => {
-      await syncGroupDetail();
       if (groupId) {
-        await queryClient.invalidateQueries({ queryKey: ['popularScenes', groupId] });
+        await invalidateAfterGroupVideoRemove(queryClient, groupId);
       }
     },
   });
@@ -162,7 +165,7 @@ export function useVideoGroupDetailMutations({
       await apiClient.deleteVideoGroup(groupId);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['videoGroups'] });
+      await invalidateAfterGroupDelete(queryClient);
       onDeleteSuccess();
     },
   });

--- a/frontend/src/hooks/useVideoUpload.ts
+++ b/frontend/src/hooks/useVideoUpload.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient, ApiError, type VideoUploadRequest } from '@/lib/api';
-import { queryKeys } from '@/lib/queryKeys';
+import { invalidateAfterVideoUpload } from '@/lib/cacheInvalidation';
 import { useAuth } from '@/hooks/useAuth';
 
 interface UseVideoUploadReturn {
@@ -127,7 +127,7 @@ export function useVideoUpload(): UseVideoUploadReturn {
       setError(null);
       setErrorParams({});
       setProgress(100);
-      await queryClient.invalidateQueries({ queryKey: queryKeys.videos.all });
+      await invalidateAfterVideoUpload(queryClient);
     },
     onError: (err) => {
       if (err instanceof ApiError && err.code === 'FILE_TOO_LARGE') {

--- a/frontend/src/lib/__tests__/cacheInvalidation.test.ts
+++ b/frontend/src/lib/__tests__/cacheInvalidation.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { QueryClient } from '@tanstack/react-query'
+import {
+  invalidateAfterVideoUpload,
+  invalidateAfterVideoDelete,
+  invalidateAfterVideoUpdate,
+  invalidateAfterTranscriptEdit,
+  invalidateAfterGroupDelete,
+  invalidateAfterGroupVideoRemove,
+} from '../cacheInvalidation'
+import { queryKeys } from '../queryKeys'
+
+function createMockQueryClient(): QueryClient {
+  return {
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    removeQueries: vi.fn(),
+  } as unknown as QueryClient
+}
+
+describe('invalidateAfterVideoUpload', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = createMockQueryClient()
+  })
+
+  it('invalidates videos.all', async () => {
+    await invalidateAfterVideoUpload(queryClient)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videos.all,
+    })
+  })
+})
+
+describe('invalidateAfterVideoDelete', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = createMockQueryClient()
+  })
+
+  it('removes the video detail cache', async () => {
+    await invalidateAfterVideoDelete(queryClient, 42)
+    expect(queryClient.removeQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videos.detail(42),
+    })
+  })
+
+  it('invalidates videos.all', async () => {
+    await invalidateAfterVideoDelete(queryClient, 42)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videos.all,
+    })
+  })
+
+  it('invalidates all videoGroup detail queries', async () => {
+    await invalidateAfterVideoDelete(queryClient, 42)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videoGroups.allDetail,
+    })
+  })
+
+  it('invalidates all sharedVideoGroup queries', async () => {
+    await invalidateAfterVideoDelete(queryClient, 42)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videoGroups.allShared,
+    })
+  })
+
+  it('invalidates all popularScenes queries', async () => {
+    await invalidateAfterVideoDelete(queryClient, 42)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.popularScenes.all,
+    })
+  })
+})
+
+describe('invalidateAfterVideoUpdate', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = createMockQueryClient()
+  })
+
+  it('invalidates the specific video detail', async () => {
+    await invalidateAfterVideoUpdate(queryClient, 7)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videos.detail(7),
+    })
+  })
+
+  it('invalidates videos.all', async () => {
+    await invalidateAfterVideoUpdate(queryClient, 7)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videos.all,
+    })
+  })
+
+  it('invalidates all videoGroup detail queries', async () => {
+    await invalidateAfterVideoUpdate(queryClient, 7)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videoGroups.allDetail,
+    })
+  })
+
+  it('invalidates all sharedVideoGroup queries', async () => {
+    await invalidateAfterVideoUpdate(queryClient, 7)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videoGroups.allShared,
+    })
+  })
+})
+
+describe('invalidateAfterTranscriptEdit', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = createMockQueryClient()
+  })
+
+  it('invalidates the specific video detail', async () => {
+    await invalidateAfterTranscriptEdit(queryClient, 3)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videos.detail(3),
+    })
+  })
+
+  it('invalidates all videoGroup detail queries', async () => {
+    await invalidateAfterTranscriptEdit(queryClient, 3)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videoGroups.allDetail,
+    })
+  })
+
+  it('invalidates all sharedVideoGroup queries', async () => {
+    await invalidateAfterTranscriptEdit(queryClient, 3)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videoGroups.allShared,
+    })
+  })
+
+  it('invalidates all popularScenes queries', async () => {
+    await invalidateAfterTranscriptEdit(queryClient, 3)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.popularScenes.all,
+    })
+  })
+})
+
+describe('invalidateAfterGroupDelete', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = createMockQueryClient()
+  })
+
+  it('invalidates all videoGroups queries', async () => {
+    await invalidateAfterGroupDelete(queryClient)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videoGroups.prefix,
+    })
+  })
+})
+
+describe('invalidateAfterGroupVideoRemove', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = createMockQueryClient()
+  })
+
+  it('invalidates the specific group detail', async () => {
+    await invalidateAfterGroupVideoRemove(queryClient, 10)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.videoGroups.detail(10),
+    })
+  })
+
+  it('invalidates popularScenes for the specific group', async () => {
+    await invalidateAfterGroupVideoRemove(queryClient, 10)
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.popularScenes.byGroup(10),
+    })
+  })
+})

--- a/frontend/src/lib/cacheInvalidation.ts
+++ b/frontend/src/lib/cacheInvalidation.ts
@@ -1,0 +1,57 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { queryKeys } from './queryKeys'
+
+export async function invalidateAfterVideoUpload(queryClient: QueryClient): Promise<void> {
+  await queryClient.invalidateQueries({ queryKey: queryKeys.videos.all })
+}
+
+export async function invalidateAfterVideoDelete(
+  queryClient: QueryClient,
+  videoId: number,
+): Promise<void> {
+  queryClient.removeQueries({ queryKey: queryKeys.videos.detail(videoId) })
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.videos.all }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.videoGroups.allDetail }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.videoGroups.allShared }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.popularScenes.all }),
+  ])
+}
+
+export async function invalidateAfterVideoUpdate(
+  queryClient: QueryClient,
+  videoId: number,
+): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.videos.detail(videoId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.videos.all }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.videoGroups.allDetail }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.videoGroups.allShared }),
+  ])
+}
+
+export async function invalidateAfterTranscriptEdit(
+  queryClient: QueryClient,
+  videoId: number,
+): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.videos.detail(videoId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.videoGroups.allDetail }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.videoGroups.allShared }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.popularScenes.all }),
+  ])
+}
+
+export async function invalidateAfterGroupDelete(queryClient: QueryClient): Promise<void> {
+  await queryClient.invalidateQueries({ queryKey: queryKeys.videoGroups.prefix })
+}
+
+export async function invalidateAfterGroupVideoRemove(
+  queryClient: QueryClient,
+  groupId: number,
+): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.videoGroups.detail(groupId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.popularScenes.byGroup(groupId) }),
+  ])
+}

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -5,8 +5,11 @@ export const queryKeys = {
     searchApiKey: ['auth', 'searchApiKey'] as const,
   },
   videoGroups: {
+    prefix: ['videoGroups'] as const,
     all: (userId: number | string | null) => ['videoGroups', userId] as const,
+    allDetail: ['videoGroup'] as const,
     detail: (groupId: number | null) => ['videoGroup', groupId] as const,
+    allShared: ['sharedVideoGroup'] as const,
     shared: (shareToken: string) => ['sharedVideoGroup', shareToken] as const,
     addableVideos: (params: {
       groupId: number | null;
@@ -24,6 +27,10 @@ export const queryKeys = {
     infinite: (params?: { tags?: number[]; q?: string; ordering?: string }) =>
       ['videos', 'infinite', { tags: params?.tags ?? [], q: params?.q ?? '', ordering: params?.ordering ?? '' }] as const,
     detail: (videoId: number | null) => ['videos', 'detail', videoId] as const,
+  },
+  popularScenes: {
+    all: ['popularScenes'] as const,
+    byGroup: (groupId: number) => ['popularScenes', groupId] as const,
   },
   tags: {
     all: ['tags'] as const,

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -13,7 +13,7 @@ import { TagCreateDialog } from '@/components/video/TagCreateDialog';
 import { useTags } from '@/hooks/useTags';
 import { useVideoEditing } from '@/hooks/useVideoEditing';
 import { useVideoDetailPageMutations } from '@/hooks/useVideoDetailPageData';
-import { queryKeys } from '@/lib/queryKeys';
+import { invalidateAfterTranscriptEdit } from '@/lib/cacheInvalidation';
 import { AppNav } from '@/components/layout/AppNav';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import {
@@ -180,10 +180,7 @@ export default function VideoDetailPage() {
     },
     onSuccess: async () => {
       if (videoId) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.videos.detail(videoId) });
-        await queryClient.invalidateQueries({ queryKey: ['videoGroup'] });
-        await queryClient.invalidateQueries({ queryKey: ['sharedVideoGroup'] });
-        await queryClient.invalidateQueries({ queryKey: ['popularScenes'] });
+        await invalidateAfterTranscriptEdit(queryClient, videoId);
       }
       setIsTranscriptEditing(false);
       setTranscriptSearch('');


### PR DESCRIPTION
## Summary

- `queryKeys` に `videoGroups.prefix`、`videoGroups.allDetail`、`videoGroups.allShared`、`popularScenes` のキーを追加し、散在していたインラインキー文字列を一元管理
- キャッシュ無効化ロジックを `frontend/src/lib/cacheInvalidation.ts` に集約（`invalidateAfterVideoUpload`、`invalidateAfterVideoDelete`、`invalidateAfterVideoUpdate`、`invalidateAfterTranscriptEdit`、`invalidateAfterGroupDelete`、`invalidateAfterGroupVideoRemove`）
- `useVideoDetailPageData`、`useVideoGroupDetailData`、`useVideoUpload`、`VideoDetailPage` の各呼び出し側を新しい関数に置き換え

## Test plan

- [x] `frontend/src/lib/__tests__/cacheInvalidation.test.ts` の全ユニットテストがパスすること
- [x] 動画アップロード後に動画一覧が更新されること
- [x] 動画削除後に一覧・グループ詳細・人気シーンが更新されること
- [x] 動画タイトル編集後に詳細・一覧・グループ詳細が更新されること
- [x] 字幕編集後に詳細・グループ・人気シーンが更新されること
- [x] グループ削除後にグループ一覧が更新されること
- [x] グループから動画削除後にグループ詳細・人気シーンが更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)