### PR TITLE
LLM/Embedding/Whisper provider factoryを統一

### DIFF
--- a/backend/app/domain/shared/exceptions.py
+++ b/backend/app/domain/shared/exceptions.py
@@ -1,8 +1,11 @@
 """Neutral domain exceptions shared across infrastructure and use cases."""
 
 
-class LLMConfigError(Exception):
-    """Raised when LLM configuration is invalid or missing."""
+class ProviderConfigError(Exception):
+    """Raised when an external provider configuration is invalid or missing."""
+
+
+LLMConfigError = ProviderConfigError
 
 
 class TokenInvalidError(Exception):

--- a/backend/app/infrastructure/common/embeddings.py
+++ b/backend/app/infrastructure/common/embeddings.py
@@ -1,33 +1,41 @@
 """Embedding provider factory for supporting multiple embedding backends."""
 
+from django.conf import settings
 from langchain_core.embeddings import Embeddings
 from langchain_ollama import OllamaEmbeddings
 from langchain_openai import OpenAIEmbeddings
 from pydantic import SecretStr
 
-from videoq import settings
+from app.infrastructure.common.provider_registry import (
+    create_from_provider_registry,
+    get_provider_setting,
+    resolve_openai_api_key,
+)
 
 
 def get_embeddings() -> Embeddings:
     """Get the configured embedding model based on EMBEDDING_PROVIDER setting."""
-    provider = settings.EMBEDDING_PROVIDER
+    provider = get_provider_setting("EMBEDDING_PROVIDER", "openai")
+    return create_from_provider_registry(
+        "EMBEDDING_PROVIDER",
+        provider,
+        {
+            "openai": _create_openai_embeddings,
+            "ollama": _create_ollama_embeddings,
+        },
+    )
 
-    if provider == "openai":
-        api_key = getattr(settings, "OPENAI_API_KEY", None)
-        if not api_key:
-            raise ValueError(
-                "OpenAI API key is required when using OpenAI embeddings. "
-                "Please set OPENAI_API_KEY in the server environment."
-            )
-        return OpenAIEmbeddings(
-            model=settings.EMBEDDING_MODEL, api_key=SecretStr(api_key)
-        )
 
-    if provider == "ollama":
-        return OllamaEmbeddings(
-            model=settings.EMBEDDING_MODEL, base_url=settings.OLLAMA_BASE_URL
-        )
+def _create_openai_embeddings() -> Embeddings:
+    api_key = resolve_openai_api_key(purpose="OpenAI embeddings")
+    return OpenAIEmbeddings(
+        model=settings.EMBEDDING_MODEL,
+        api_key=SecretStr(api_key),
+    )
 
