### PR TITLE
Auth状態とAPIクライアントの責務を分離

### DIFF
--- a/frontend/src/components/auth/AuthProvider.tsx
+++ b/frontend/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api';
+import { useI18nLocation, useI18nNavigate } from '@/lib/i18n';
+import { isPublicAuthPath } from '@/lib/authConfig';
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const queryClient = useQueryClient();
+  const navigate = useI18nNavigate();
+  const location = useI18nLocation();
+  const pathnameRef = useRef(location.pathname);
+
+  useEffect(() => {
+    pathnameRef.current = location.pathname;
+  }, [location.pathname]);
+
+  useEffect(() => {
+    apiClient.setUnauthorizedHandler(() => {
+      queryClient.clear();
+      if (!isPublicAuthPath(pathnameRef.current)) {
+        navigate('/login');
+      }
+    });
+
+    return () => {
+      apiClient.setUnauthorizedHandler(undefined);
+    };
+  }, [navigate, queryClient]);
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/auth/__tests__/AuthProvider.test.tsx
+++ b/frontend/src/components/auth/__tests__/AuthProvider.test.tsx
@@ -1,0 +1,95 @@
+import { act, render } from '@testing-library/react'
+import { useEffect } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import type { QueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/lib/api'
+import { queryKeys } from '@/lib/queryKeys'
+import { useI18nNavigate } from '@/lib/i18n'
+import { AuthProvider } from '../AuthProvider'
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    setUnauthorizedHandler: vi.fn(),
+  },
+}))
+
+function latestUnauthorizedHandler(): (() => void | Promise<void>) {
+  const calls = (apiClient.setUnauthorizedHandler as ReturnType<typeof vi.fn>).mock.calls
+  for (let i = calls.length - 1; i >= 0; i -= 1) {
+    const candidate = calls[i][0]
+    if (typeof candidate === 'function') {
+      return candidate
+    }
+  }
+  throw new Error('Unauthorized handler was not registered')
+}
+
+describe('AuthProvider', () => {
+  let queryClient: QueryClient | null = null
+
+  function QueryClientProbe({ onClient }: { onClient: (client: QueryClient) => void }) {
+    const client = useQueryClient()
+    useEffect(() => {
+      onClient(client)
+    }, [client, onClient])
+    return null
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient = null
+    ;(globalThis as any).__setMockPathname?.('/videos')
+    window.history.pushState({}, '', '/videos')
+  })
+
+  it('clears cached auth state and redirects protected routes when any API reports unauthorized', async () => {
+    render(
+      <AuthProvider>
+        <QueryClientProbe onClient={(client) => { queryClient = client }} />
+      </AuthProvider>,
+    )
+
+    expect(apiClient.setUnauthorizedHandler).toHaveBeenCalledWith(expect.any(Function))
+    expect(queryClient).not.toBeNull()
+    queryClient!.setQueryData(queryKeys.auth.me, { id: 1, username: 'testuser' })
+
+    await act(async () => {
+      await latestUnauthorizedHandler()()
+    })
+
+    expect(queryClient!.getQueryData(queryKeys.auth.me)).toBeUndefined()
+    expect(useI18nNavigate()).toHaveBeenCalledWith('/login')
+  })
+
+  it('clears cached auth state without redirecting from public routes', async () => {
+    ;(globalThis as any).__setMockPathname?.('/login')
+    window.history.pushState({}, '', '/login')
+
+    render(
+      <AuthProvider>
+        <QueryClientProbe onClient={(client) => { queryClient = client }} />
+      </AuthProvider>,
+    )
+
+    queryClient!.setQueryData(queryKeys.auth.me, { id: 1, username: 'testuser' })
+
+    await act(async () => {
+      await latestUnauthorizedHandler()()
+    })
+
+    expect(queryClient!.getQueryData(queryKeys.auth.me)).toBeUndefined()
+    expect(useI18nNavigate()).not.toHaveBeenCalled()
+  })
+
+  it('unregisters the unauthorized handler on unmount', () => {
+    const { unmount } = render(
+      <AuthProvider>
+        <QueryClientProbe onClient={(client) => { queryClient = client }} />
+      </AuthProvider>,
+    )
+
+    unmount()
+
+    expect(apiClient.setUnauthorizedHandler).toHaveBeenLastCalledWith(undefined)
+  })
+})

--- a/frontend/src/hooks/__tests__/useVideos.test.ts
+++ b/frontend/src/hooks/__tests__/useVideos.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/lib/api', () => ({
   apiClient: {
     getVideos: vi.fn(),
     getVideo: vi.fn(),
-    isAuthenticated: vi.fn(),
+    getMe: vi.fn(),
   },
 }))
 
