### PR TITLE
動画一覧フィルタをURLとserver queryに同期

### DIFF
--- a/backend/app/infrastructure/repositories/django_video_repository.py
+++ b/backend/app/infrastructure/repositories/django_video_repository.py
@@ -164,7 +164,15 @@ class DjangoVideoRepository(VideoRepository):
             )
 
         if search.status_filter:
-            queryset = queryset.filter(status=search.status_filter)
+            status_values = [
+                status_value.strip()
+                for status_value in search.status_filter.split(",")
+                if status_value.strip()
+            ]
+            if len(status_values) == 1:
+                queryset = queryset.filter(status=status_values[0])
+            elif status_values:
+                queryset = queryset.filter(status__in=status_values)
 
         if search.tag_ids:
             queryset = queryset.filter(tags__id__in=search.tag_ids).distinct()

--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -359,6 +359,28 @@ class VideoListViewTests(APITestCase):
         for video in response.data["results"]:
             self.assertEqual(video["status"], "completed")
 
+    def test_list_videos_with_multiple_status_filter(self):
+        """Test video list with comma-separated status filters"""
+        Video.objects.create(
+            user=self.user,
+            title="Processing Video",
+            description="Currently processing",
+            status="processing",
+        )
+        Video.objects.create(
+            user=self.user,
+            title="Indexing Video",
+            description="Currently indexing",
+            status="indexing",
+        )
+
+        url = reverse("video-list")
+        response = self.client.get(url, {"status": "pending,processing,indexing,uploading"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        statuses = {video["status"] for video in response.data["results"]}
+        self.assertEqual(statuses, {"pending", "processing", "indexing"})
+
     def test_list_videos_with_ordering(self):
         """Test video list with ordering"""
         url = reverse("video-list")

--- a/frontend/src/hooks/__tests__/useVideos.test.ts
+++ b/frontend/src/hooks/__tests__/useVideos.test.ts
@@ -134,6 +134,18 @@ describe('useVideos', () => {
     })
   })
 