-    raise ValueError(
-        f"Invalid EMBEDDING_PROVIDER: {provider}. Must be 'openai' or 'ollama'."
+
+def _create_ollama_embeddings() -> Embeddings:
+    return OllamaEmbeddings(
+        model=settings.EMBEDDING_MODEL,
+        base_url=settings.OLLAMA_BASE_URL,
     )

--- a/backend/app/infrastructure/common/provider_registry.py
+++ b/backend/app/infrastructure/common/provider_registry.py
@@ -1,0 +1,76 @@
+"""Shared helpers for provider-backed infrastructure factories."""
+
+from collections.abc import Callable, Iterable, Mapping
+from typing import TypeVar
+
+from django.conf import settings
+
+from app.domain.shared.exceptions import ProviderConfigError
+
+T = TypeVar("T")
+
+
+def normalize_provider(value: object, default: str) -> str:
+    """Normalize provider names from Django settings."""
+    if value is None:
+        value = default
+    return str(value).strip().lower()
+
+
+def get_provider_setting(setting_name: str, default: str) -> str:
+    """Read a provider setting from Django settings and normalize it."""
+    return normalize_provider(getattr(settings, setting_name, default), default)
+
+
+def validate_provider(
+    setting_name: str,
+    provider: object,
+    allowed_providers: Iterable[str],
+) -> str:
+    """Validate a provider name against a registry's known keys."""
+    normalized_provider = normalize_provider(provider, "")
+    allowed = tuple(allowed_providers)
+    if normalized_provider in allowed:
+        return normalized_provider
+
+    raise ProviderConfigError(
+        f"Invalid {setting_name}: {provider}. "
+        f"Must be {_format_allowed_providers(allowed)}."
+    )
+
+
+def create_from_provider_registry(
+    setting_name: str,
+    provider: object,
+    registry: Mapping[str, Callable[[], T]],
+) -> T:
+    """Create a provider-backed object from a registry of builder strategies."""
+    normalized_provider = validate_provider(setting_name, provider, registry.keys())
+    return registry[normalized_provider]()
+
+
+def resolve_openai_api_key(
+    api_key: str | None = None,
+    *,
+    allow_settings_fallback: bool = True,
+    purpose: str = "OpenAI provider",
+) -> str:
+    """Resolve an OpenAI API key from an explicit value or Django settings."""
+    resolved_key = api_key
+    if not resolved_key and allow_settings_fallback:
+        resolved_key = getattr(settings, "OPENAI_API_KEY", None)
+
+    if not resolved_key:
+        raise ProviderConfigError(
+            f"OpenAI API key is required when using {purpose}. "
+            "Please set OPENAI_API_KEY in the server environment."
+        )
+
+    return resolved_key
+
+
+def _format_allowed_providers(providers: Iterable[str]) -> str:
+    quoted_providers = [f"'{provider}'" for provider in sorted(providers)]
+    if len(quoted_providers) == 1:
+        return quoted_providers[0]
+    return f"{', '.join(quoted_providers[:-1])} or {quoted_providers[-1]}"

--- a/backend/app/infrastructure/common/tests/test_embeddings.py
+++ b/backend/app/infrastructure/common/tests/test_embeddings.py
@@ -1,0 +1,60 @@
+"""Tests for shared embedding provider creation."""
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+from pydantic import SecretStr
+
+from app.domain.shared.exceptions import ProviderConfigError
+from app.infrastructure.common.embeddings import get_embeddings
+
+
+class GetEmbeddingsTests(SimpleTestCase):
+    """Tests for get_embeddings provider selection."""
+
+    @patch("app.infrastructure.common.embeddings.OpenAIEmbeddings")
+    @override_settings(
+        EMBEDDING_PROVIDER="openai",
+        EMBEDDING_MODEL="text-embedding-3-small",
+        OPENAI_API_KEY="server-openai-key",
+    )
+    def test_creates_openai_embeddings_from_django_settings(self, mock_openai):
+        get_embeddings()
+
+        mock_openai.assert_called_once_with(
+            model="text-embedding-3-small",
+            api_key=SecretStr("server-openai-key"),
+        )
+
+    @patch("app.infrastructure.common.embeddings.OllamaEmbeddings")
+    @override_settings(
+        EMBEDDING_PROVIDER="ollama",
+        EMBEDDING_MODEL="qwen3-embedding:0.6b",
+        OLLAMA_BASE_URL="http://localhost:11434",
+        OPENAI_API_KEY="",
+    )
+    def test_creates_ollama_embeddings(self, mock_ollama):
+        get_embeddings()
+
+        mock_ollama.assert_called_once_with(
+            model="qwen3-embedding:0.6b",
+            base_url="http://localhost:11434",
+        )
+
+    @override_settings(
+        EMBEDDING_PROVIDER="openai",
+        EMBEDDING_MODEL="text-embedding-3-small",
+        OPENAI_API_KEY="",
+    )
+    def test_openai_embeddings_require_api_key(self):
+        with self.assertRaises(ProviderConfigError) as context:
+            get_embeddings()
+
+        self.assertIn("OpenAI API key", str(context.exception))
+
+    @override_settings(EMBEDDING_PROVIDER="unknown_provider")
+    def test_invalid_embedding_provider_raises_provider_config_error(self):
+        with self.assertRaises(ProviderConfigError) as context:
+            get_embeddings()
+
+        self.assertIn("Invalid EMBEDDING_PROVIDER", str(context.exception))

--- a/backend/app/infrastructure/common/tests/test_whisper_client.py
+++ b/backend/app/infrastructure/common/tests/test_whisper_client.py
@@ -1,0 +1,101 @@
+"""Tests for Whisper provider configuration and client creation."""
+
+import os
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from app.domain.shared.exceptions import ProviderConfigError
+from app.infrastructure.common.whisper_client import (
+    WhisperConfig,
+    create_async_whisper_client,
+    create_whisper_client,
+    get_whisper_model_name,
+)
+
+
+class WhisperConfigTests(SimpleTestCase):
+    """Tests for WhisperConfig settings resolution."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "WHISPER_BACKEND": "openai",
+            "WHISPER_LOCAL_URL": "http://env-value:8080",
+        },
+    )
+    @override_settings(
+        WHISPER_BACKEND="whisper.cpp",
+        WHISPER_LOCAL_URL="http://settings-value:8080",
+    )
+    def test_reads_django_settings_instead_of_environment_directly(self):
+        config = WhisperConfig()
+
+        self.assertEqual(config.backend, "whisper.cpp")
+        self.assertEqual(config.local_url, "http://settings-value:8080")
+        self.assertTrue(config.is_local())
+        self.assertFalse(config.is_openai())
+
+    @override_settings(WHISPER_BACKEND="invalid")
+    def test_invalid_backend_raises_provider_config_error(self):
+        with self.assertRaises(ProviderConfigError) as context:
+            WhisperConfig()
+
+        self.assertIn("Invalid WHISPER_BACKEND", str(context.exception))
+
+
+class CreateWhisperClientTests(SimpleTestCase):
+    """Tests for sync and async Whisper client factories."""
+
+    @patch("app.infrastructure.common.whisper_client.OpenAI")
+    @override_settings(WHISPER_BACKEND="openai", OPENAI_API_KEY="server-key")
+    def test_openai_client_uses_settings_api_key_fallback(self, mock_openai):
+        create_whisper_client(api_key=None)
+
+        mock_openai.assert_called_once_with(api_key="server-key")
+
+    @patch("app.infrastructure.common.whisper_client.OpenAI")
+    @override_settings(
+        WHISPER_BACKEND="whisper.cpp",
+        WHISPER_LOCAL_URL="http://localhost:8080",
+        OPENAI_API_KEY="",
+    )
+    def test_local_client_uses_dummy_key_and_local_url(self, mock_openai):
+        create_whisper_client(api_key=None)
+
+        mock_openai.assert_called_once_with(
+            api_key="dummy-key-for-local",
+            base_url="http://localhost:8080",
+        )
+
+    @patch("app.infrastructure.common.whisper_client.AsyncOpenAI")
+    @override_settings(
+        WHISPER_BACKEND="whisper.cpp",
+        WHISPER_LOCAL_URL="http://localhost:8080",
+        OPENAI_API_KEY="",
+    )
+    def test_async_local_client_uses_dummy_key_and_local_url(self, mock_async_openai):
+        create_async_whisper_client(api_key=None)
+
+        mock_async_openai.assert_called_once_with(
+            api_key="dummy-key-for-local",
+            base_url="http://localhost:8080",
+        )
+
+    @override_settings(WHISPER_BACKEND="openai", OPENAI_API_KEY="")
+    def test_openai_client_requires_api_key(self):
+        with self.assertRaises(ProviderConfigError) as context:
+            create_whisper_client(api_key=None)
+
+        self.assertIn("OpenAI API key", str(context.exception))
+
+    @override_settings(
+        WHISPER_BACKEND="whisper.cpp",
+        WHISPER_LOCAL_URL="http://localhost:8080",
+    )
+    def test_local_model_name(self):
+        self.assertEqual(get_whisper_model_name(), "whisper-local")
+
+    @override_settings(WHISPER_BACKEND="openai")
+    def test_openai_model_name(self):
+        self.assertEqual(get_whisper_model_name(), "whisper-1")

--- a/backend/app/infrastructure/common/whisper_client.py
+++ b/backend/app/infrastructure/common/whisper_client.py
@@ -1,9 +1,16 @@
 """Whisper client factory for OpenAI API and local whisper.cpp server."""
 
 import logging
-import os
 
+from django.conf import settings
 from openai import AsyncOpenAI, OpenAI
+
+from app.infrastructure.common.provider_registry import (
+    create_from_provider_registry,
+    get_provider_setting,
+    resolve_openai_api_key,
+    validate_provider,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +22,14 @@ class WhisperConfig:
     BACKEND_LOCAL = "whisper.cpp"
 
     def __init__(self):
-        self.backend = os.getenv("WHISPER_BACKEND", self.BACKEND_OPENAI).lower()
-        self.local_url = os.getenv(
-            "WHISPER_LOCAL_URL", "http://host.docker.internal:8080"
+        provider = get_provider_setting("WHISPER_BACKEND", self.BACKEND_OPENAI)
+        self.backend = validate_provider(
+            "WHISPER_BACKEND",
+            provider,
+            (self.BACKEND_OPENAI, self.BACKEND_LOCAL),
+        )
+        self.local_url = getattr(
+            settings, "WHISPER_LOCAL_URL", "http://host.docker.internal:8080"
         )
 
         logger.info("Whisper backend configured: %s", self.backend)
@@ -36,15 +48,14 @@ def create_whisper_client(api_key, config=None):
     if config is None:
         config = WhisperConfig()
 
-    if config.is_local():
-        logger.debug("Creating local whisper client: %s", config.local_url)
-        return OpenAI(
-            api_key=api_key or "dummy-key-for-local",
-            base_url=config.local_url,
-        )
-
-    logger.debug("Creating OpenAI whisper client")
-    return OpenAI(api_key=api_key)
+    return create_from_provider_registry(
+        "WHISPER_BACKEND",
+        config.backend,
+        {
+            config.BACKEND_OPENAI: lambda: _create_openai_whisper_client(api_key),
+            config.BACKEND_LOCAL: lambda: _create_local_whisper_client(api_key, config),
+        },
+    )
 
 
 def create_async_whisper_client(api_key, config=None):
@@ -52,15 +63,16 @@ def create_async_whisper_client(api_key, config=None):
     if config is None:
         config = WhisperConfig()
 
-    if config.is_local():
-        logger.debug("Creating async local whisper client: %s", config.local_url)
-        return AsyncOpenAI(
-            api_key=api_key or "dummy-key-for-local",
-            base_url=config.local_url,
-        )
-
-    logger.debug("Creating async OpenAI whisper client")
-    return AsyncOpenAI(api_key=api_key)
+    return create_from_provider_registry(
+        "WHISPER_BACKEND",
+        config.backend,
+        {
+            config.BACKEND_OPENAI: lambda: _create_async_openai_whisper_client(api_key),
+            config.BACKEND_LOCAL: lambda: _create_async_local_whisper_client(
+                api_key, config
+            ),
+        },
+    )
 
 
 def get_whisper_model_name(config=None):
@@ -68,6 +80,39 @@ def get_whisper_model_name(config=None):
     if config is None:
         config = WhisperConfig()
 
-    if config.is_local():
-        return "whisper-local"
-    return "whisper-1"
+    return create_from_provider_registry(
+        "WHISPER_BACKEND",
+        config.backend,
+        {
+            config.BACKEND_OPENAI: lambda: "whisper-1",
+            config.BACKEND_LOCAL: lambda: "whisper-local",
+        },
+    )
+
+
+def _create_openai_whisper_client(api_key):
+    logger.debug("Creating OpenAI whisper client")
+    return OpenAI(api_key=resolve_openai_api_key(api_key, purpose="OpenAI Whisper"))
+
+
+def _create_local_whisper_client(api_key, config):
+    logger.debug("Creating local whisper client: %s", config.local_url)
+    return OpenAI(
+        api_key=api_key or "dummy-key-for-local",
+        base_url=config.local_url,
+    )
+
+
+def _create_async_openai_whisper_client(api_key):
+    logger.debug("Creating async OpenAI whisper client")
+    return AsyncOpenAI(
+        api_key=resolve_openai_api_key(api_key, purpose="OpenAI Whisper")
+    )
+
+
+def _create_async_local_whisper_client(api_key, config):
+    logger.debug("Creating async local whisper client: %s", config.local_url)
+    return AsyncOpenAI(
+        api_key=api_key or "dummy-key-for-local",
+        base_url=config.local_url,
+    )

--- a/backend/app/infrastructure/external/llm.py
+++ b/backend/app/infrastructure/external/llm.py
@@ -8,7 +8,11 @@ from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
 from pydantic import SecretStr
 
-from app.domain.shared.exceptions import LLMConfigError
+from app.infrastructure.common.provider_registry import (
+    create_from_provider_registry,
+    get_provider_setting,
+    resolve_openai_api_key,
+)
 
 
 def get_langchain_llm(api_key: Optional[str] = None) -> BaseChatModel:
@@ -22,42 +26,38 @@ def get_langchain_llm(api_key: Optional[str] = None) -> BaseChatModel:
         BaseChatModel: Configured LLM instance.
 
     Raises:
-        LLMConfigError: If the LLM cannot be configured due to missing key or unknown provider.
+        ProviderConfigError: If the LLM cannot be configured due to missing key or unknown provider.
     """
-    provider = getattr(settings, "LLM_PROVIDER", "openai")
-    temperature = 0.0  # Temperature is fixed at 0.0
+    provider = get_provider_setting("LLM_PROVIDER", "openai")
+    return create_from_provider_registry(
+        "LLM_PROVIDER",
+        provider,
+        {
+            "openai": lambda: _create_openai_llm(api_key),
+            "ollama": _create_ollama_llm,
+        },
+    )
 
-    if provider == "openai":
-        resolved_key = api_key or getattr(settings, "OPENAI_API_KEY", None)
-        if not resolved_key:
-            raise LLMConfigError(
-                "OpenAI API key is not configured. Please set your API key in Settings."
-            )
 
-        model = getattr(settings, "LLM_MODEL", "gpt-4o-mini")
+def _create_openai_llm(api_key: Optional[str] = None) -> BaseChatModel:
+    resolved_key = resolve_openai_api_key(api_key, purpose="OpenAI LLM")
+    model = getattr(settings, "LLM_MODEL", "gpt-4o-mini")
 
-        llm = ChatOpenAI(
-            model=model,
-            api_key=SecretStr(resolved_key),
-            temperature=temperature,
-        )
-        llm.max_tokens = 1024
-        return llm
+    llm = ChatOpenAI(
+        model=model,
+        api_key=SecretStr(resolved_key),
+        temperature=0.0,
+    )
+    llm.max_tokens = 1024
+    return llm
 
-    elif provider == "ollama":
-        # Use Ollama LLM
-        base_url = getattr(
-            settings, "OLLAMA_BASE_URL", "http://host.docker.internal:11434"
-        )
-        model = getattr(settings, "LLM_MODEL", "qwen3:0.6b")
 
-        return ChatOllama(
-            model=model,
-            base_url=base_url,
-            temperature=temperature,
-        )
+def _create_ollama_llm() -> BaseChatModel:
+    base_url = getattr(settings, "OLLAMA_BASE_URL", "http://host.docker.internal:11434")
+    model = getattr(settings, "LLM_MODEL", "qwen3:0.6b")
 
-    else:
-        raise LLMConfigError(
-            f"Invalid LLM_PROVIDER: {provider}. Must be 'openai' or 'ollama'."
-        )
+    return ChatOllama(
+        model=model,
+        base_url=base_url,
+        temperature=0.0,
+    )

--- a/backend/app/infrastructure/external/rag_gateway.py
+++ b/backend/app/infrastructure/external/rag_gateway.py
@@ -18,9 +18,9 @@ from app.domain.chat.gateways import (
     RagUserNotFoundError,
 )
 from app.domain.chat.dtos import ChatMessageDTO, CitationDTO
+from app.domain.shared.exceptions import ProviderConfigError
 from app.infrastructure.external.llm import get_langchain_llm
 from app.infrastructure.external.rag_service import RagChatService, _RagServiceStreamEnd
-from app.domain.shared.exceptions import LLMConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class RagChatGateway(RagGateway):
 
         try:
             llm = get_langchain_llm(api_key=api_key)
-        except LLMConfigError as e:
+        except ProviderConfigError as e:
             raise LLMConfigurationError(str(e)) from e
 
         service = RagChatService(user=user, llm=llm, api_key=api_key)
@@ -109,7 +109,7 @@ class RagChatGateway(RagGateway):
 
         try:
             llm = get_langchain_llm(api_key=api_key)
-        except LLMConfigError as e:
+        except ProviderConfigError as e:
             raise LLMConfigurationError(str(e)) from e
 
         service = RagChatService(user=user, llm=llm, api_key=api_key)

--- a/backend/app/infrastructure/external/tests/test_llm.py
+++ b/backend/app/infrastructure/external/tests/test_llm.py
@@ -4,14 +4,14 @@ Tests for llm module
 
 from unittest.mock import patch
 
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, override_settings
 from pydantic import SecretStr
 
+from app.domain.shared.exceptions import ProviderConfigError
 from app.infrastructure.external.llm import get_langchain_llm
-from app.domain.shared.exceptions import LLMConfigError
 
 
-class GetLangchainLLMTests(TestCase):
+class GetLangchainLLMTests(SimpleTestCase):
     """Tests for get_langchain_llm function"""
 
     @patch("app.infrastructure.external.llm.ChatOpenAI")
@@ -42,14 +42,14 @@ class GetLangchainLLMTests(TestCase):
 
     @override_settings(LLM_PROVIDER="openai", LLM_MODEL="gpt-4o-mini", OPENAI_API_KEY="")
     def test_get_langchain_llm_without_api_key(self):
-        """Test get_langchain_llm raises LLMConfigError when no key provided"""
-        with self.assertRaises(LLMConfigError):
+        """Test get_langchain_llm raises ProviderConfigError when no key provided"""
+        with self.assertRaises(ProviderConfigError):
             get_langchain_llm()
 
     @override_settings(LLM_PROVIDER="openai", LLM_MODEL="gpt-4o-mini", OPENAI_API_KEY="")
     def test_get_langchain_llm_with_none_api_key(self):
-        """Test get_langchain_llm raises LLMConfigError when API key is None"""
-        with self.assertRaises(LLMConfigError):
+        """Test get_langchain_llm raises ProviderConfigError when API key is None"""
+        with self.assertRaises(ProviderConfigError):
             get_langchain_llm(api_key=None)
 
     @patch("app.infrastructure.external.llm.ChatOpenAI")
@@ -84,7 +84,7 @@ class GetLangchainLLMTests(TestCase):
 
     @override_settings(LLM_PROVIDER="unknown_provider")
     def test_get_langchain_llm_with_invalid_provider(self):
-        """Test get_langchain_llm raises LLMConfigError for unknown provider"""
-        with self.assertRaises(LLMConfigError) as ctx:
+        """Test get_langchain_llm raises ProviderConfigError for unknown provider"""
+        with self.assertRaises(ProviderConfigError) as ctx:
             get_langchain_llm()
         self.assertIn("Invalid LLM_PROVIDER", str(ctx.exception))

--- a/backend/app/infrastructure/scene_otsu/embedders.py
+++ b/backend/app/infrastructure/scene_otsu/embedders.py
@@ -10,6 +10,12 @@ from langchain_openai import OpenAIEmbeddings
 from pydantic import SecretStr
 from tqdm import tqdm
 
+from app.infrastructure.common.provider_registry import (
+    create_from_provider_registry,
+    get_provider_setting,
+    resolve_openai_api_key,
+)
+
 
 class BaseEmbedder(ABC):
     """Abstract base class for embedding generation"""
@@ -73,21 +79,33 @@ def create_embedder(
     api_key: Optional[str] = None, batch_size: int = 16
 ) -> BaseEmbedder:
     """Create embedder based on EMBEDDING_PROVIDER setting"""
-    provider = settings.EMBEDDING_PROVIDER
+    provider = get_provider_setting("EMBEDDING_PROVIDER", "openai")
+    return create_from_provider_registry(
+        "EMBEDDING_PROVIDER",
+        provider,
+        {
+            "openai": lambda: _create_openai_embedder(api_key, batch_size),
+            "ollama": lambda: _create_ollama_embedder(batch_size),
+        },
+    )
 
-    if provider == "openai":
-        if not api_key:
-            raise ValueError("OpenAI API key is required when using OpenAI embeddings")
-        return OpenAIEmbedder(
-            api_key=api_key, model=settings.EMBEDDING_MODEL, batch_size=batch_size
-        )
-    elif provider == "ollama":
-        return OllamaEmbedder(
-            model=settings.EMBEDDING_MODEL,
-            base_url=settings.OLLAMA_BASE_URL,
-            batch_size=batch_size,
-        )
-    else:
-        raise ValueError(
-            f"Invalid EMBEDDING_PROVIDER: {provider}. Must be 'openai' or 'ollama'."
-        )
+
+def _create_openai_embedder(api_key: Optional[str], batch_size: int) -> BaseEmbedder:
+    resolved_key = resolve_openai_api_key(
+        api_key,
+        allow_settings_fallback=False,
+        purpose="OpenAI embeddings",
+    )
+    return OpenAIEmbedder(
+        api_key=resolved_key,
+        model=settings.EMBEDDING_MODEL,
+        batch_size=batch_size,
+    )
+
+
+def _create_ollama_embedder(batch_size: int) -> BaseEmbedder:
+    return OllamaEmbedder(
+        model=settings.EMBEDDING_MODEL,
+        base_url=settings.OLLAMA_BASE_URL,
+        batch_size=batch_size,
+    )

--- a/backend/app/infrastructure/scene_otsu/tests/test_embedders.py
+++ b/backend/app/infrastructure/scene_otsu/tests/test_embedders.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, override_settings
 
+from app.domain.shared.exceptions import ProviderConfigError
+
 
 class BaseEmbedderTests(SimpleTestCase):
     """Tests for BaseEmbedder class"""
@@ -138,10 +140,10 @@ class CreateEmbedderOpenAITests(SimpleTestCase):
         )
 
     def test_raises_without_api_key(self):
