### PR TITLE
confirm/alertを共通FeedbackProvider(Dialog/Toast)に置き換える

### DIFF
--- a/frontend/src/components/common/FeedbackProvider.tsx
+++ b/frontend/src/components/common/FeedbackProvider.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { FeedbackContext, type ConfirmOptions, type FeedbackContextValue, type ToastOptions } from './feedback';
+
+interface ConfirmRequest {
+  options: Required<Pick<ConfirmOptions, 'title' | 'confirmLabel' | 'cancelLabel' | 'variant'>> &
+    Pick<ConfirmOptions, 'description'>;
+  resolve: (confirmed: boolean) => void;
+}
+
+interface ToastItem extends Required<Omit<ToastOptions, 'durationMs'>> {
+  id: number;
+}
+
+function normalizeConfirmOptions(options: ConfirmOptions | string): ConfirmRequest['options'] {
+  if (typeof options === 'string') {
+    return {
+      title: options,
+      description: undefined,
+      confirmLabel: 'Confirm',
+      cancelLabel: 'Cancel',
+      variant: 'default',
+    };
+  }
+
+  return {
+    title: options.title,
+    description: options.description,
+    confirmLabel: options.confirmLabel ?? 'Confirm',
+    cancelLabel: options.cancelLabel ?? 'Cancel',
+    variant: options.variant ?? 'default',
+  };
+}
+
+export function FeedbackProvider({ children }: { children: ReactNode }) {
+  const [confirmRequest, setConfirmRequest] = useState<ConfirmRequest | null>(null);
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const nextToastId = useRef(1);
+
+  const resolveConfirm = useCallback((confirmed: boolean) => {
+    setConfirmRequest((current) => {
+      current?.resolve(confirmed);
+      return null;
+    });
+  }, []);
+
+  const requestConfirmation = useCallback((options: ConfirmOptions | string) => {
+    return new Promise<boolean>((resolve) => {
+      setConfirmRequest({
+        options: normalizeConfirmOptions(options),
+        resolve,
+      });
+    });
+  }, []);
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const toast = useCallback((options: ToastOptions) => {
+    const id = nextToastId.current;
+    nextToastId.current += 1;
+    const item: ToastItem = {
+      id,
+      message: options.message,
+      variant: options.variant ?? 'info',
+    };
+
+    setToasts((current) => [...current, item]);
+
+    if (options.durationMs !== 0) {
+      window.setTimeout(() => dismissToast(id), options.durationMs ?? 4000);
+    }
+  }, [dismissToast]);
+
+  const contextValue = useMemo<FeedbackContextValue>(() => ({
+    requestConfirmation,
+    toast,
+  }), [requestConfirmation, toast]);
+
+  return (
+    <FeedbackContext.Provider value={contextValue}>
+      {children}
+
+      <Dialog open={!!confirmRequest} onOpenChange={(open) => !open && resolveConfirm(false)}>
+        <DialogContent className="sm:max-w-md" showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>{confirmRequest?.options.title}</DialogTitle>
+            {confirmRequest?.options.description ? (
+              <DialogDescription>{confirmRequest.options.description}</DialogDescription>
+            ) : (
+              <DialogDescription className="sr-only">Confirm this action.</DialogDescription>
+            )}
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              autoFocus
+              onClick={() => resolveConfirm(false)}
+            >
+              {confirmRequest?.options.cancelLabel}
+            </Button>
+            <Button
+              type="button"
+              variant={confirmRequest?.options.variant === 'danger' ? 'destructive' : 'default'}
+              onClick={() => resolveConfirm(true)}
+            >
+              {confirmRequest?.options.confirmLabel}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {toasts.length > 0 && (
+        <div className="fixed bottom-4 right-4 z-50 flex w-[min(calc(100vw-2rem),24rem)] flex-col gap-2">
+          {toasts.map((toastItem) => (
+            <div
+              key={toastItem.id}
+              role={toastItem.variant === 'error' ? 'alert' : 'status'}
+              className={cn(
+                'flex items-start gap-3 rounded-xl border bg-white px-4 py-3 text-sm font-medium shadow-[0_8px_30px_rgba(28,25,23,0.12)]',
+                toastItem.variant === 'error' && 'border-red-200 text-red-700',
+                toastItem.variant === 'success' && 'border-green-200 text-green-700',
+                toastItem.variant === 'info' && 'border-[#e1e3de] text-[#191c19]',
+              )}
+            >
+              <span className="flex-1 leading-5">{toastItem.message}</span>
+              <button
+                type="button"
+                aria-label="Dismiss notification"
+                className="rounded-full p-1 text-current opacity-70 transition-opacity hover:opacity-100"
+                onClick={() => dismissToast(toastItem.id)}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </FeedbackContext.Provider>
+  );
+}

--- a/frontend/src/components/common/FeedbackProvider.tsx
+++ b/frontend/src/components/common/FeedbackProvider.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
 import { X } from 'lucide-react';
 import {
   Dialog,
@@ -15,6 +16,7 @@ import { FeedbackContext, type ConfirmOptions, type FeedbackContextValue, type T
 interface ConfirmRequest {
   options: Required<Pick<ConfirmOptions, 'title' | 'confirmLabel' | 'cancelLabel' | 'variant'>> &
     Pick<ConfirmOptions, 'description'>;
+  navigationKey: string;
   resolve: (confirmed: boolean) => void;
 }
 
@@ -43,25 +45,58 @@ function normalizeConfirmOptions(options: ConfirmOptions | string): ConfirmReque
 }
 
 export function FeedbackProvider({ children }: { children: ReactNode }) {
-  const [confirmRequest, setConfirmRequest] = useState<ConfirmRequest | null>(null);
+  const location = useLocation();
+  const navigationKey = `${location.pathname}${location.search}${location.hash}`;
+  const previousNavigationKey = useRef(navigationKey);
+  const activeConfirmRequest = useRef<ConfirmRequest | null>(null);
+  const [confirmRequest, setConfirmRequestState] = useState<ConfirmRequest | null>(null);
   const [toasts, setToasts] = useState<ToastItem[]>([]);
   const nextToastId = useRef(1);
 
   const resolveConfirm = useCallback((confirmed: boolean) => {
-    setConfirmRequest((current) => {
-      current?.resolve(confirmed);
-      return null;
-    });
+    const current = activeConfirmRequest.current;
+    if (!current) return;
+
+    activeConfirmRequest.current = null;
+    setConfirmRequestState(null);
+    current.resolve(confirmed);
   }, []);
 
   const requestConfirmation = useCallback((options: ConfirmOptions | string) => {
     return new Promise<boolean>((resolve) => {
-      setConfirmRequest({
+      activeConfirmRequest.current?.resolve(false);
+
+      const nextRequest = {
         options: normalizeConfirmOptions(options),
+        navigationKey,
         resolve,
-      });
+      };
+      activeConfirmRequest.current = nextRequest;
+      setConfirmRequestState(nextRequest);
     });
-  }, []);
+  }, [navigationKey]);
+
+  useLayoutEffect(() => {
+    if (previousNavigationKey.current === navigationKey) {
+      return;
+    }
+
+    previousNavigationKey.current = navigationKey;
+    const current = activeConfirmRequest.current;
+    if (current && current.navigationKey !== navigationKey) {
+      activeConfirmRequest.current = null;
+      current.resolve(false);
+      window.queueMicrotask(() => {
+        setConfirmRequestState((latest) => (latest === current ? null : latest));
+      });
+    }
+  }, [navigationKey]);
+
+  const visibleConfirmRequest =
+    confirmRequest &&
+    confirmRequest.navigationKey === navigationKey
+      ? confirmRequest
+      : null;
 
   const dismissToast = useCallback((id: number) => {
     setToasts((current) => current.filter((toast) => toast.id !== id));
@@ -92,12 +127,12 @@ export function FeedbackProvider({ children }: { children: ReactNode }) {
     <FeedbackContext.Provider value={contextValue}>
       {children}
 
-      <Dialog open={!!confirmRequest} onOpenChange={(open) => !open && resolveConfirm(false)}>
+      <Dialog open={!!visibleConfirmRequest} onOpenChange={(open) => !open && resolveConfirm(false)}>
         <DialogContent className="sm:max-w-md" showCloseButton={false}>
           <DialogHeader>
-            <DialogTitle>{confirmRequest?.options.title}</DialogTitle>
-            {confirmRequest?.options.description ? (
-              <DialogDescription>{confirmRequest.options.description}</DialogDescription>
+            <DialogTitle>{visibleConfirmRequest?.options.title}</DialogTitle>
+            {visibleConfirmRequest?.options.description ? (
+              <DialogDescription>{visibleConfirmRequest.options.description}</DialogDescription>
             ) : (
               <DialogDescription className="sr-only">Confirm this action.</DialogDescription>
             )}
@@ -109,14 +144,14 @@ export function FeedbackProvider({ children }: { children: ReactNode }) {
               autoFocus
               onClick={() => resolveConfirm(false)}
             >
-              {confirmRequest?.options.cancelLabel}
+              {visibleConfirmRequest?.options.cancelLabel}
             </Button>
             <Button
               type="button"
-              variant={confirmRequest?.options.variant === 'danger' ? 'destructive' : 'default'}
+              variant={visibleConfirmRequest?.options.variant === 'danger' ? 'destructive' : 'default'}
               onClick={() => resolveConfirm(true)}
             >
-              {confirmRequest?.options.confirmLabel}
+              {visibleConfirmRequest?.options.confirmLabel}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/common/__tests__/FeedbackProvider.test.tsx
+++ b/frontend/src/components/common/__tests__/FeedbackProvider.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { FeedbackProvider } from '../FeedbackProvider'
+import { useConfirm, useToast } from '../feedback'
+
+function ConfirmHarness({ onResult }: { onResult: (value: boolean) => void }) {
+  const confirm = useConfirm()
+
+  return (
+    <button
+      onClick={async () => {
+        const confirmed = await confirm({
+          title: 'Delete video?',
+          description: 'This action cannot be undone.',
+          confirmLabel: 'Delete',
+          cancelLabel: 'Cancel',
+          variant: 'danger',
+        })
+        onResult(confirmed)
+      }}
+    >
+      Open confirm
+    </button>
+  )
+}
+
+function ToastHarness() {
+  const toast = useToast()
+
+  return (
+    <button
+      onClick={() => toast({ message: 'Copy failed', variant: 'error' })}
+    >
+      Show toast
+    </button>
+  )
+}
+
+describe('FeedbackProvider', () => {
+  it('renders an accessible confirm dialog and resolves true on confirm', async () => {
+    const onResult = vi.fn()
+
+    render(
+      <FeedbackProvider>
+        <ConfirmHarness onResult={onResult} />
+      </FeedbackProvider>,
+    )
+
+    fireEvent.click(screen.getByText('Open confirm'))
+
+    expect(await screen.findByRole('dialog', { name: 'Delete video?' })).toBeInTheDocument()
+    expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(onResult).toHaveBeenCalledWith(true)
+      expect(screen.queryByRole('dialog', { name: 'Delete video?' })).not.toBeInTheDocument()
+    })
+  })
+
+  it('resolves false when the confirm dialog is cancelled', async () => {
+    const onResult = vi.fn()
+
+    render(
+      <FeedbackProvider>
+        <ConfirmHarness onResult={onResult} />
+      </FeedbackProvider>,
+    )
+
+    fireEvent.click(screen.getByText('Open confirm'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(onResult).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('shows and dismisses toast messages', async () => {
+    render(
+      <FeedbackProvider>
+        <ToastHarness />
+      </FeedbackProvider>,
+    )
+
+    fireEvent.click(screen.getByText('Show toast'))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Copy failed')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss notification' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/common/__tests__/FeedbackProvider.test.tsx
+++ b/frontend/src/components/common/__tests__/FeedbackProvider.test.tsx
@@ -36,6 +36,14 @@ function ToastHarness() {
 }
 
 describe('FeedbackProvider', () => {
+  beforeEach(() => {
+    globalThis.__setMockPathname('/')
+  })
+
+  afterEach(() => {
+    globalThis.__setMockPathname('/')
+  })
+
   it('renders an accessible confirm dialog and resolves true on confirm', async () => {
     const onResult = vi.fn()
 
@@ -73,6 +81,32 @@ describe('FeedbackProvider', () => {
 
     await waitFor(() => {
       expect(onResult).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('resolves false and closes pending confirm dialogs when the route changes', async () => {
+    const onResult = vi.fn()
+    const ui = (
+      <FeedbackProvider>
+        <ConfirmHarness onResult={onResult} />
+      </FeedbackProvider>
+    )
+    const { rerender } = render(ui)
+
+    fireEvent.click(screen.getByText('Open confirm'))
+
+    expect(await screen.findByRole('dialog', { name: 'Delete video?' })).toBeInTheDocument()
+
+    globalThis.__setMockPathname('/videos')
+    rerender(
+      <FeedbackProvider>
+        <ConfirmHarness onResult={onResult} />
+      </FeedbackProvider>,
+    )
+
+    await waitFor(() => {
+      expect(onResult).toHaveBeenCalledWith(false)
+      expect(screen.queryByRole('dialog', { name: 'Delete video?' })).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/common/feedback.ts
+++ b/frontend/src/components/common/feedback.ts
@@ -1,0 +1,38 @@
+import { createContext, useContext } from 'react';
+
+export interface ConfirmOptions {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'default' | 'danger';
+}
+
+export interface ToastOptions {
+  message: string;
+  variant?: 'info' | 'success' | 'error';
+  durationMs?: number;
+}
+
+export interface FeedbackContextValue {
+  requestConfirmation: (options: ConfirmOptions | string) => Promise<boolean>;
+  toast: (options: ToastOptions) => void;
+}
+
+export const FeedbackContext = createContext<FeedbackContextValue | null>(null);
+
+export function useConfirm() {
+  const context = useContext(FeedbackContext);
+  if (!context) {
+    throw new Error('useConfirm must be used within FeedbackProvider');
+  }
+  return context.requestConfirmation;
+}
+
+export function useToast() {
+  const context = useContext(FeedbackContext);
+  if (!context) {
+    throw new Error('useToast must be used within FeedbackProvider');
+  }
+  return context.toast;
+}

--- a/frontend/src/hooks/__tests__/useAsyncState.test.ts
+++ b/frontend/src/hooks/__tests__/useAsyncState.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act, waitFor } from '@testing-library/react'
+import { renderHook, act, waitFor, screen, fireEvent } from '@testing-library/react'
 import { useAsyncState } from '../useAsyncState'
 
 describe('useAsyncState', () => {
@@ -121,30 +121,40 @@ describe('useAsyncState', () => {
   })
 
   it('should use mutate with confirmation when user confirms', async () => {
-    window.confirm = vi.fn(() => true)
     const { result } = renderHook(() => useAsyncState({ confirmMessage: 'Confirm?' }))
+    let mutatePromise!: Promise<string | undefined>
     
-    await act(async () => {
-      const mutateResult = await result.current.mutate(async () => 'success')
-      expect(mutateResult).toBe('success')
+    act(() => {
+      mutatePromise = result.current.mutate(async () => 'success')
     })
 
-    expect(window.confirm).toHaveBeenCalledWith('Confirm?')
+    expect(await screen.findByRole('dialog', { name: 'Confirm?' })).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+      expect(await mutatePromise).toBe('success')
+    })
+
     await waitFor(() => {
       expect(result.current.data).toBe('success')
     })
   })
 
   it('should use mutate with confirmation when user cancels', async () => {
-    window.confirm = vi.fn(() => false)
     const { result } = renderHook(() => useAsyncState({ confirmMessage: 'Confirm?' }))
+    let mutatePromise!: Promise<string | undefined>
     
-    await act(async () => {
-      const mutateResult = await result.current.mutate(async () => 'success')
-      expect(mutateResult).toBeUndefined()
+    act(() => {
+      mutatePromise = result.current.mutate(async () => 'success')
     })
 
-    expect(window.confirm).toHaveBeenCalledWith('Confirm?')
+    expect(await screen.findByRole('dialog', { name: 'Confirm?' })).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(await mutatePromise).toBeUndefined()
+    })
+
     expect(result.current.data).toBeNull()
   })
 
@@ -168,17 +178,20 @@ describe('useAsyncState', () => {
   })
 
   it('should handle non-Error exceptions in mutate', async () => {
-    window.confirm = vi.fn(() => true)
     const { result } = renderHook(() => useAsyncState({ confirmMessage: 'Confirm?' }))
+    let mutatePromise!: Promise<unknown>
     
+    act(() => {
+      mutatePromise = result.current.mutate(async () => {
+        throw 'String error'
+      })
+    })
+
+    await screen.findByRole('dialog', { name: 'Confirm?' })
+
     await act(async () => {
-      try {
-        await result.current.mutate(async () => {
-          throw 'String error'
-        })
-      } catch {
-        // Expected to throw
-      }
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+      await expect(mutatePromise).rejects.toBe('String error')
     })
 
     await waitFor(() => {
@@ -210,18 +223,21 @@ describe('useAsyncState', () => {
   })
 
   it('should call onError with Error object when non-Error is thrown in mutate', async () => {
-    window.confirm = vi.fn(() => true)
     const onError = vi.fn()
     const { result } = renderHook(() => useAsyncState({ onError, confirmMessage: 'Confirm?' }))
+    let mutatePromise!: Promise<unknown>
     
+    act(() => {
+      mutatePromise = result.current.mutate(async () => {
+        throw 'String error'
+      })
+    })
+
+    await screen.findByRole('dialog', { name: 'Confirm?' })
+
     await act(async () => {
-      try {
-        await result.current.mutate(async () => {
-          throw 'String error'
-        })
-      } catch {
-        // Expected to throw
-      }
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+      await expect(mutatePromise).rejects.toBe('String error')
     })
 
     await waitFor(() => {
@@ -232,4 +248,3 @@ describe('useAsyncState', () => {
     })
   })
 })
-

--- a/frontend/src/hooks/__tests__/useShareLink.test.ts
+++ b/frontend/src/hooks/__tests__/useShareLink.test.ts
@@ -1,0 +1,70 @@
+import { act, fireEvent, renderHook, screen, waitFor } from '@testing-library/react'
+import { apiClient, type VideoGroup } from '@/lib/api'
+import { useShareLink } from '../useShareLink'
+
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    createShareLink: vi.fn(),
+    deleteShareLink: vi.fn(),
+  },
+}))
+
+const group: VideoGroup = {
+  id: 1,
+  name: 'Group',
+  description: '',
+  videos: [],
+  video_count: 0,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  share_slug: 'share-token',
+}
+
+describe('useShareLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn(),
+      },
+    })
+  })
+
+  it('uses the shared confirm dialog before disabling a share link', async () => {
+    ;(apiClient.deleteShareLink as ReturnType<typeof vi.fn>).mockResolvedValue({})
+    const { result } = renderHook(() => useShareLink(group))
+
+    act(() => {
+      void result.current.deleteShareLink()
+    })
+
+    expect(await screen.findByRole('dialog', { name: 'confirmations.disableShareLink' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.actions.disable' }))
+
+    await waitFor(() => {
+      expect(apiClient.deleteShareLink).toHaveBeenCalledWith(1)
+    })
+  })
+
+  it('shows a toast when copying the share link fails', async () => {
+    const clipboard = navigator.clipboard as { writeText: ReturnType<typeof vi.fn> }
+    clipboard.writeText.mockRejectedValue(new Error('copy failed'))
+    const { result } = renderHook(() => useShareLink(group))
+
+    await waitFor(() => {
+      expect(result.current.shareLink).toContain('/share/share-token')
+    })
+
+    await act(async () => {
+      await result.current.copyShareLink()
+    })
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('common.messages.copyFailed')
+  })
+})

--- a/frontend/src/hooks/useAsyncState.ts
+++ b/frontend/src/hooks/useAsyncState.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
+import { useConfirm } from '@/components/common/feedback';
 
 /**
  * Custom hook to unify state management for async operations
@@ -31,6 +32,7 @@ export function useAsyncState<T = unknown>(
   options: UseAsyncStateOptions<T> = {}
 ): UseAsyncStateReturn<T> {
   const { initialData = null, onSuccess, onError, confirmMessage } = options;
+  const requestConfirmation = useConfirm();
   
   const [data, setData] = useState<T | null>(initialData);
   const [isLoading, setIsLoading] = useState(false);
@@ -71,7 +73,7 @@ export function useAsyncState<T = unknown>(
   }, []);
 
   const mutate = useCallback(async (asyncFn: () => Promise<T>): Promise<T | undefined> => {
-    if (confirmMessage && !confirm(confirmMessage)) {
+    if (confirmMessage && !(await requestConfirmation(confirmMessage))) {
       return;
     }
 
@@ -101,7 +103,7 @@ export function useAsyncState<T = unknown>(
     } finally {
       setIsLoading(false);
     }
-  }, [confirmMessage]);
+  }, [confirmMessage, requestConfirmation]);
 
   const reset = useCallback(() => {
     setData(initialData);

--- a/frontend/src/hooks/useShareLink.ts
+++ b/frontend/src/hooks/useShareLink.ts
@@ -6,6 +6,7 @@ import { addLocalePrefix } from '@/lib/i18n';
 import { type Locale } from '@/i18n/config';
 import { handleAsyncError } from '@/lib/utils/errorHandling';
 import { queryKeys } from '@/lib/queryKeys';
+import { useConfirm, useToast } from '@/components/common/feedback';
 
 interface UseShareLinkReturn {
   shareLink: string | null;
@@ -19,6 +20,8 @@ interface UseShareLinkReturn {
 export function useShareLink(group: VideoGroup | null): UseShareLinkReturn {
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
+  const requestConfirmation = useConfirm();
+  const toast = useToast();
   const [shareLink, setShareLink] = useState<string | null>(null);
   const [isCopied, setIsCopied] = useState(false);
 
@@ -58,7 +61,14 @@ export function useShareLink(group: VideoGroup | null): UseShareLinkReturn {
   }, [group, createShareLinkMutation, queryClient, i18n.language, t]);
 
   const deleteShareLink = useCallback(async () => {
-    if (!group || !confirm(t('confirmations.disableShareLink'))) return;
+    if (!group) return;
+    const confirmed = await requestConfirmation({
+      title: t('confirmations.disableShareLink'),
+      confirmLabel: t('common.actions.disable'),
+      cancelLabel: t('common.actions.cancel'),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
     try {
       await deleteShareLinkMutation.mutateAsync(group.id);
       queryClient.setQueryData<VideoGroup>(queryKeys.videoGroups.detail(group.id), (prev) =>
@@ -68,7 +78,7 @@ export function useShareLink(group: VideoGroup | null): UseShareLinkReturn {
     } catch (err) {
       handleAsyncError(err, t('videos.groupDetail.disableShareError'), () => { });
     }
-  }, [group, deleteShareLinkMutation, queryClient, t]);
+  }, [requestConfirmation, group, deleteShareLinkMutation, queryClient, t]);
 
   const copyShareLink = useCallback(async () => {
     if (!shareLink) return;
@@ -96,9 +106,9 @@ export function useShareLink(group: VideoGroup | null): UseShareLinkReturn {
       setTimeout(() => setIsCopied(false), 2000);
     } catch (err) {
       console.error('Failed to copy:', err);
-      alert(t('common.messages.copyFailed'));
+      toast({ message: t('common.messages.copyFailed'), variant: 'error' });
     }
-  }, [shareLink, t]);
+  }, [shareLink, t, toast]);
 
   return {
     shareLink,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import i18n from './i18n/config'
 import App from './App.tsx'
 import { AuthProvider } from './components/auth/AuthProvider'
+import { FeedbackProvider } from './components/common/FeedbackProvider'
 import { appQueryClient } from './lib/queryClient'
 import './index.css'
 
@@ -15,9 +16,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       <I18nextProvider i18n={i18n}>
         <QueryClientProvider client={appQueryClient}>
-          <AuthProvider>
-            <App />
-          </AuthProvider>
+          <FeedbackProvider>
+            <AuthProvider>
+              <App />
+            </AuthProvider>
+          </FeedbackProvider>
           {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
         </QueryClientProvider>
       </I18nextProvider>

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -16,6 +16,7 @@ import { useVideoDetailPageMutations } from '@/hooks/useVideoDetailPageData';
 import { invalidateAfterTranscriptEdit } from '@/lib/cacheInvalidation';
 import { AppNav } from '@/components/layout/AppNav';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useConfirm } from '@/components/common/feedback';
 import {
   ArrowLeft, Calendar, CheckCircle, Search,
   Trash2, Pencil, X, Save, Video as VideoIcon,
@@ -94,6 +95,7 @@ export default function VideoDetailPage() {
   const startTime = searchParams.get('t');
   const [manualYoutubeStartSeconds, setManualYoutubeStartSeconds] = useState<number | null>(null);
   const { t } = useTranslation();
+  const requestConfirmation = useConfirm();
   const locale = useLocale();
   const queryClient = useQueryClient();
 
@@ -167,6 +169,18 @@ export default function VideoDetailPage() {
   const isDeleting = deleteMutation.isPending;
   const isUpdating = updateMutation.isPending;
   const updateError = updateMutation.error instanceof Error ? updateMutation.error.message : null;
+
+  const handleDeleteVideo = useCallback(async () => {
+    const confirmed = await requestConfirmation({
+      title: t('confirmations.deleteVideo'),
+      confirmLabel: t('common.actions.delete'),
+      cancelLabel: t('common.actions.cancel'),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+    setDeleteError(null);
+    deleteMutation.mutate();
+  }, [requestConfirmation, deleteMutation, t]);
 
   const handleCancelEdit = useCallback(() => {
     cancelEditing();
@@ -497,11 +511,7 @@ export default function VideoDetailPage() {
                   {t('videos.detail.editButton')}
                 </button>
                 <button
-                  onClick={() => {
-                    if (!window.confirm(t('confirmations.deleteVideo'))) return;
-                    setDeleteError(null);
-                    deleteMutation.mutate();
-                  }}
+                  onClick={handleDeleteVideo}
                   disabled={isDeleting}
                   className="flex items-center gap-1.5 px-4 py-2 text-red-600 text-sm font-bold rounded-xl hover:bg-red-50 transition-colors disabled:opacity-50"
                 >

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/hooks/useVideoGroupDetailData';
 import { TagFilterPanel } from '@/components/video/TagFilterPanel';
 import { AppNav } from '@/components/layout/AppNav';
+import { useConfirm, useToast } from '@/components/common/feedback';
 import {
   ArrowLeft, Plus, GripVertical,
   CheckCircle, Clock, AlertCircle, Copy, Trash2,
@@ -260,6 +261,7 @@ interface AddVideosDialogProps {
 
 function AddVideosDialog({ isOpen, onOpenChange, groupId, group, onVideosAdded }: AddVideosDialogProps) {
   const { t } = useTranslation();
+  const toast = useToast();
   const { tags } = useTags();
 
   const [videoSearchInput, setVideoSearchInput] = useState('');
@@ -305,7 +307,10 @@ function AddVideosDialog({ isOpen, onOpenChange, groupId, group, onVideosAdded }
       onOpenChange(false);
       setSelectedVideos([]);
       if (result.skipped_count > 0) {
-        alert(t('videos.groupDetail.addResult', { added: result.added_count, skipped: result.skipped_count }));
+        toast({
+          message: t('videos.groupDetail.addResult', { added: result.added_count, skipped: result.skipped_count }),
+          variant: 'info',
+        });
       }
     } catch (err) {
       handleAsyncError(err, t('videos.groupDetail.addError'), () => {});
@@ -430,6 +435,7 @@ export default function VideoGroupDetailPage() {
   const navigate = useI18nNavigate();
   const groupId = params?.id ? Number.parseInt(params.id, 10) : null;
   const { t } = useTranslation();
+  const requestConfirmation = useConfirm();
 
   useAuth();
 
@@ -506,7 +512,14 @@ export default function VideoGroupDetailPage() {
 
 
   const handleRemoveVideo = async (videoId: number) => {
-    if (!confirm(t('videos.groupDetail.removeVideoConfirm')) || !groupId) return;
+    if (!groupId) return;
+    const confirmed = await requestConfirmation({
+      title: t('videos.groupDetail.removeVideoConfirm'),
+      confirmLabel: t('common.actions.confirm'),
+      cancelLabel: t('common.actions.cancel'),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
     try {
       await removeVideoMutation.mutateAsync(videoId);
       if (selectedVideoId === videoId) setSelectedVideoId(null);
@@ -532,7 +545,14 @@ export default function VideoGroupDetailPage() {
   };
 
   const handleDelete = async () => {
-    if (!groupId || !confirm(t('confirmations.deleteGroup'))) return;
+    if (!groupId) return;
+    const confirmed = await requestConfirmation({
+      title: t('confirmations.deleteGroup'),
+      confirmLabel: t('common.actions.delete'),
+      cancelLabel: t('common.actions.cancel'),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
     setDeleteError(null);
     try {
       await deleteGroupMutation.mutateAsync();

--- a/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoDetailPage.test.tsx
@@ -223,7 +223,6 @@ describe('VideoDetailPage - Delete error', () => {
   })
 
   it('should show delete error when delete fails', async () => {
-    window.confirm = vi.fn(() => true)
     ;(apiClient.deleteVideo as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error('Delete failed'),
     )
@@ -231,6 +230,7 @@ describe('VideoDetailPage - Delete error', () => {
     render(<VideoDetailPage />)
 
     fireEvent.click(screen.getByText('videos.detail.deleteButton'))
+    fireEvent.click(await screen.findByRole('button', { name: 'common.actions.delete' }))
 
     await waitFor(() => {
       expect(screen.getByText('Delete failed')).toBeInTheDocument()
@@ -356,13 +356,13 @@ describe('VideoDetailPage - Not found state', () => {
 
 describe('VideoDetailPage - Delete', () => {
   it('should call deleteVideo when delete is confirmed', async () => {
-    window.confirm = vi.fn(() => true)
       ; (apiClient.deleteVideo as ReturnType<typeof vi.fn>).mockResolvedValue({})
 
     render(<VideoDetailPage />)
 
     const deleteButton = screen.getByText('videos.detail.deleteButton')
     fireEvent.click(deleteButton)
+    fireEvent.click(await screen.findByRole('button', { name: 'common.actions.delete' }))
 
     await waitFor(() => {
       expect(apiClient.deleteVideo).toHaveBeenCalledWith(1)

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -291,7 +291,6 @@ describe('VideoGroupDetailPage - Loading state', () => {
 })
 
 describe('VideoGroupDetailPage - Delete', () => {
-  const originalConfirm = window.confirm
   let currentGroup = structuredClone(mockGroup)
 
   beforeEach(() => {
@@ -305,11 +304,6 @@ describe('VideoGroupDetailPage - Delete', () => {
           videos: currentGroup.videos.filter((video) => video.id !== videoId),
         }
       })
-    window.confirm = vi.fn(() => true)
-  })
-
-  afterEach(() => {
-    window.confirm = originalConfirm
   })
 
   it('should call deleteVideoGroup when delete is confirmed', async () => {
@@ -320,6 +314,7 @@ describe('VideoGroupDetailPage - Delete', () => {
     })
 
     fireEvent.click(screen.getByTitle('videos.groupDetail.delete'))
+    fireEvent.click(await screen.findByRole('button', { name: 'common.actions.delete' }))
 
     await waitFor(() => {
       expect(apiClient.deleteVideoGroup).toHaveBeenCalledWith(1)
@@ -351,6 +346,7 @@ describe('VideoGroupDetailPage - Delete', () => {
     })
 
     fireEvent.click(screen.getByTitle('videos.groupDetail.delete'))
+    fireEvent.click(await screen.findByRole('button', { name: 'common.actions.delete' }))
 
     await waitFor(() => {
       expect(screen.getByText('Delete failed')).toBeInTheDocument()
@@ -362,9 +358,9 @@ describe('VideoGroupDetailPage - Delete', () => {
 
     const [firstRemoveButton] = await screen.findAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
     fireEvent.click(firstRemoveButton)
+    fireEvent.click(await screen.findByRole('button', { name: 'common.actions.confirm' }))
 
     await waitFor(() => {
-      expect(window.confirm).toHaveBeenCalledWith('videos.groupDetail.removeVideoConfirm')
       expect(apiClient.removeVideoFromGroup).toHaveBeenCalledWith(1, 1)
     })
 
@@ -385,6 +381,7 @@ describe('VideoGroupDetailPage - Delete', () => {
     // Remove Video 1 (the auto-selected one)
     const [firstRemoveButton] = screen.getAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
     fireEvent.click(firstRemoveButton)
+    fireEvent.click(await screen.findByRole('button', { name: 'common.actions.confirm' }))
 
     await waitFor(() => {
       expect(screen.queryAllByText('Video 1')).toHaveLength(0)
@@ -416,6 +413,7 @@ describe('VideoGroupDetailPage - Delete', () => {
     // autoVideoId: V1 stale → resets to V2 (first in new list)
     const [firstRemoveButton] = screen.getAllByRole('button', { name: 'videos.groupDetail.removeFromGroup' })
     fireEvent.click(firstRemoveButton)
+    fireEvent.click(await screen.findByRole('button', { name: 'common.actions.confirm' }))
 
     await waitFor(() => {
       expect(screen.queryAllByText('Video 1')).toHaveLength(0)

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -5,6 +5,7 @@ import React from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { HelmetProvider } from 'react-helmet-async'
 import { createAppQueryClient } from './src/lib/queryClient'
+import { FeedbackProvider } from './src/components/common/FeedbackProvider'
 import enTranslation from './src/i18n/locales/en/translation.json'
 import jaTranslation from './src/i18n/locales/ja/translation.json'
 
@@ -17,7 +18,11 @@ vi.mock('@testing-library/react', async () => {
       const content = React.createElement(
         HelmetProvider,
         {},
-        React.createElement(QueryClientProvider, { client: queryClient }, children),
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(FeedbackProvider, {}, children),
+        ),
       )
       if (!UserWrapper) {
         return content


### PR DESCRIPTION
## Summary

- `window.confirm` / `alert` の直接呼び出しをすべて廃止し、`FeedbackProvider` が提供する `useConfirm` / `useToast` フックに統一した
- `FeedbackProvider` はアプリルート (`main.tsx`) とテストセットアップ (`vitest.setup.ts`) の両方に追加し、全コンポーネントから利用可能にした
- ブラウザネイティブダイアログの代わりに一貫したUI (shadcn/ui Dialog + Toast) でフィードバックを表示するようになった

## Changed Files

| ファイル | 変更内容 |
|---|---|
| `components/common/FeedbackProvider.tsx` | 新規: Dialog/Toastを管理するプロバイダーコンポーネント |
| `components/common/feedback.ts` | 新規: `useConfirm` / `useToast` フックのエクスポート |
| `hooks/useAsyncState.ts` | `confirm()` → `useConfirm()` に置き換え |
| `hooks/useShareLink.ts` | `confirm()` → `useConfirm()`、`alert()` → `useToast()` に置き換え |
| `pages/VideoDetailPage.tsx` | 動画削除の `window.confirm` → `useConfirm()` に置き換え |
| `pages/VideoGroupDetailPage.tsx` | グループ削除・動画除外の `confirm`、スキップ通知の `alert` を置き換え |
| `main.tsx` | `FeedbackProvider` をルートに追加 |
| `vitest.setup.ts` | テストラッパーに `FeedbackProvider` を追加 |

## Test plan

- [x] `useAsyncState` テスト: `window.confirm` モックを廃止し、ダイアログのボタンクリックで操作するよう更新済み
- [x] `useShareLink` テスト: 新規追加
- [x] `FeedbackProvider` テスト: 新規追加
- [x] `VideoDetailPage` / `VideoGroupDetailPage` テスト: ダイアログの Confirm/Cancel ボタンクリックに変更済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)