@@ -377,7 +377,7 @@ describe('useVideo', () => {
   })
 
   it('should initialize with null video', () => {
-    ;(apiClient.isAuthenticated as any).mockReturnValue(true)
+    ;(apiClient.getMe as any).mockReturnValue(new Promise(() => {}))
     ;(apiClient.getVideo as any).mockReturnValue(new Promise(() => {}))
     const { result } = renderHook(() => useVideo(1))
 
@@ -397,6 +397,7 @@ describe('useVideo', () => {
   })
 
   it('should load video', async () => {
+    const mockUser = { id: 1, username: 'testuser' }
     const mockVideo = {
       id: 1,
       title: 'Test Video',
@@ -405,7 +406,7 @@ describe('useVideo', () => {
       uploaded_at: '',
       status: 'completed' as const,
     }
-    ;(apiClient.isAuthenticated as any).mockReturnValue(true)
+    ;(apiClient.getMe as any).mockResolvedValue(mockUser)
     ;(apiClient.getVideo as any).mockResolvedValue(mockVideo)
 
     const { result } = renderHook(() => useVideo(1))
@@ -421,7 +422,7 @@ describe('useVideo', () => {
   })
 
   it('should redirect to login if not authenticated', async () => {
-    ;(apiClient.isAuthenticated as any).mockReturnValue(false)
+    ;(apiClient.getMe as any).mockRejectedValue(new Error('Unauthorized'))
 
     const { result } = renderHook(() => useVideo(1))
 
@@ -434,11 +435,36 @@ describe('useVideo', () => {
     })
 
     const navigate = useI18nNavigate()
-    expect(navigate).toHaveBeenCalledWith('/login')
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith('/login')
+    })
+    expect(apiClient.getVideo).not.toHaveBeenCalled()
+  })
+
+  it('should use the shared auth query instead of a separate isAuthenticated check', async () => {
+    const mockUser = { id: 1, username: 'testuser' }
+    const mockVideo = {
+      id: 1,
+      title: 'Test Video',
+      user: 1,
+      file: '',
+      uploaded_at: '',
+      status: 'completed' as const,
+    }
+    ;(apiClient.getMe as any).mockResolvedValue(mockUser)
+    ;(apiClient.getVideo as any).mockResolvedValue(mockVideo)
+
+    renderHook(() => useVideo(1))
+
+    await waitFor(() => {
+      expect(apiClient.getMe).toHaveBeenCalled()
+      expect(apiClient.getVideo).toHaveBeenCalledWith(1)
+    })
+    expect((apiClient as any).isAuthenticated).toBeUndefined()
   })
 
   it('should handle loading errors', async () => {
-    ;(apiClient.isAuthenticated as any).mockReturnValue(true)
+    ;(apiClient.getMe as any).mockResolvedValue({ id: 1, username: 'testuser' })
     ;(apiClient.getVideo as any).mockRejectedValue(new Error('Failed to load'))
 
     const { result } = renderHook(() => useVideo(1))

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useI18nNavigate, useI18nLocation, removeLocalePrefix } from '@/lib/i18n';
 import { apiClient, type User } from '@/lib/api';
 import { queryKeys } from '@/lib/queryKeys';
+import { isPublicAuthPath } from '@/lib/authConfig';
 
 interface UseAuthReturn {
   user: User | null;
@@ -31,17 +32,7 @@ export function useAuth(options: UseAuthOptions = {}): UseAuthReturn {
     onAuthErrorRef.current = onAuthError;
   }, [onAuthError]);
 
-  const publicPaths = [
-    '/login',
-    '/signup',
-    '/signup/check-email',
-    '/forgot-password',
-    '/reset-password',
-    '/verify-email',
-    '/share',
-    '/docs',
-  ];
-  const authRequired = !publicPaths.some((path) => pathname.startsWith(path));
+  const authRequired = !isPublicAuthPath(pathname);
 
   const authQuery = useQuery<User | null>({
     queryKey: queryKeys.auth.me,

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -55,8 +55,8 @@ export function useAuth(options: UseAuthOptions = {}): UseAuthReturn {
       return;
     }
 
-    // 401 errors are handled in apiClient.getMe(), and token refresh is attempted.
-    // If refresh also fails, apiClient redirects to /login.
+    // apiClient retries token refresh, then reports auth failure without routing.
+    // Redirect decisions stay in this hook so API calls remain UI-agnostic.
     console.error('Authentication check failed:', authQuery.error);
     if (redirectToLogin) {
       const currentPath = removeLocalePrefix(window.location.pathname);

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useEffect, useState, useRef } from 'react';
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { apiClient, type Video, type VideoList as VideoListType } from '@/lib/api';
-import { useI18nNavigate } from '@/lib/i18n';
+import { useAuth } from '@/hooks/useAuth';
 import { queryKeys } from '@/lib/queryKeys';
 
 const PAGE_SIZE = 24;
@@ -124,24 +124,11 @@ interface UseVideoReturn {
 }
 
 export function useVideo(videoId: number | null): UseVideoReturn {
-  const navigate = useI18nNavigate();
-  const authQuery = useQuery<boolean>({
-    queryKey: ['auth', 'status', videoId],
-    enabled: !!videoId,
-    queryFn: async () => await apiClient.isAuthenticated(),
-    retry: false,
-  });
-  const isAuthenticated = authQuery.data ?? false;
-
-  useEffect(() => {
-    if (videoId && authQuery.isFetched && !isAuthenticated) {
-      navigate('/login');
-    }
-  }, [videoId, authQuery.isFetched, isAuthenticated, navigate]);
+  const { user, isLoading: authLoading, refetch: refetchAuth } = useAuth();
 
   const videoQuery = useQuery<Video>({
     queryKey: queryKeys.videos.detail(videoId),
-    enabled: !!videoId && isAuthenticated,
+    enabled: !!videoId && !!user,
     queryFn: async () => {
       if (!videoId) {
         throw new Error('Video ID is required');
@@ -153,9 +140,9 @@ export function useVideo(videoId: number | null): UseVideoReturn {
   const handleLoadVideo = useCallback(async () => {
     if (!videoId) return;
 
-    const authenticated = await apiClient.isAuthenticated();
-    if (!authenticated) {
-      navigate('/login');
+    try {
+      await refetchAuth();
+    } catch {
       throw new Error('Authentication required');
     }
 
@@ -164,11 +151,11 @@ export function useVideo(videoId: number | null): UseVideoReturn {
       console.error('Failed to load video:', result.error);
       throw result.error;
     }
-  }, [videoId, navigate, videoQuery]);
+  }, [videoId, refetchAuth, videoQuery]);
 
   return {
     video: videoQuery.data || null,
-    isLoading: (!!videoId && authQuery.isLoading) || videoQuery.isLoading,
+    isLoading: (!!videoId && authLoading) || videoQuery.isLoading,
     error: videoQuery.error instanceof Error ? videoQuery.error.message : null,
     loadVideo: handleLoadVideo,
     refetch: handleLoadVideo,

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -11,7 +11,7 @@ vi.stubGlobal('import.meta', {
 });
 
 // Import the apiClient singleton
-import { apiClient } from '../api';
+import { apiClient, createApiClient } from '../api';
 
 describe('ApiClient', () => {
   // Mock fetch
@@ -414,7 +414,14 @@ describe('ApiClient', () => {
       expect(fetchMock).toHaveBeenCalledTimes(3);
     });
 
-    it('should handle 401 and redirect to login if refresh fails', async () => {
+    it('should handle 401 and call onUnauthorized if refresh fails', async () => {
+      const onUnauthorized = vi.fn();
+      const client = createApiClient({
+        baseUrl: 'http://localhost:8000/api',
+        fetchFn: fetchMock,
+        onUnauthorized,
+      });
+
       // First call fails with 401
       fetchMock.mockResolvedValueOnce({
         ok: false,
@@ -427,11 +434,19 @@ describe('ApiClient', () => {
       // Mock logout (which is called on auth error)
       fetchMock.mockResolvedValueOnce({ ok: true });
 
-      await expect(apiClient.getMe()).rejects.toThrow('Authentication failed');
-      expect(window.location.href).toBe('/login');
+      await expect(client.getMe()).rejects.toThrow('Authentication failed');
+      expect(onUnauthorized).toHaveBeenCalledTimes(1);
+      expect(window.location.href).toBe('http://frontend.example.com/');
     });
 
     it('should not cause infinite loop when refreshToken gets 401 (original request → refresh 401 → auth error)', async () => {
+      const onUnauthorized = vi.fn();
+      const client = createApiClient({
+        baseUrl: 'http://localhost:8000/api',
+        fetchFn: fetchMock,
+        onUnauthorized,
+      });
+
       // Original API call returns 401
       fetchMock.mockResolvedValueOnce({
         ok: false,
@@ -447,11 +462,32 @@ describe('ApiClient', () => {
       // Mock logout call
       fetchMock.mockResolvedValueOnce({ ok: true });
 
-      await expect(apiClient.getMe()).rejects.toThrow('Authentication failed');
+      await expect(client.getMe()).rejects.toThrow('Authentication failed');
       // Should be called exactly 3 times: original request + refresh attempt + logout
       // (NOT infinite calls)
       expect(fetchMock).toHaveBeenCalledTimes(3);
-      expect(window.location.href).toBe('/login');
+      expect(onUnauthorized).toHaveBeenCalledTimes(1);
+      expect(window.location.href).toBe('http://frontend.example.com/');
+    });
+
+    it('createApiClient should inject baseUrl and fetch implementation', async () => {
+      const customFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify({ id: 1, username: 'custom' })),
+      });
+      const client = createApiClient({
+        baseUrl: 'https://api.example.test/v1',
+        fetchFn: customFetch,
+      });
+
+      const result = await client.getMe();
+
+      expect(result).toEqual({ id: 1, username: 'custom' });
+      expect(customFetch).toHaveBeenCalledWith(
+        'https://api.example.test/v1/auth/me',
+        expect.objectContaining({ credentials: 'include' }),
+      );
     });
   });
 

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -489,6 +489,27 @@ describe('ApiClient', () => {
         expect.objectContaining({ credentials: 'include' }),
       );
     });
+
+    it('setUnauthorizedHandler should update the handler used by later auth failures', async () => {
+      const firstHandler = vi.fn();
+      const secondHandler = vi.fn();
+      const client = createApiClient({
+        baseUrl: 'http://localhost:8000/api',
+        fetchFn: fetchMock,
+        onUnauthorized: firstHandler,
+      });
+      client.setUnauthorizedHandler(secondHandler);
+
+      fetchMock
+        .mockResolvedValueOnce({ ok: false, status: 401 })
+        .mockRejectedValueOnce(new Error('Refresh failed'))
+        .mockResolvedValueOnce({ ok: true });
+
+      await expect(client.getMe()).rejects.toThrow('Authentication failed');
+
+      expect(firstHandler).not.toHaveBeenCalled();
+      expect(secondHandler).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Video Methods', () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,16 @@ export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/ap
 const USE_S3_STORAGE = import.meta.env.VITE_USE_S3_STORAGE === 'true';
 
 type RequestBody = BodyInit | object | null | undefined;
+type ApiFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+const defaultFetch: ApiFetch = (input, init) => (
+  init === undefined ? fetch(input) : fetch(input, init)
+);
+
+export interface ApiClientOptions {
+  baseUrl?: string;
+  fetchFn?: ApiFetch;
+  onUnauthorized?: () => void | Promise<void>;
+}
 
 interface PaginatedResponse<T> {
   count: number;
@@ -294,11 +304,15 @@ export interface TagUpdateRequest {
   color?: string;
 }
 
-class ApiClient {
+export class ApiClient {
   private baseUrl: string;
+  private fetchFn: ApiFetch;
+  private onUnauthorized?: () => void | Promise<void>;
 
-  constructor() {
-    this.baseUrl = API_URL;
+  constructor(options: ApiClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? API_URL;
+    this.fetchFn = options.fetchFn ?? defaultFetch;
+    this.onUnauthorized = options.onUnauthorized;
   }
 
   // HttpOnly Cookie-based authentication (security enhancement)
@@ -306,7 +320,7 @@ class ApiClient {
 
   async isAuthenticated(): Promise<boolean> {
     try {
-      const response = await fetch(`${this.baseUrl}/auth/me/`, {
+      const response = await this.fetchFn(`${this.baseUrl}/auth/me/`, {
         method: 'GET',
         credentials: 'include', // Send HttpOnly Cookie
         headers: {
@@ -322,7 +336,7 @@ class ApiClient {
   async logout(): Promise<void> {
     try {
       const csrfToken = await this.ensureCsrfToken();
-      await fetch(`${this.baseUrl}/auth/sessions/`, {
+      await this.fetchFn(`${this.baseUrl}/auth/sessions/`, {
         method: 'DELETE',
         credentials: 'include', // Send HttpOnly Cookie
         headers: {
@@ -384,7 +398,7 @@ class ApiClient {
     }
 
     // Fetch from server; cross-origin deployments return token in body
-    const response = await fetch(this.buildUrl('/auth/csrf/'), {
+    const response = await this.fetchFn(this.buildUrl('/auth/csrf/'), {
       method: 'GET',
       credentials: 'include',
       headers: {},
@@ -452,7 +466,7 @@ class ApiClient {
   private async handleAuthError(): Promise<void> {
     // With HttpOnly Cookie-based authentication, delegate logout to backend
     await this.logout();
-    window.location.href = '/login';
+    await this.onUnauthorized?.();
     throw new Error("Authentication failed");
   }
 
@@ -514,7 +528,7 @@ class ApiClient {
     url: string,
     config: RequestInit
   ): Promise<Response> {
-    const response = await fetch(url, config);
+    const response = await this.fetchFn(url, config);
 
     // Process errors other than 401 immediately
     if (!response.ok && response.status !== 401) {
@@ -647,7 +661,7 @@ class ApiClient {
   private fetchMe(): Promise<Response> {
     const url = this.buildUrl('/auth/me');
     const headers = this.buildHeaders();
-    return fetch(url, { credentials: 'include', headers });
+    return this.fetchFn(url, { credentials: 'include', headers });
   }
 
   async getMeOrNull(): Promise<User | null> {
@@ -735,7 +749,7 @@ class ApiClient {
       headers['X-CSRFToken'] = csrfToken;
     }
 
-    const fetchStream = () => fetch(url, {
+    const fetchStream = () => this.fetchFn(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(bodyData),
@@ -829,7 +843,7 @@ class ApiClient {
     const url = this.buildUrl(`/chat/groups/${groupId}/history/?download=csv`);
 
     const doFetch = async (): Promise<Response> => {
-      return fetch(url, {
+      return this.fetchFn(url, {
         method: 'GET',
         credentials: 'include',
         headers: {},
@@ -1075,7 +1089,7 @@ class ApiClient {
   async getSharedGroup(shareSlug: string): Promise<VideoGroup> {
     // Shared groups don't require authentication, so don't include credentials
     const url = this.buildUrl(`/videos/groups/share/${shareSlug}/`);
-    const response = await fetch(url);
+    const response = await this.fetchFn(url);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -1199,4 +1213,8 @@ class ApiClient {
 
 }
 
-export const apiClient = new ApiClient();
+export function createApiClient(options?: ApiClientOptions): ApiClient {
+  return new ApiClient(options);
+}
+
+export const apiClient = createApiClient();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -315,6 +315,10 @@ export class ApiClient {
     this.onUnauthorized = options.onUnauthorized;
   }
 
+  setUnauthorizedHandler(onUnauthorized: ApiClientOptions['onUnauthorized']): void {
+    this.onUnauthorized = onUnauthorized;
+  }
+
   // HttpOnly Cookie-based authentication (security enhancement)
   // Use HttpOnly Cookie instead of localStorage to prevent XSS attacks
 

--- a/frontend/src/lib/authConfig.ts
+++ b/frontend/src/lib/authConfig.ts
@@ -59,3 +59,17 @@ export const AUTH_FIELDS = {
   } as FormFieldConfig,
 } as const;
 
+export const PUBLIC_AUTH_PATHS = [
+  '/login',
+  '/signup',
+  '/signup/check-email',
+  '/forgot-password',
+  '/reset-password',
+  '/verify-email',
+  '/share',
+  '/docs',
+] as const;
+
+export function isPublicAuthPath(pathname: string): boolean {
+  return PUBLIC_AUTH_PATHS.some((path) => pathname.startsWith(path));
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import i18n from './i18n/config'
 import App from './App.tsx'
+import { AuthProvider } from './components/auth/AuthProvider'
 import { appQueryClient } from './lib/queryClient'
 import './index.css'
 
@@ -14,7 +15,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       <I18nextProvider i18n={i18n}>
         <QueryClientProvider client={appQueryClient}>
-          <App />
+          <AuthProvider>
+            <App />
+          </AuthProvider>
           {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
         </QueryClientProvider>
       </I18nextProvider>

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -242,5 +242,6 @@ vi.mock('@/lib/api', async (importOriginal) => {
     getVideoUrl: vi.fn(mockGetVideoUrl),
     getSharedVideoUrl: vi.fn(mockGetSharedVideoUrl),
     logout: vi.fn(() => Promise.resolve()),
+    setUnauthorizedHandler: vi.fn(),
   },
 }});


### PR DESCRIPTION
## Summary
- APIクライアントを factory 化し、baseUrl / fetch / onUnauthorized を注入可能にする
- API層からログインリダイレクトの副作用を外し、未認証時の遷移を useAuth 側へ集約
- useVideo の独自 isAuthenticated query を廃止し、共有 auth query に寄せる

## Tests
- npm test
- npm run typecheck
- npm run lint（既存 warning: frontend/src/hooks/useChatMessages.ts:205）
- git diff --check

Closes #738