-        """Test that ValueError is raised without API key"""
+        """Test that ProviderConfigError is raised without API key"""
         from app.infrastructure.scene_otsu.embedders import create_embedder
 
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(ProviderConfigError) as context:
             create_embedder(api_key=None)
 
         self.assertIn("OpenAI API key is required", str(context.exception))
@@ -182,10 +184,10 @@ class CreateEmbedderInvalidTests(SimpleTestCase):
     """Tests for create_embedder function with invalid provider"""
 
     def test_raises_for_invalid_provider(self):
-        """Test that ValueError is raised for invalid provider"""
+        """Test that ProviderConfigError is raised for invalid provider"""
         from app.infrastructure.scene_otsu.embedders import create_embedder
 
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(ProviderConfigError) as context:
             create_embedder(api_key="test-key")
 
         self.assertIn("Invalid EMBEDDING_PROVIDER", str(context.exception))

--- a/backend/app/infrastructure/transcription/srt_processing.py
+++ b/backend/app/infrastructure/transcription/srt_processing.py
@@ -4,8 +4,6 @@ SRT subtitle processing utilities
 
 import logging
 
-from django.conf import settings
-
 from app.infrastructure.scene_otsu import SceneSplitter, SubtitleParser
 from app.infrastructure.transcription.audio_processing import process_audio_segments_parallel
 