+  it('should pass status param to API', async () => {
+    ;(apiClient.getVideos as any).mockResolvedValue(mockPaginatedResponse([]))
+
+    renderHook(() => useVideos({ status: 'completed' }))
+
+    await waitFor(() => {
+      expect(apiClient.getVideos).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'completed' }),
+      )
+    })
+  })
+
   it('should pass limit=24 and offset=0 to API on first page', async () => {
     ;(apiClient.getVideos as any).mockResolvedValue(mockPaginatedResponse([]))
 

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -11,6 +11,7 @@ export type VideosOrdering = 'uploaded_at_desc' | 'uploaded_at_asc' | 'title_asc
 interface UseVideosParams {
   tagIds?: number[];
   q?: string;
+  status?: string;
   ordering?: VideosOrdering;
 }
 
@@ -35,15 +36,17 @@ export function useVideos(params?: UseVideosParams): UseVideosReturn {
     () => (params?.tagIds && params.tagIds.length > 0 ? params.tagIds : undefined),
     [params?.tagIds],
   );
-  const q = params?.q || undefined;
+  const q = params?.q?.trim() || undefined;
+  const status = params?.status?.trim() || undefined;
   const ordering: VideosOrdering | undefined = params?.ordering || undefined;
 
   const videosQuery = useInfiniteQuery({
-    queryKey: queryKeys.videos.infinite({ tags: normalizedTagIds, q, ordering }),
+    queryKey: queryKeys.videos.infinite({ tags: normalizedTagIds, q, status, ordering }),
     queryFn: async ({ pageParam }) => {
       return apiClient.getVideos({
         tags: normalizedTagIds,
         q,
+        status,
         ordering,
         limit: PAGE_SIZE,
         offset: pageParam as number,

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -24,8 +24,8 @@ export const queryKeys = {
     all: ['videos'] as const,
     list: (params?: { tags?: number[] }) =>
       ['videos', 'list', { tags: params?.tags ?? [] }] as const,
-    infinite: (params?: { tags?: number[]; q?: string; ordering?: string }) =>
-      ['videos', 'infinite', { tags: params?.tags ?? [], q: params?.q ?? '', ordering: params?.ordering ?? '' }] as const,
+    infinite: (params?: { tags?: number[]; q?: string; status?: string; ordering?: string }) =>
+      ['videos', 'infinite', { tags: params?.tags ?? [], q: params?.q ?? '', status: params?.status ?? '', ordering: params?.ordering ?? '' }] as const,
     detail: (videoId: number | null) => ['videos', 'detail', videoId] as const,
   },
   popularScenes: {

--- a/frontend/src/pages/VideosPage.tsx
+++ b/frontend/src/pages/VideosPage.tsx
@@ -8,20 +8,72 @@ import { VideoCard } from '@/components/video/VideoCard';
 import { TagManagementModal } from '@/components/video/TagManagementModal';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { useAuth } from '@/hooks/useAuth';
-import { useI18nNavigate } from '@/lib/i18n';
 import { useTags } from '@/hooks/useTags';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
 import { Plus, Search, Tag } from 'lucide-react';
 
-type StatusFilter = 'all' | 'completed' | 'processing' | 'error';
+const STATUS_FILTERS = ['all', 'completed', 'processing', 'error'] as const;
+type StatusFilter = (typeof STATUS_FILTERS)[number];
+
 type SortOrder = Extract<VideosOrdering, 'uploaded_at_desc' | 'uploaded_at_asc' | 'title_asc'>;
+const SORT_ORDERS: SortOrder[] = ['uploaded_at_desc', 'uploaded_at_asc', 'title_asc'];
+const IN_PROGRESS_STATUSES = ['pending', 'processing', 'indexing', 'uploading'];
+
+function parseStatusFilter(value: string | null): StatusFilter {
+  return STATUS_FILTERS.includes(value as StatusFilter) ? (value as StatusFilter) : 'all';
+}
+
+function parseSortOrder(value: string | null): SortOrder {
+  return SORT_ORDERS.includes(value as SortOrder) ? (value as SortOrder) : 'uploaded_at_desc';
+}
+
+function parseTagIds(value: string | null): number[] {
+  if (!value) return [];
+  const ids = value
+    .split(',')
+    .map((raw) => Number(raw))
+    .filter((id) => Number.isInteger(id) && id > 0);
+  return Array.from(new Set(ids)).sort((a, b) => a - b);
+}
+
+function toApiStatusFilter(statusFilter: StatusFilter): string | undefined {
+  if (statusFilter === 'all') return undefined;
+  if (statusFilter === 'processing') return IN_PROGRESS_STATUSES.join(',');
+  return statusFilter;
+}
 
 export default function VideosPage() {
-  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortOrder, setSortOrder] = useState<SortOrder>('uploaded_at_desc');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedTagIds = useMemo(
+    () => parseTagIds(searchParams.get('tags')),
+    [searchParams],
+  );
+  const statusFilter = useMemo(
+    () => parseStatusFilter(searchParams.get('status')),
+    [searchParams],
+  );
+  const searchQuery = searchParams.get('q') ?? '';
+  const sortOrder = useMemo(
+    () => parseSortOrder(searchParams.get('ordering')),
+    [searchParams],
+  );
+  const apiStatusFilter = useMemo(() => toApiStatusFilter(statusFilter), [statusFilter]);
+
+  const updateSearchParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      const next = new URLSearchParams(searchParams);
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === null || value === '') {
+          next.delete(key);
+          return;
+        }
+        next.set(key, value);
+      });
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
 
   const {
     videos,
@@ -34,14 +86,13 @@ export default function VideosPage() {
   } = useVideos({
     tagIds: selectedTagIds,
     q: searchQuery,
+    status: apiStatusFilter,
     ordering: sortOrder,
   });
 
   const stats = useVideoStats(videos);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [isTagManagementOpen, setIsTagManagementOpen] = useState(false);
-  const [searchParams] = useSearchParams();
-  const navigate = useI18nNavigate();
   const { t } = useTranslation();
   const { user, isLoading: userLoading, refetch: refetchUser } = useAuth();
   const { tags } = useTags();
@@ -52,10 +103,13 @@ export default function VideosPage() {
   );
 
   const handleTagToggle = useCallback((tagId: number) => {
-    setSelectedTagIds((prev) =>
-      prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId],
-    );
-  }, []);
+    const nextTagIds = selectedTagIds.includes(tagId)
+      ? selectedTagIds.filter((id) => id !== tagId)
+      : [...selectedTagIds, tagId].sort((a, b) => a - b);
+    updateSearchParams({
+      tags: nextTagIds.length > 0 ? nextTagIds.join(',') : null,
+    });
+  }, [selectedTagIds, updateSearchParams]);
 
   const handleUploadSuccess = useCallback(() => {
     void refetchVideos();
@@ -65,26 +119,11 @@ export default function VideosPage() {
   const handleCloseModal = () => {
     setIsUploadModalOpen(false);
     if (shouldOpenModalFromQuery) {
-      navigate('/videos', { replace: true });
+      updateSearchParams({ upload: null });
     }
   };
 
   const isUploadDisabled = useMemo(() => !user || userLoading, [user, userLoading]);
-
-  const filteredVideos = useMemo(() => {
-    if (statusFilter === 'completed') {
-      return videos.filter((v) => v.status === 'completed');
-    }
-    if (statusFilter === 'processing') {
-      return videos.filter((v) =>
-        ['pending', 'processing', 'indexing', 'uploading'].includes(v.status),
-      );
-    }
-    if (statusFilter === 'error') {
-      return videos.filter((v) => v.status === 'error');
-    }
-    return videos;
-  }, [videos, statusFilter]);
 
   return (
     <AppPageShell activePage="videos">
@@ -129,14 +168,19 @@ export default function VideosPage() {
                 placeholder={t('videos.list.searchPlaceholder')}
                 type="text"
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => updateSearchParams({ q: e.target.value })}
               />
             </div>
             <div className="flex items-center gap-2 shrink-0">
               <span className="text-sm font-medium text-[#3f493f]">{t('videos.list.sortLabel')}</span>
               <select
                 value={sortOrder}
-                onChange={(e) => setSortOrder(e.target.value as SortOrder)}
+                onChange={(e) => {
+                  const nextOrdering = e.target.value as SortOrder;
+                  updateSearchParams({
+                    ordering: nextOrdering === 'uploaded_at_desc' ? null : nextOrdering,
+                  });
+                }}
                 className="bg-[#f2f4ef] border border-[#e1e3de] px-4 py-3 rounded-xl text-sm font-medium hover:bg-[#e7e9e4] transition-colors outline-none cursor-pointer"
               >
                 <option value="uploaded_at_desc">{t('videos.list.sort.uploadedDesc')}</option>
@@ -158,7 +202,7 @@ export default function VideosPage() {
               ).map(({ key, label }) => (
                 <button
                   key={key}
-                  onClick={() => setStatusFilter(key)}
+                  onClick={() => updateSearchParams({ status: key === 'all' ? null : key })}
                   className={`px-4 py-1.5 rounded-full text-sm font-semibold transition-colors ${
                     statusFilter === key
                       ? 'bg-[#00652c] text-white'
@@ -216,7 +260,7 @@ export default function VideosPage() {
           <div className="text-center py-24 text-red-500">{error}</div>
         ) : (
           <>
-            {filteredVideos.length === 0 ? (
+            {videos.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-24 text-[#3f493f]">
                 <div className="w-24 h-24 bg-[#f2f4ef] rounded-full flex items-center justify-center mb-4">
                   <Search className="w-12 h-12 text-[#becabc]" />
@@ -226,7 +270,7 @@ export default function VideosPage() {
               </div>
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {filteredVideos.map((video) => (
+                {videos.map((video) => (
                   <VideoCard key={video.id} video={video} />
                 ))}
               </div>

--- a/frontend/src/pages/__tests__/VideosPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideosPage.test.tsx
@@ -10,24 +10,14 @@ const mockVideos = [
 
 const mockLoadVideos = vi.fn()
 const mockFetchNextPage = vi.fn()
+const mockUseVideos = vi.fn()
 
 let mockHasNextPage = false
 let mockIsFetchingNextPage = false
 let mockTotalCount = 4
 
 vi.mock('@/hooks/useVideos', () => ({
-  useVideos: () => ({
-    videos: mockVideos,
-    isLoading: false,
-    error: null,
-    hasNextPage: mockHasNextPage,
-    fetchNextPage: mockFetchNextPage,
-    isFetchingNextPage: mockIsFetchingNextPage,
-    totalCount: mockTotalCount,
-    loadVideos: mockLoadVideos,
-    refetch: mockLoadVideos,
-    sentinelRef: vi.fn(),
-  }),
+  useVideos: (params: unknown) => mockUseVideos(params),
 }))
 
 vi.mock('@/hooks/useVideoStats', () => ({
@@ -79,6 +69,20 @@ describe('VideosPage', () => {
     mockHasNextPage = false
     mockIsFetchingNextPage = false
     mockTotalCount = 4
+    globalThis.__setMockSearchParams('')
+    globalThis.__getMockSetSearchParams().mockClear()
+    mockUseVideos.mockImplementation(() => ({
+      videos: mockVideos,
+      isLoading: false,
+      error: null,
+      hasNextPage: mockHasNextPage,
+      fetchNextPage: mockFetchNextPage,
+      isFetchingNextPage: mockIsFetchingNextPage,
+      totalCount: mockTotalCount,
+      loadVideos: mockLoadVideos,
+      refetch: mockLoadVideos,
+      sentinelRef: vi.fn(),
+    }))
   })
 
   afterEach(() => {
@@ -120,6 +124,47 @@ describe('VideosPage', () => {
     expect(screen.getByText('Video 2')).toBeInTheDocument()
     expect(screen.getByText('Video 3')).toBeInTheDocument()
     expect(screen.getByText('Video 4')).toBeInTheDocument()
+  })
+
+  it('should pass URL filters to useVideos on initial render', () => {
+    globalThis.__setMockSearchParams('q=python&status=completed&ordering=title_asc&tags=2,1')
+
+    render(<VideosPage />)
+
+    expect(mockUseVideos).toHaveBeenCalledWith({
+      tagIds: [1, 2],
+      q: 'python',
+      status: 'completed',
+      ordering: 'title_asc',
+    })
+  })
+
+  it('should map the processing URL filter to all in-progress API statuses', () => {
+    globalThis.__setMockSearchParams('status=processing')
+
+    render(<VideosPage />)
+
+    expect(mockUseVideos).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'pending,processing,indexing,uploading',
+      }),
+    )
+  })
+
+  it('should update the URL when filters change', () => {
+    render(<VideosPage />)
+
+    fireEvent.change(screen.getByPlaceholderText('videos.list.searchPlaceholder'), {
+      target: { value: 'django' },
+    })
+    let lastCall = globalThis.__getMockSetSearchParams().mock.calls.at(-1)
+    expect(lastCall?.[0].toString()).toBe('q=django')
+    expect(lastCall?.[1]).toEqual({ replace: true })
+
+    fireEvent.click(screen.getByText('videos.list.filter.completed'))
+    lastCall = globalThis.__getMockSetSearchParams().mock.calls.at(-1)
+    expect(lastCall?.[0].toString()).toBe('status=completed')
+    expect(lastCall?.[1]).toEqual({ replace: true })
   })
 
   it('should not manually load videos on mount (query handles initial fetch)', () => {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -48,6 +48,8 @@ vi.mock('@testing-library/react', async () => {
 declare global {
   interface GlobalThis {
     __setMockPathname: (pathname: string) => void
+    __setMockSearchParams: (search: string) => void
+    __getMockSetSearchParams: () => ReturnType<typeof vi.fn>
     __setMockLanguage: (language: 'en' | 'ja') => void
   }
 }
@@ -81,10 +83,19 @@ Object.defineProperty(globalThis, 'IntersectionObserver', {
 // Cleanup after each test
 afterEach(() => {
   cleanup()
+  mockLocation.search = ''
+  mockSetSearchParams.mockClear()
 })
 
 // Mock React Router
 const mockNavigate = vi.fn()
+const mockSetSearchParams = vi.fn((nextInit: URLSearchParams | string) => {
+  const next = nextInit instanceof URLSearchParams
+    ? nextInit
+    : new URLSearchParams(nextInit)
+  const nextSearch = next.toString()
+  mockLocation.search = nextSearch ? `?${nextSearch}` : ''
+})
 const mockLocation: {
   pathname: string
   search: string
@@ -119,6 +130,11 @@ const lookupSeoTranslation = (language: 'en' | 'ja', key: string): string | unde
 globalThis.__setMockPathname = (pathname: string) => {
   mockLocation.pathname = pathname
 }
+globalThis.__setMockSearchParams = (search: string) => {
+  const normalizedSearch = search.startsWith('?') ? search.slice(1) : search
+  mockLocation.search = normalizedSearch ? `?${normalizedSearch}` : ''
+}
+globalThis.__getMockSetSearchParams = () => mockSetSearchParams
 globalThis.__setMockLanguage = (language: 'en' | 'ja') => {
   mockLanguage = language
 }
@@ -134,7 +150,7 @@ vi.mock('react-router-dom', async () => {
     useNavigate: () => mockNavigate,
     useLocation: () => mockLocation,
     useParams: () => ({}),
-    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+    useSearchParams: () => [new URLSearchParams(mockLocation.search), mockSetSearchParams],
     Link: ({ children, to, ...props }: MockLinkProps) =>
       React.createElement('a', { href: typeof to === 'string' ? to : '', ...props }, children),
   }


### PR DESCRIPTION
## Summary
- 動画一覧の検索・状態フィルタ・ソート・タグ選択をURLSearchParams由来に変更
- useVideosのquery key/API requestへstatusを含め、processingフィルタをin-progress status群としてserver query化
- backendの動画一覧status filterでカンマ区切り複数statusを扱うように変更

## Tests
- npm test -- src/hooks/__tests__/useVideos.test.ts src/pages/__tests__/VideosPage.test.tsx
- npm test
- npm run typecheck
- npm run lint（既存warning: frontend/src/hooks/useChatMessages.ts:205）
- docker compose run --rm backend python manage.py test app.presentation.video.tests.test_views.VideoListViewTests --keepdb
- git diff --check

Closes #745