@@ -69,8 +67,6 @@ def apply_scene_splitting(srt_content, api_key, original_segment_count=None):
     api_key: API key for OpenAI (required when using OpenAI provider)
     """
     try:
-        if settings.EMBEDDING_PROVIDER == "openai" and not api_key:
-            raise ValueError("OpenAI API key is required when using OpenAI embeddings")
         splitter = SceneSplitter(api_key=api_key)
         scene_split_srt = splitter.process(srt_content, max_tokens=512)
         scene_count = count_scenes(scene_split_srt)

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -114,7 +114,8 @@ class DefaultSettings:
     LLM_MODEL = "gpt-4o-mini"  # Default LLM model (provider-agnostic)
 
     # Whisper configuration
-    WHISPER_BACKEND = "openai"  # openai or local
+    WHISPER_BACKEND = "openai"  # openai or whisper.cpp
+    WHISPER_LOCAL_URL = "http://host.docker.internal:8080"
     SEARCHAPI_TIMEOUT_SECONDS = 60
 
 
@@ -581,7 +582,12 @@ LLM_PROVIDER = os.environ.get("LLM_PROVIDER", DefaultSettings.LLM_PROVIDER).lowe
 LLM_MODEL = os.environ.get("LLM_MODEL", DefaultSettings.LLM_MODEL)
 
 # Whisper configuration
-WHISPER_BACKEND = os.environ.get("WHISPER_BACKEND", DefaultSettings.WHISPER_BACKEND).lower()
+WHISPER_BACKEND = os.environ.get(
+    "WHISPER_BACKEND", DefaultSettings.WHISPER_BACKEND
+).lower()
+WHISPER_LOCAL_URL = os.environ.get(
+    "WHISPER_LOCAL_URL", DefaultSettings.WHISPER_LOCAL_URL
+)
 SEARCHAPI_TIMEOUT_SECONDS = int(
     os.environ.get("SEARCHAPI_TIMEOUT_SECONDS", DefaultSettings.SEARCHAPI_TIMEOUT_SECONDS)
 )


### PR DESCRIPTION
## Summary
- LLM / embedding / Whisper の provider registry/helper を追加し、provider 選択と設定エラーを統一
- Whisper 設定を Django settings 経由に寄せ、WHISPER_LOCAL_URL を settings 化
- provider contract テストを追加し、既存テストを ProviderConfigError に更新

## Tests
- python backend/manage.py test app.infrastructure.external.tests.test_llm app.infrastructure.common.tests.test_embeddings app.infrastructure.common.tests.test_whisper_client app.infrastructure.scene_otsu.tests.test_embedders app.infrastructure.transcription.tests.test_srt_processing app.infrastructure.transcription.tests.test_audio_processing
- docker compose run --rm backend python manage.py test app.infrastructure.external.tests.test_rag_chat --keepdb
- docker compose run --rm backend python manage.py test app.infrastructure.scene_otsu.tests --keepdb
- python backend/manage.py check
- git diff --check

Closes #744