### PR TITLE
チャットストリーミング処理をreducer/stream controllerに分離する

### DIFF
--- a/frontend/src/components/chat/ChatComposer.tsx
+++ b/frontend/src/components/chat/ChatComposer.tsx
@@ -1,0 +1,44 @@
+import type { KeyboardEvent } from 'react';
+import { Send } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { InlineSpinner } from '@/components/common/InlineSpinner';
+
+interface ChatComposerProps {
+  input: string;
+  isLoading: boolean;
+  onInputChange: (input: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  onSend: () => Promise<void>;
+}
+
+export function ChatComposer({
+  input,
+  isLoading,
+  onInputChange,
+  onKeyDown,
+  onSend,
+}: ChatComposerProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="p-4 bg-[#f2f4ef] border-t border-stone-100 shrink-0">
+      <div className="relative">
+        <input
+          value={input}
+          onChange={(e) => onInputChange(e.target.value)}
+          onKeyDown={onKeyDown}
+          disabled={isLoading}
+          placeholder={t('chat.placeholder')}
+          className="w-full bg-white rounded-2xl py-3 pl-4 pr-12 text-sm outline-none focus:ring-2 focus:ring-[#00652c]/30 shadow-inner"
+        />
+        <button
+          onClick={() => void onSend()}
+          disabled={isLoading || !input.trim()}
+          className="absolute right-2 top-1.5 w-9 h-9 bg-[#00652c] text-white rounded-full flex items-center justify-center hover:bg-[#005323] transition-colors active:scale-95 disabled:opacity-40"
+        >
+          {isLoading ? <InlineSpinner className="w-4 h-4" /> : <Send className="w-4 h-4" />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatHistoryView.tsx
+++ b/frontend/src/components/chat/ChatHistoryView.tsx
@@ -1,0 +1,166 @@
+import { BookOpen, Download, ThumbsDown, ThumbsUp } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { ChatHistoryItem, ChatLogEvaluation } from '@/lib/api';
+import { InlineSpinner } from '@/components/common/InlineSpinner';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { MessageBody } from '@/components/chat/MessageBody';
+
+interface ChatHistoryViewProps {
+  history: ChatHistoryItem[] | null;
+  historyLoading: boolean;
+  isExportingHistoryCsv: boolean;
+  onExportHistoryCsv: () => Promise<void>;
+  onVideoNavigate: (videoId: number, startTime: string) => void;
+}
+
+function formatEvaluationPercent(value: number | null | undefined) {
+  if (value == null) return '-';
+  return `${Math.round(value * 100)}%`;
+}
+
+function EvaluationMetric({
+  label,
+  value,
+}: {
+  label: string;
+  value: number | null | undefined;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-stone-500">{label}</span>
+      <span className="font-semibold text-stone-800">{formatEvaluationPercent(value)}</span>
+    </div>
+  );
+}
+
+function HistoryEvaluation({ evaluation }: { evaluation?: ChatLogEvaluation }) {
+  const { t } = useTranslation();
+
+  if (!evaluation) return null;
+
+  if (evaluation.status === 'pending') {
+    return (
+      <div className="rounded-lg bg-stone-50 px-3 py-2 text-[11px] font-medium text-stone-500">
+        {t('chat.evaluation.status.pending')}
+      </div>
+    );
+  }
+
+  if (evaluation.status === 'failed') {
+    return (
+      <div className="rounded-lg bg-stone-50 px-3 py-2 text-[11px] font-medium text-stone-500">
+        {t('chat.evaluation.status.failed')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-stone-100 bg-stone-50/70 px-3 py-2">
+      <div className="mb-2 text-[11px] font-semibold text-[#00652c]">
+        {t('chat.evaluation.status.completed')}
+      </div>
+      <div className="space-y-1.5 text-[11px]">
+        <EvaluationMetric
+          label={t('chat.evaluation.metrics.faithfulness')}
+          value={evaluation.faithfulness}
+        />
+        <EvaluationMetric
+          label={t('chat.evaluation.metrics.answerRelevancy')}
+          value={evaluation.answer_relevancy}
+        />
+        <EvaluationMetric
+          label={t('chat.evaluation.metrics.contextPrecision')}
+          value={evaluation.context_precision}
+        />
+      </div>
+    </div>
+  );
+}
+
+function HistoryItem({
+  item,
+  onVideoNavigate,
+}: {
+  item: ChatHistoryItem;
+  onVideoNavigate: (videoId: number, startTime: string) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-center">
+        <span className="text-[10px] text-stone-400 bg-stone-100 px-2 py-0.5 rounded-full">
+          {new Date(item.created_at).toLocaleString()}
+        </span>
+      </div>
+
+      <div className="flex flex-col items-end">
+        <div className="bg-[#006d30] text-white rounded-2xl rounded-tr-none px-4 py-3 text-sm max-w-[90%] shadow-sm">
+          {item.question}
+        </div>
+      </div>
+
+      <div className="flex flex-col items-start">
+        <div className="bg-white border-l-4 border-[#00652c] rounded-2xl rounded-tl-none p-4 text-sm shadow-sm space-y-2">
+          <div className="flex items-center gap-2 text-[#00652c] font-bold text-xs">
+            <BookOpen className="w-3.5 h-3.5" />
+            AI {t('chat.teacher')}
+          </div>
+          <MessageBody
+            content={item.answer}
+            citations={item.citations}
+            onVideoNavigate={onVideoNavigate}
+          />
+          <HistoryEvaluation evaluation={item.evaluation} />
+          {item.feedback && (
+            <div className={`flex items-center gap-1 pt-1 text-[10px] font-bold ${item.feedback === 'good' ? 'text-[#00652c]' : 'text-red-400'}`}>
+              {item.feedback === 'good' ? <ThumbsUp className="w-3 h-3" /> : <ThumbsDown className="w-3 h-3" />}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ChatHistoryView({
+  history,
+  historyLoading,
+  isExportingHistoryCsv,
+  onExportHistoryCsv,
+  onVideoNavigate,
+}: ChatHistoryViewProps) {
+  const { t } = useTranslation();
+  const historyCount = history?.length ?? 0;
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      {!historyLoading && historyCount > 0 && (
+        <div className="flex justify-end px-4 pt-3 shrink-0">
+          <button
+            onClick={() => void onExportHistoryCsv()}
+            disabled={isExportingHistoryCsv}
+            className="flex items-center gap-1.5 text-xs font-bold text-[#00652c] hover:underline disabled:opacity-50"
+          >
+            {isExportingHistoryCsv ? <InlineSpinner className="w-3 h-3" /> : <Download className="w-3 h-3" />}
+            {t('chat.exportCsvShort', 'CSV')}
+          </button>
+        </div>
+      )}
+      <div className="flex-1 overflow-y-auto p-4 space-y-6">
+        {historyLoading && (
+          <LoadingSpinner />
+        )}
+        {!historyLoading && historyCount === 0 && (
+          <p className="text-sm text-stone-400 text-center py-8">{t('chat.historyEmpty')}</p>
+        )}
+        {!historyLoading && history?.map((item, i) => (
+          <div key={item.id}>
+            {i > 0 && <div className="border-t border-stone-100 mb-6" />}
+            <HistoryItem item={item} onVideoNavigate={onVideoNavigate} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatMessageBubble.tsx
+++ b/frontend/src/components/chat/ChatMessageBubble.tsx
@@ -1,0 +1,68 @@
+import { BookOpen, ThumbsDown, ThumbsUp } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { Message } from '@/hooks/useChatMessages';
+import { MessageBody } from '@/components/chat/MessageBody';
+
+interface ChatMessageBubbleProps {
+  message: Message;
+  feedbackUpdatingId: number | null;
+  onVideoNavigate: (videoId: number, startTime: string) => void;
+  onFeedback: (chatLogId: number, value: 'good' | 'bad') => Promise<unknown>;
+}
+
+export function ChatMessageBubble({
+  message,
+  feedbackUpdatingId,
+  onVideoNavigate,
+  onFeedback,
+}: ChatMessageBubbleProps) {
+  const { t } = useTranslation();
+
+  if (message.role === 'user') {
+    return (
+      <div className="flex flex-col items-end gap-1">
+        <div className="bg-[#006d30] text-white rounded-2xl rounded-tr-none px-4 py-3 text-sm max-w-[90%] shadow-sm">
+          {message.content}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <div className="bg-white border-l-4 border-[#00652c] rounded-2xl rounded-tl-none p-4 text-sm shadow-sm space-y-2">
+        <div className="flex items-center gap-2 text-[#00652c] font-bold text-xs mb-1">
+          <BookOpen className="w-3.5 h-3.5" />
+          AI {t('chat.teacher')}
+        </div>
+        <MessageBody
+          content={message.content}
+          citations={message.citations}
+          onVideoNavigate={onVideoNavigate}
+        />
+        {message.chatLogId && (
+          <div className="flex gap-2 pt-2">
+            <button
+              disabled={feedbackUpdatingId === message.chatLogId}
+              onClick={() => onFeedback(message.chatLogId!, 'good')}
+              className={`p-1 hover:bg-stone-100 rounded transition-colors disabled:opacity-40 ${
+                message.feedback === 'good' ? 'text-[#00652c]' : 'text-stone-400'
+              }`}
+            >
+              <ThumbsUp className="w-4 h-4" />
+            </button>
+            <button
+              disabled={feedbackUpdatingId === message.chatLogId}
+              onClick={() => onFeedback(message.chatLogId!, 'bad')}
+              className={`p-1 hover:bg-stone-100 rounded transition-colors disabled:opacity-40 ${
+                message.feedback === 'bad' ? 'text-red-500' : 'text-stone-400'
+              }`}
+            >
+              <ThumbsDown className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatMessagesView.tsx
+++ b/frontend/src/components/chat/ChatMessagesView.tsx
@@ -1,0 +1,36 @@
+import type { RefObject } from 'react';
+import type { Message } from '@/hooks/useChatMessages';
+import { ChatMessageBubble } from '@/components/chat/ChatMessageBubble';
+
+interface ChatMessagesViewProps {
+  messages: Message[];
+  feedbackUpdatingId: number | null;
+  messagesContainerRef: RefObject<HTMLDivElement | null>;
+  messagesEndRef: RefObject<HTMLDivElement | null>;
+  onVideoNavigate: (videoId: number, startTime: string) => void;
+  onFeedback: (chatLogId: number, value: 'good' | 'bad') => Promise<unknown>;
+}
+
+export function ChatMessagesView({
+  messages,
+  feedbackUpdatingId,
+  messagesContainerRef,
+  messagesEndRef,
+  onVideoNavigate,
+  onFeedback,
+}: ChatMessagesViewProps) {
+  return (
+    <div ref={messagesContainerRef} className="flex-1 overflow-y-auto p-4 space-y-4">
+      {messages.map((message, index) => (
+        <ChatMessageBubble
+          key={index}
+          message={message}
+          feedbackUpdatingId={feedbackUpdatingId}
+          onVideoNavigate={onVideoNavigate}
+          onFeedback={onFeedback}
+        />
+      ))}
+      <div ref={messagesEndRef} />
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,266 +1,12 @@
-import { Fragment, useState } from 'react';
-import { type ChatHistoryItem, type ChatLogEvaluation, type Citation } from '@/lib/api';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { timeStringToSeconds } from '@/lib/utils/video';
 import { cn } from '@/lib/utils';
-import { InlineSpinner } from '@/components/common/InlineSpinner';
-import { LoadingSpinner } from '@/components/common/LoadingSpinner';
-import { useTranslation } from 'react-i18next';
-import { useChatMessages, type Message } from '@/hooks/useChatMessages';
+import { useChatMessages } from '@/hooks/useChatMessages';
 import { useChatHistory } from '@/hooks/useChatHistory';
-import { BookOpen, ThumbsUp, ThumbsDown, Send, Download } from 'lucide-react';
-
-// ── Message bubble ────────────────────────────────────────────────────────────
-
-interface ChatMessageBubbleProps {
-  message: Message;
-  feedbackUpdatingId: number | null;
-  onVideoNavigate: (videoId: number, startTime: string) => void;
-  onFeedback: (chatLogId: number, value: 'good' | 'bad') => Promise<void>;
-}
-
-function MessageBody({
-  content,
-  citations,
-  onVideoNavigate,
-}: {
-  content: string;
-  citations?: Citation[];
-  onVideoNavigate: (videoId: number, startTime: string) => void;
-}) {
-  const formatInlineTime = (time: string | undefined) => {
-    if (!time) return '';
-    const main = time.split(',')[0];
-    return main.replace(/^00:/, '').replace(/^0(\d:)/, '$1');
-  };
-
-  const formatTimeRange = (startTime: string | undefined, endTime: string | undefined) => {
-    const start = formatInlineTime(startTime);
-    const end = formatInlineTime(endTime);
-    if (start && end) return `${start}-${end}`;
-    return start || end;
-  };
-
-  const tagPattern = /\[(\d+)\]/g;
-  const nodes: Array<
-    | { type: 'text'; value: string }
-    | { type: 'ref'; id: number }
-  > = [];
-  let lastIndex = 0;
-
-  for (const match of content.matchAll(tagPattern)) {
-    const id = Number(match[1]);
-    const start = match.index ?? 0;
-
-    if (start > lastIndex) {
-      nodes.push({ type: 'text', value: content.slice(lastIndex, start) });
-    }
-
-    nodes.push({ type: 'ref', id });
-    lastIndex = start + match[0].length;
-  }
-
-  if (lastIndex < content.length) {
-    nodes.push({ type: 'text', value: content.slice(lastIndex) });
-  }
-
-  const normalizedNodes = nodes.length > 0 ? nodes : [{ type: 'text' as const, value: content }];
-  const citationMap = new Map((citations ?? []).map((citation) => [citation.id, citation]));
-
-  return (
-    <div className="text-[#3f493f] leading-relaxed whitespace-pre-wrap">
-      {normalizedNodes.map((node, i) => {
-        if (node.type === 'text') {
-          return <Fragment key={`text-${i}`}>{node.value}</Fragment>;
-        }
-
-        const video = citationMap.get(node.id);
-        if (!video) {
-          return <Fragment key={`ref-${i}`}>[{node.id}]</Fragment>;
-        }
-
-        const primaryRange = formatTimeRange(video.start_time, video.end_time);
-
-        return (
-          <Fragment key={`${video.video_id}-${video.start_time}-${i}`}>
-            {primaryRange && (
-              <button
-                type="button"
-                onClick={() => onVideoNavigate(video.video_id, video.start_time)}
-                className="inline text-left text-[#00652c] underline decoration-[#00652c]/35 underline-offset-3 hover:text-[#00461e] hover:decoration-[#00461e] transition-colors"
-                title={`${video.title} ${video.start_time}`}
-                aria-label={`${video.title} ${video.start_time}`}
-              >
-                {` (${primaryRange})`}
-              </button>
-            )}
-          </Fragment>
-        );
-      })}
-    </div>
-  );
-}
-
-function ChatMessageBubble({ message, feedbackUpdatingId, onVideoNavigate, onFeedback }: ChatMessageBubbleProps) {
-  const { t } = useTranslation();
-
-  if (message.role === 'user') {
-    return (
-      <div className="flex flex-col items-end gap-1">
-        <div className="bg-[#006d30] text-white rounded-2xl rounded-tr-none px-4 py-3 text-sm max-w-[90%] shadow-sm">
-          {message.content}
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col items-start gap-1">
-      <div className="bg-white border-l-4 border-[#00652c] rounded-2xl rounded-tl-none p-4 text-sm shadow-sm space-y-2">
-        <div className="flex items-center gap-2 text-[#00652c] font-bold text-xs mb-1">
-          <BookOpen className="w-3.5 h-3.5" />
-          AI {t('chat.teacher')}
-        </div>
-        <MessageBody
-          content={message.content}
-          citations={message.citations}
-          onVideoNavigate={onVideoNavigate}
-        />
-        {message.role === 'assistant' && message.chatLogId && (
-          <div className="flex gap-2 pt-2">
-            <button
-              disabled={feedbackUpdatingId === message.chatLogId}
-              onClick={() => onFeedback(message.chatLogId!, 'good')}
-              className={`p-1 hover:bg-stone-100 rounded transition-colors disabled:opacity-40 ${
-                message.feedback === 'good' ? 'text-[#00652c]' : 'text-stone-400'
-              }`}
-            >
-              <ThumbsUp className="w-4 h-4" />
-            </button>
-            <button
-              disabled={feedbackUpdatingId === message.chatLogId}
-              onClick={() => onFeedback(message.chatLogId!, 'bad')}
-              className={`p-1 hover:bg-stone-100 rounded transition-colors disabled:opacity-40 ${
-                message.feedback === 'bad' ? 'text-red-500' : 'text-stone-400'
-              }`}
-            >
-              <ThumbsDown className="w-4 h-4" />
-            </button>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ── History item ──────────────────────────────────────────────────────────────
-
-function formatEvaluationPercent(value: number | null | undefined) {
-  if (value == null) return '-';
-  return `${Math.round(value * 100)}%`;
-}
-
-function EvaluationMetric({
-  label,
-  value,
-}: {
-  label: string;
-  value: number | null | undefined;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-stone-500">{label}</span>
-      <span className="font-semibold text-stone-800">{formatEvaluationPercent(value)}</span>
-    </div>
-  );
-}
-
-function HistoryEvaluation({ evaluation }: { evaluation?: ChatLogEvaluation }) {
-  const { t } = useTranslation();
-
-  if (!evaluation) return null;
-
-  if (evaluation.status === 'pending') {
-    return (
-      <div className="rounded-lg bg-stone-50 px-3 py-2 text-[11px] font-medium text-stone-500">
-        {t('chat.evaluation.status.pending')}
-      </div>
-    );
-  }
-
-  if (evaluation.status === 'failed') {
-    return (
-      <div className="rounded-lg bg-stone-50 px-3 py-2 text-[11px] font-medium text-stone-500">
-        {t('chat.evaluation.status.failed')}
-      </div>
-    );
-  }
-
-  return (
-    <div className="rounded-lg border border-stone-100 bg-stone-50/70 px-3 py-2">
-      <div className="mb-2 text-[11px] font-semibold text-[#00652c]">
-        {t('chat.evaluation.status.completed')}
-      </div>
-      <div className="space-y-1.5 text-[11px]">
-        <EvaluationMetric
-          label={t('chat.evaluation.metrics.faithfulness')}
-          value={evaluation.faithfulness}
-        />
-        <EvaluationMetric
-          label={t('chat.evaluation.metrics.answerRelevancy')}
-          value={evaluation.answer_relevancy}
-        />
-        <EvaluationMetric
-          label={t('chat.evaluation.metrics.contextPrecision')}
-          value={evaluation.context_precision}
-        />
-      </div>
-    </div>
-  );
-}
-
-function HistoryItem({ item, onVideoNavigate }: { item: ChatHistoryItem; onVideoNavigate: (videoId: number, startTime: string) => void }) {
-  const { t } = useTranslation();
-  return (
-    <div className="space-y-3">
-      {/* timestamp */}
-      <div className="flex justify-center">
-        <span className="text-[10px] text-stone-400 bg-stone-100 px-2 py-0.5 rounded-full">
-          {new Date(item.created_at).toLocaleString()}
-        </span>
-      </div>
-
-      {/* user question */}
-      <div className="flex flex-col items-end">
-        <div className="bg-[#006d30] text-white rounded-2xl rounded-tr-none px-4 py-3 text-sm max-w-[90%] shadow-sm">
-          {item.question}
-        </div>
-      </div>
-
-      {/* AI answer */}
-      <div className="flex flex-col items-start">
-        <div className="bg-white border-l-4 border-[#00652c] rounded-2xl rounded-tl-none p-4 text-sm shadow-sm space-y-2">
-          <div className="flex items-center gap-2 text-[#00652c] font-bold text-xs">
-            <BookOpen className="w-3.5 h-3.5" />
-            AI {t('chat.teacher')}
-          </div>
-          <MessageBody
-            content={item.answer}
-            citations={item.citations}
-            onVideoNavigate={onVideoNavigate}
-          />
-          <HistoryEvaluation evaluation={item.evaluation} />
-          {item.feedback && (
-            <div className={`flex items-center gap-1 pt-1 text-[10px] font-bold ${item.feedback === 'good' ? 'text-[#00652c]' : 'text-red-400'}`}>
-              {item.feedback === 'good' ? <ThumbsUp className="w-3 h-3" /> : <ThumbsDown className="w-3 h-3" />}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── ChatPanel ─────────────────────────────────────────────────────────────────
+import { ChatComposer } from '@/components/chat/ChatComposer';
+import { ChatHistoryView } from '@/components/chat/ChatHistoryView';
+import { ChatMessagesView } from '@/components/chat/ChatMessagesView';
 
 interface ChatPanelProps {
   groupId?: number;
@@ -303,17 +49,17 @@ export function ChatPanel({ groupId, onVideoPlay, shareToken, className }: ChatP
   const navigateToVideo = (videoId: number, startTime: string) => {
     if (onVideoPlay) {
       onVideoPlay(videoId, startTime);
-    } else {
-      const seconds = timeStringToSeconds(startTime);
-      window.open(`/videos/${videoId}?t=${seconds}`, '_blank');
+      return;
     }
+
+    const seconds = timeStringToSeconds(startTime);
+    window.open(`/videos/${videoId}?t=${seconds}`, '_blank');
   };
 
   const handleFeedbackWithSync = async (chatLogId: number, value: 'good' | 'bad') => {
-    await handleFeedback(chatLogId, value);
-    const targetMessage = messages.find((m) => m.chatLogId === chatLogId);
-    if (targetMessage) {
-      syncFeedbackInHistoryCache(chatLogId, targetMessage.feedback === value ? null : value);
+    const nextFeedback = await handleFeedback(chatLogId, value);
+    if (nextFeedback !== undefined) {
+      syncFeedbackInHistoryCache(chatLogId, nextFeedback);
     }
   };
 
@@ -321,12 +67,11 @@ export function ChatPanel({ groupId, onVideoPlay, shareToken, className }: ChatP
 
   const containerClass = cn(
     'flex flex-col overflow-hidden rounded-xl bg-white',
-    className ?? 'h-[500px] lg:h-[600px]'
+    className ?? 'h-[500px] lg:h-[600px]',
   );
 
   return (
     <div className={containerClass}>
-      {/* Header */}
       <div className="px-4 py-3 border-b border-stone-100 shrink-0 flex items-center justify-between gap-4">
         <h2 className="font-extrabold text-[#191c19] shrink-0">{t('chat.title')}</h2>
         {showTabs && (
@@ -356,69 +101,30 @@ export function ChatPanel({ groupId, onVideoPlay, shareToken, className }: ChatP
       </div>
 
       {tab === 'history' ? (
-        /* ── History view ──────────────────────────────────────────────── */
-        <div className="flex-1 flex flex-col min-h-0">
-          {!historyLoading && (history?.length ?? 0) > 0 && (
-            <div className="flex justify-end px-4 pt-3 shrink-0">
-              <button
-                onClick={() => void exportHistoryCsv()}
-                disabled={isExportingHistoryCsv}
-                className="flex items-center gap-1.5 text-xs font-bold text-[#00652c] hover:underline disabled:opacity-50"
-              >
-                {isExportingHistoryCsv ? <InlineSpinner className="w-3 h-3" /> : <Download className="w-3 h-3" />}
-                {t('chat.exportCsvShort', 'CSV')}
-              </button>
-            </div>
-          )}
-          <div className="flex-1 overflow-y-auto p-4 space-y-6">
-            {historyLoading && (
-              <LoadingSpinner />
-            )}
-            {!historyLoading && (history?.length ?? 0) === 0 && (
-              <p className="text-sm text-stone-400 text-center py-8">{t('chat.historyEmpty')}</p>
-            )}
-            {!historyLoading && history?.map((item, i) => (
-              <div key={item.id}>
-                {i > 0 && <div className="border-t border-stone-100 mb-6" />}
-                <HistoryItem item={item} onVideoNavigate={navigateToVideo} />
-              </div>
-            ))}
-          </div>
-        </div>
+        <ChatHistoryView
+          history={history}
+          historyLoading={historyLoading}
+          isExportingHistoryCsv={isExportingHistoryCsv}
+          onExportHistoryCsv={exportHistoryCsv}
+          onVideoNavigate={navigateToVideo}
+        />
       ) : (
-        /* ── Chat view ─────────────────────────────────────────────────── */
         <>
-          <div ref={messagesContainerRef} className="flex-1 overflow-y-auto p-4 space-y-4">
-            {messages.map((message: Message, index: number) => (
-              <ChatMessageBubble
-                key={index}
-                message={message}
-                feedbackUpdatingId={feedbackUpdatingId}
-                onVideoNavigate={navigateToVideo}
-                onFeedback={handleFeedbackWithSync}
-              />
-            ))}
-            <div ref={messagesEndRef} />
-          </div>
-          <div className="p-4 bg-[#f2f4ef] border-t border-stone-100 shrink-0">
-            <div className="relative">
-              <input
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                onKeyDown={handleKeyPress}
-                disabled={isLoading}
-                placeholder={t('chat.placeholder')}
-                className="w-full bg-white rounded-2xl py-3 pl-4 pr-12 text-sm outline-none focus:ring-2 focus:ring-[#00652c]/30 shadow-inner"
-              />
-              <button
-                onClick={handleSend}
-                disabled={isLoading || !input.trim()}
-                className="absolute right-2 top-1.5 w-9 h-9 bg-[#00652c] text-white rounded-full flex items-center justify-center hover:bg-[#005323] transition-colors active:scale-95 disabled:opacity-40"
-              >
-                {isLoading ? <InlineSpinner className="w-4 h-4" /> : <Send className="w-4 h-4" />}
-              </button>
-            </div>
-          </div>
+          <ChatMessagesView
+            messages={messages}
+            feedbackUpdatingId={feedbackUpdatingId}
+            messagesContainerRef={messagesContainerRef}
+            messagesEndRef={messagesEndRef}
+            onVideoNavigate={navigateToVideo}
+            onFeedback={handleFeedbackWithSync}
+          />
+          <ChatComposer
+            input={input}
+            isLoading={isLoading}
+            onInputChange={setInput}
+            onKeyDown={handleKeyPress}
+            onSend={handleSend}
+          />
         </>
       )}
     </div>

--- a/frontend/src/components/chat/MessageBody.tsx
+++ b/frontend/src/components/chat/MessageBody.tsx
@@ -1,0 +1,82 @@
+import { Fragment } from 'react';
+import type { Citation } from '@/lib/api';
+
+interface MessageBodyProps {
+  content: string;
+  citations?: Citation[];
+  onVideoNavigate: (videoId: number, startTime: string) => void;
+}
+
+function formatInlineTime(time: string | undefined) {
+  if (!time) return '';
+  const main = time.split(',')[0];
+  return main.replace(/^00:/, '').replace(/^0(\d:)/, '$1');
+}
+
+function formatTimeRange(startTime: string | undefined, endTime: string | undefined) {
+  const start = formatInlineTime(startTime);
+  const end = formatInlineTime(endTime);
+  if (start && end) return `${start}-${end}`;
+  return start || end;
+}
+
+export function MessageBody({ content, citations, onVideoNavigate }: MessageBodyProps) {
+  const tagPattern = /\[(\d+)\]/g;
+  const nodes: Array<
+    | { type: 'text'; value: string }
+    | { type: 'ref'; id: number }
+  > = [];
+  let lastIndex = 0;
+
+  for (const match of content.matchAll(tagPattern)) {
+    const id = Number(match[1]);
+    const start = match.index ?? 0;
+
+    if (start > lastIndex) {
+      nodes.push({ type: 'text', value: content.slice(lastIndex, start) });
+    }
+
+    nodes.push({ type: 'ref', id });
+    lastIndex = start + match[0].length;
+  }
+
+  if (lastIndex < content.length) {
+    nodes.push({ type: 'text', value: content.slice(lastIndex) });
+  }
+
+  const normalizedNodes = nodes.length > 0 ? nodes : [{ type: 'text' as const, value: content }];
+  const citationMap = new Map((citations ?? []).map((citation) => [citation.id, citation]));
+
+  return (
+    <div className="text-[#3f493f] leading-relaxed whitespace-pre-wrap">
+      {normalizedNodes.map((node, i) => {
+        if (node.type === 'text') {
+          return <Fragment key={`text-${i}`}>{node.value}</Fragment>;
+        }
+
+        const video = citationMap.get(node.id);
+        if (!video) {
+          return <Fragment key={`ref-${i}`}>[{node.id}]</Fragment>;
+        }
+
+        const primaryRange = formatTimeRange(video.start_time, video.end_time);
+
+        return (
+          <Fragment key={`${video.video_id}-${video.start_time}-${i}`}>
+            {primaryRange && (
+              <button
+                type="button"
+                onClick={() => onVideoNavigate(video.video_id, video.start_time)}
+                className="inline text-left text-[#00652c] underline decoration-[#00652c]/35 underline-offset-3 hover:text-[#00461e] hover:decoration-[#00461e] transition-colors"
+                title={`${video.title} ${video.start_time}`}
+                aria-label={`${video.title} ${video.start_time}`}
+              >
+                {` (${primaryRange})`}
+              </button>
+            )}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/hooks/__tests__/useChatMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useChatMessages.test.ts
@@ -224,4 +224,60 @@ describe('useChatMessages streaming', () => {
       )
     })
   })
+
+  it('guards against rapid consecutive sends before loading state rerenders', async () => {
+    const resolvers: Array<() => void> = []
+    ;(apiClient.chatStream as any).mockImplementation(async function* () {
+      await new Promise<void>((resolve) => resolvers.push(resolve))
+      yield { type: 'done' as const, chat_log_id: null, feedback: null }
+    })
+
+    const { result } = renderHook(() => useChatMessages({}))
+
+    act(() => { result.current.setInput('Hi') })
+
+    await waitFor(() => {
+      expect(result.current.input).toBe('Hi')
+    })
+
+    act(() => {
+      void result.current.handleSend()
+      void result.current.handleSend()
+    })
+
+    await waitFor(() => {
+      expect(apiClient.chatStream).toHaveBeenCalledTimes(1)
+    })
+
+    act(() => {
+      resolvers[0]?.()
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
+
+  it('toggles feedback back to null when the same feedback is selected', async () => {
+    ;(apiClient.setChatFeedback as any).mockResolvedValue({
+      chat_log_id: 42,
+      feedback: null,
+    })
+
+    const { result } = renderHook(() => useChatMessages({ shareToken: 'shared' }))
+
+    act(() => {
+      result.current.setMessages([
+        { role: 'assistant', content: 'Answer', chatLogId: 42, feedback: 'good' },
+      ])
+    })
+
+    await act(async () => {
+      await result.current.handleFeedback(42, 'good')
+    })
+
+    expect(apiClient.setChatFeedback).toHaveBeenCalledWith(42, null, 'shared')
+    expect(result.current.messages[0].feedback).toBeNull()
+    expect(result.current.feedbackUpdatingId).toBeNull()
+  })
 })

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -1,18 +1,25 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { flushSync } from 'react-dom';
 import { useMutation } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { apiClient, ApiError, type Citation } from '@/lib/api';
-
-const STREAM_RENDER_TICK_MS = 24;
-const STREAM_RENDER_CHARS_PER_TICK = 3;
+import {
+  ChatStreamController,
+  type ChatStreamDoneEvent,
+  type ChatStreamErrorEvent,
+} from '@/lib/chatStreamController';
+import {
+  applyChatFeedback,
+  getNextChatFeedback,
+  type ChatFeedbackValue,
+} from '@/lib/chatFeedback';
 
 export interface Message {
   role: 'user' | 'assistant';
   content: string;
   citations?: Citation[];
   chatLogId?: number;
-  feedback?: 'good' | 'bad' | null;
+  feedback?: ChatFeedbackValue;
 }
 
 interface UseChatMessagesOptions {
@@ -31,11 +38,12 @@ interface UseChatMessagesReturn {
   messagesContainerRef: React.RefObject<HTMLDivElement | null>;
   handleSend: () => Promise<void>;
   handleKeyPress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-  handleFeedback: (chatLogId: number, value: 'good' | 'bad') => Promise<void>;
+  handleFeedback: (chatLogId: number, value: 'good' | 'bad') => Promise<ChatFeedbackValue | undefined>;
 }
 
 export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions): UseChatMessagesReturn {
   const { t } = useTranslation();
+  const tRef = useRef(t);
   const [messages, setMessages] = useState<Message[]>(() => [
     { role: 'assistant', content: t('chat.assistantGreeting') },
   ]);
@@ -44,21 +52,31 @@ export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions)
   const [feedbackUpdatingId, setFeedbackUpdatingId] = useState<number | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
-  const pendingContentRef = useRef('');
-  const pendingDoneEventRef = useRef<Extract<Awaited<ReturnType<typeof apiClient.chatStream>> extends AsyncGenerator<infer T> ? T : never, { type: 'done' }> | null>(null);
-  const drainTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const streamFinishedRef = useRef(false);
-  const drainWaitersRef = useRef<Array<() => void>>([]);
+  const sendInFlightRef = useRef(false);
 
-  const stopDrainTimer = useCallback(() => {
-    if (drainTimerRef.current !== null) {
-      clearInterval(drainTimerRef.current);
-      drainTimerRef.current = null;
-    }
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
+
+  const appendAssistantContent = useCallback((text: string) => {
+    setMessages((prev) => {
+      if (prev.length === 0) {
+        return [{ role: 'assistant', content: text }];
+      }
+
+      const updated = [...prev];
+      const last = updated[updated.length - 1];
+      updated[updated.length - 1] = { ...last, content: last.content + text };
+      return updated;
+    });
   }, []);
 
-  const applyDoneMetadata = useCallback((event: NonNullable<typeof pendingDoneEventRef.current>) => {
+  const applyDoneMetadata = useCallback((event: ChatStreamDoneEvent) => {
     setMessages((prev) => {
+      if (prev.length === 0) {
+        return prev;
+      }
+
       const updated = [...prev];
       updated[updated.length - 1] = {
         ...updated[updated.length - 1],
@@ -70,62 +88,36 @@ export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions)
     });
   }, []);
 
-  const flushDrainWaiters = useCallback(() => {
-    const waiters = drainWaitersRef.current.splice(0);
-    waiters.forEach((resolve) => resolve());
+  const replaceLastAssistantMessage = useCallback((content: string) => {
+    setMessages((prev) => {
+      if (prev.length === 0) {
+        return [{ role: 'assistant', content }];
+      }
+
+      const updated = [...prev];
+      updated[updated.length - 1] = { role: 'assistant', content };
+      return updated;
+    });
   }, []);
 
-  const tryFinalizeDrain = useCallback(() => {
-    if (pendingContentRef.current !== '' || !streamFinishedRef.current) {
-      return;
-    }
-    stopDrainTimer();
-    if (pendingDoneEventRef.current) {
-      applyDoneMetadata(pendingDoneEventRef.current);
-      pendingDoneEventRef.current = null;
-    }
-    flushDrainWaiters();
-  }, [applyDoneMetadata, flushDrainWaiters, stopDrainTimer]);
+  const handleStreamError = useCallback((event: ChatStreamErrorEvent) => {
+    const errorMessage =
+      event.code === 'OVER_QUOTA'
+        ? tRef.current('chat.errorOverQuota')
+        : tRef.current('chat.error');
+    replaceLastAssistantMessage(errorMessage);
+  }, [replaceLastAssistantMessage]);
 
-  const drainNextSlice = useCallback(() => {
-    if (pendingContentRef.current === '') {
-      tryFinalizeDrain();
-      return;
-    }
-
-    const nextText = pendingContentRef.current.slice(0, STREAM_RENDER_CHARS_PER_TICK);
-    pendingContentRef.current = pendingContentRef.current.slice(STREAM_RENDER_CHARS_PER_TICK);
-
-    flushSync(() => {
-      setMessages((prev) => {
-        const updated = [...prev];
-        const last = updated[updated.length - 1];
-        updated[updated.length - 1] = { ...last, content: last.content + nextText };
-        return updated;
-      });
-    });
-
-    tryFinalizeDrain();
-  }, [tryFinalizeDrain]);
-
-  const ensureDrainTimer = useCallback(() => {
-    if (drainTimerRef.current !== null) {
-      return;
-    }
-    drainTimerRef.current = setInterval(() => {
-      drainNextSlice();
-    }, STREAM_RENDER_TICK_MS);
-  }, [drainNextSlice]);
-
-  const waitForDrainCompletion = useCallback(async () => {
-    if (pendingContentRef.current === '' && streamFinishedRef.current) {
-      tryFinalizeDrain();
-      return;
-    }
-    await new Promise<void>((resolve) => {
-      drainWaitersRef.current.push(resolve);
-    });
-  }, [tryFinalizeDrain]);
+  const streamController = useMemo(
+    () =>
+      new ChatStreamController({
+        flush: flushSync,
+        onAppendContent: appendAssistantContent,
+        onDone: applyDoneMetadata,
+        onError: handleStreamError,
+      }),
+    [appendAssistantContent, applyDoneMetadata, handleStreamError],
+  );
 
   // Auto-scroll on new messages
   useEffect(() => {
@@ -134,19 +126,23 @@ export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions)
     }
   }, [messages]);
 
+  useEffect(() => {
+    return () => {
+      streamController.dispose();
+    };
+  }, [streamController]);
+
   const feedbackMutation = useMutation({
-    mutationFn: async ({ chatLogId, nextFeedback }: { chatLogId: number; nextFeedback: 'good' | 'bad' | null }) =>
+    mutationFn: async ({ chatLogId, nextFeedback }: { chatLogId: number; nextFeedback: ChatFeedbackValue }) =>
       await apiClient.setChatFeedback(chatLogId, nextFeedback, shareToken),
   });
 
   const handleSend = useCallback(async () => {
-    if (!input.trim() || isLoading) return;
+    if (!input.trim() || sendInFlightRef.current) return;
 
     const userMessage: Message = { role: 'user', content: input };
-    pendingContentRef.current = '';
-    pendingDoneEventRef.current = null;
-    streamFinishedRef.current = false;
-    stopDrainTimer();
+    sendInFlightRef.current = true;
+    streamController.start();
     setMessages((prev) => [...prev, userMessage, { role: 'assistant', content: '' }]);
     setInput('');
     setIsLoading(true);
@@ -157,63 +153,30 @@ export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions)
         ...(groupId ? { group_id: groupId } : {}),
         ...(shareToken ? { share_slug: shareToken } : {}),
       })) {
-        if (event.type === 'content_chunk') {
-          pendingContentRef.current += event.text;
-          ensureDrainTimer();
-        } else if (event.type === 'done') {
-          pendingDoneEventRef.current = event;
-          streamFinishedRef.current = true;
-          tryFinalizeDrain();
-        } else if (event.type === 'error') {
-          pendingContentRef.current = '';
-          pendingDoneEventRef.current = null;
-          streamFinishedRef.current = true;
-          stopDrainTimer();
-          flushDrainWaiters();
-          const errorMessage =
-            event.code === 'OVER_QUOTA'
-              ? t('chat.errorOverQuota')
-              : t('chat.error');
-          setMessages((prev) => {
-            const updated = [...prev];
-            updated[updated.length - 1] = { role: 'assistant', content: errorMessage };
-            return updated;
-          });
+        streamController.handleEvent(event);
+        if (event.type === 'error') {
+          return;
         }
       }
-      streamFinishedRef.current = true;
-      await waitForDrainCompletion();
+      await streamController.complete();
     } catch (error) {
-      pendingContentRef.current = '';
-      pendingDoneEventRef.current = null;
-      streamFinishedRef.current = true;
-      stopDrainTimer();
-      flushDrainWaiters();
+      streamController.abort();
       console.error('Chat error:', error);
       const errorMessage =
         error instanceof ApiError && error.code === 'OVER_QUOTA'
-          ? t('chat.errorOverQuota')
-          : t('chat.error');
-      setMessages((prev) => {
-        const updated = [...prev];
-        updated[updated.length - 1] = { role: 'assistant', content: errorMessage };
-        return updated;
-      });
+          ? tRef.current('chat.errorOverQuota')
+          : tRef.current('chat.error');
+      replaceLastAssistantMessage(errorMessage);
     } finally {
+      sendInFlightRef.current = false;
       setIsLoading(false);
     }
   }, [
-    applyDoneMetadata,
-    ensureDrainTimer,
-    flushDrainWaiters,
     groupId,
     input,
-    isLoading,
+    replaceLastAssistantMessage,
     shareToken,
-    stopDrainTimer,
-    t,
-    tryFinalizeDrain,
-    waitForDrainCompletion,
+    streamController,
   ]);
 
   const handleKeyPress = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -226,34 +189,24 @@ export function useChatMessages({ groupId, shareToken }: UseChatMessagesOptions)
 
   const handleFeedback = useCallback(async (chatLogId: number, value: 'good' | 'bad') => {
     const targetMessage = messages.find((message) => message.chatLogId === chatLogId);
-    if (!targetMessage) return;
+    if (!targetMessage) return undefined;
 
-    const nextFeedback = targetMessage.feedback === value ? null : value;
+    const nextFeedback = getNextChatFeedback(targetMessage.feedback, value);
 
     setFeedbackUpdatingId(chatLogId);
     try {
       const result = await feedbackMutation.mutateAsync({ chatLogId, nextFeedback });
       const normalizedFeedback = result.feedback ?? null;
 
-      setMessages((prev) =>
-        prev.map((message) =>
-          message.chatLogId === chatLogId
-            ? { ...message, feedback: normalizedFeedback }
-            : message,
-        ),
-      );
+      setMessages((prev) => applyChatFeedback(prev, chatLogId, normalizedFeedback));
+      return normalizedFeedback;
     } catch (error) {
       console.error('Failed to update feedback', error);
+      return undefined;
     } finally {
       setFeedbackUpdatingId(null);
     }
   }, [messages, feedbackMutation]);
-
-  useEffect(() => {
-    return () => {
-      stopDrainTimer();
-    };
-  }, [stopDrainTimer]);
 
   return {
     messages,

--- a/frontend/src/lib/__tests__/chatStreamController.test.ts
+++ b/frontend/src/lib/__tests__/chatStreamController.test.ts
@@ -1,0 +1,185 @@
+import {
+  ChatStreamController,
+  chatStreamReducer,
+  createInitialChatStreamState,
+} from '@/lib/chatStreamController'
+import type { ChatStreamEvent, Citation } from '@/lib/api'
+
+const citation: Citation = {
+  id: 1,
+  video_id: 10,
+  title: 'Video',
+  start_time: '00:00:05',
+  end_time: '00:00:10',
+}
+
+describe('chatStreamReducer', () => {
+  it('queues content chunks and keeps done metadata pending until the queue is drained', () => {
+    let state = createInitialChatStreamState()
+
+    state = chatStreamReducer(state, {
+      type: 'stream_event',
+      event: { type: 'content_chunk', text: 'Hello ' },
+    })
+    state = chatStreamReducer(state, {
+      type: 'stream_event',
+      event: { type: 'content_chunk', text: 'World' },
+    })
+    state = chatStreamReducer(state, {
+      type: 'stream_event',
+      event: {
+        type: 'done',
+        chat_log_id: 99,
+        feedback: 'good',
+        citations: [citation],
+      },
+    })
+
+    expect(state.queuedContent).toBe('Hello World')
+    expect(state.streamFinished).toBe(true)
+    expect(state.doneEvent).toEqual({
+      type: 'done',
+      chat_log_id: 99,
+      feedback: 'good',
+      citations: [citation],
+    })
+    expect(state.errorEvent).toBeNull()
+  })
+
+  it('clears pending content and metadata when an error event arrives', () => {
+    let state = createInitialChatStreamState()
+
+    state = chatStreamReducer(state, {
+      type: 'stream_event',
+      event: { type: 'content_chunk', text: 'Partial answer' },
+    })
+    state = chatStreamReducer(state, {
+      type: 'stream_event',
+      event: {
+        type: 'done',
+        chat_log_id: 1,
+        feedback: null,
+      },
+    })
+    state = chatStreamReducer(state, {
+      type: 'stream_event',
+      event: {
+        type: 'error',
+        code: 'LLM_PROVIDER_ERROR',
+        message: 'failed',
+      },
+    })
+
+    expect(state.queuedContent).toBe('')
+    expect(state.doneEvent).toBeNull()
+    expect(state.streamFinished).toBe(true)
+    expect(state.errorEvent).toEqual({
+      type: 'error',
+      code: 'LLM_PROVIDER_ERROR',
+      message: 'failed',
+    })
+  })
+})
+
+describe('ChatStreamController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('drains content over render ticks and applies done metadata only after draining', async () => {
+    const rendered: string[] = []
+    const doneEvents: ChatStreamEvent[] = []
+    const controller = new ChatStreamController({
+      onAppendContent: (text) => rendered.push(text),
+      onDone: (event) => doneEvents.push(event),
+      onError: vi.fn(),
+    })
+
+    controller.start()
+    controller.handleEvent({ type: 'content_chunk', text: 'ABCDEF' })
+    controller.handleEvent({
+      type: 'done',
+      chat_log_id: 42,
+      feedback: 'bad',
+      citations: [citation],
+    })
+
+    const completion = controller.complete()
+
+    expect(rendered).toEqual([])
+    expect(doneEvents).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(24)
+    expect(rendered).toEqual(['ABC'])
+    expect(doneEvents).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(24)
+    await completion
+
+    expect(rendered).toEqual(['ABC', 'DEF'])
+    expect(doneEvents).toEqual([
+      {
+        type: 'done',
+        chat_log_id: 42,
+        feedback: 'bad',
+        citations: [citation],
+      },
+    ])
+    expect(controller.getSnapshot().timerActive).toBe(false)
+  })
+
+  it('stops draining and resolves waiters when an error event arrives', async () => {
+    const rendered: string[] = []
+    const onError = vi.fn()
+    const controller = new ChatStreamController({
+      onAppendContent: (text) => rendered.push(text),
+      onDone: vi.fn(),
+      onError,
+    })
+
+    controller.start()
+    controller.handleEvent({ type: 'content_chunk', text: 'ABCDEF' })
+    const completion = controller.waitForDrainCompletion()
+    controller.handleEvent({
+      type: 'error',
+      code: 'OVER_QUOTA',
+      message: 'quota exceeded',
+    })
+
+    await completion
+    await vi.advanceTimersByTimeAsync(48)
+
+    expect(rendered).toEqual([])
+    expect(onError).toHaveBeenCalledWith({
+      type: 'error',
+      code: 'OVER_QUOTA',
+      message: 'quota exceeded',
+    })
+    expect(controller.getSnapshot().timerActive).toBe(false)
+    expect(controller.getSnapshot().queuedContent).toBe('')
+  })
+
+  it('cleans up the drain timer on dispose', async () => {
+    const rendered: string[] = []
+    const controller = new ChatStreamController({
+      onAppendContent: (text) => rendered.push(text),
+      onDone: vi.fn(),
+      onError: vi.fn(),
+    })
+
+    controller.start()
+    controller.handleEvent({ type: 'content_chunk', text: 'ABCDEF' })
+
+    expect(controller.getSnapshot().timerActive).toBe(true)
+
+    controller.dispose()
+    await vi.advanceTimersByTimeAsync(48)
+
+    expect(rendered).toEqual([])
+    expect(controller.getSnapshot().timerActive).toBe(false)
+  })
+})

--- a/frontend/src/lib/chatFeedback.ts
+++ b/frontend/src/lib/chatFeedback.ts
@@ -1,0 +1,25 @@
+export type ChatFeedbackValue = 'good' | 'bad' | null;
+
+interface FeedbackMessage {
+  chatLogId?: number;
+  feedback?: ChatFeedbackValue;
+}
+
+export function getNextChatFeedback(
+  currentFeedback: ChatFeedbackValue | undefined,
+  selectedFeedback: Exclude<ChatFeedbackValue, null>,
+): ChatFeedbackValue {
+  return currentFeedback === selectedFeedback ? null : selectedFeedback;
+}
+
+export function applyChatFeedback<T extends FeedbackMessage>(
+  messages: T[],
+  chatLogId: number,
+  feedback: ChatFeedbackValue,
+): T[] {
+  return messages.map((message) =>
+    message.chatLogId === chatLogId
+      ? { ...message, feedback }
+      : message,
+  );
+}

--- a/frontend/src/lib/chatStreamController.ts
+++ b/frontend/src/lib/chatStreamController.ts
@@ -1,0 +1,250 @@
+import type { ChatStreamEvent } from '@/lib/api';
+
+export const CHAT_STREAM_RENDER_TICK_MS = 24;
+export const CHAT_STREAM_RENDER_CHARS_PER_TICK = 3;
+
+export type ChatStreamDoneEvent = Extract<ChatStreamEvent, { type: 'done' }>;
+export type ChatStreamErrorEvent = Extract<ChatStreamEvent, { type: 'error' }>;
+
+export interface ChatStreamState {
+  queuedContent: string;
+  doneEvent: ChatStreamDoneEvent | null;
+  errorEvent: ChatStreamErrorEvent | null;
+  streamFinished: boolean;
+}
+
+export type ChatStreamAction =
+  | { type: 'stream_started' }
+  | { type: 'stream_event'; event: ChatStreamEvent }
+  | { type: 'stream_finished' }
+  | { type: 'content_drained'; charCount: number }
+  | { type: 'done_applied' }
+  | { type: 'stream_aborted' };
+
+type TimerId = ReturnType<typeof setInterval>;
+
+interface ChatStreamControllerOptions {
+  charsPerTick?: number;
+  tickMs?: number;
+  flush?: (callback: () => void) => void;
+  onAppendContent: (text: string) => void;
+  onDone: (event: ChatStreamDoneEvent) => void;
+  onError: (event: ChatStreamErrorEvent) => void;
+}
+
+export function createInitialChatStreamState(): ChatStreamState {
+  return {
+    queuedContent: '',
+    doneEvent: null,
+    errorEvent: null,
+    streamFinished: false,
+  };
+}
+
+export function chatStreamReducer(
+  state: ChatStreamState,
+  action: ChatStreamAction,
+): ChatStreamState {
+  switch (action.type) {
+    case 'stream_started':
+      return createInitialChatStreamState();
+    case 'stream_event':
+      if (action.event.type === 'content_chunk') {
+        return {
+          ...state,
+          queuedContent: state.queuedContent + action.event.text,
+        };
+      }
+      if (action.event.type === 'done') {
+        return {
+          ...state,
+          doneEvent: action.event,
+          errorEvent: null,
+          streamFinished: true,
+        };
+      }
+      return {
+        ...state,
+        queuedContent: '',
+        doneEvent: null,
+        errorEvent: action.event,
+        streamFinished: true,
+      };
+    case 'stream_finished':
+      return {
+        ...state,
+        streamFinished: true,
+      };
+    case 'content_drained':
+      return {
+        ...state,
+        queuedContent: state.queuedContent.slice(action.charCount),
+      };
+    case 'done_applied':
+      return {
+        ...state,
+        doneEvent: null,
+      };
+    case 'stream_aborted':
+      return {
+        ...createInitialChatStreamState(),
+        streamFinished: true,
+      };
+    default:
+      return state;
+  }
+}
+
+export class ChatStreamController {
+  private state = createInitialChatStreamState();
+  private drainTimer: TimerId | null = null;
+  private readonly charsPerTick: number;
+  private readonly tickMs: number;
+  private readonly flush: (callback: () => void) => void;
+  private readonly onAppendContent: (text: string) => void;
+  private readonly onDone: (event: ChatStreamDoneEvent) => void;
+  private readonly onError: (event: ChatStreamErrorEvent) => void;
+  private waiters: Array<() => void> = [];
+
+  constructor({
+    charsPerTick = CHAT_STREAM_RENDER_CHARS_PER_TICK,
+    tickMs = CHAT_STREAM_RENDER_TICK_MS,
+    flush = (callback) => callback(),
+    onAppendContent,
+    onDone,
+    onError,
+  }: ChatStreamControllerOptions) {
+    this.charsPerTick = charsPerTick;
+    this.tickMs = tickMs;
+    this.flush = flush;
+    this.onAppendContent = onAppendContent;
+    this.onDone = onDone;
+    this.onError = onError;
+  }
+
+  start() {
+    this.stopDrainTimer();
+    this.flushDrainWaiters();
+    this.state = chatStreamReducer(this.state, { type: 'stream_started' });
+  }
+
+  handleEvent(event: ChatStreamEvent) {
+    this.state = chatStreamReducer(this.state, { type: 'stream_event', event });
+
+    if (event.type === 'content_chunk') {
+      if (event.text !== '') {
+        this.ensureDrainTimer();
+      }
+      return;
+    }
+
+    if (event.type === 'done') {
+      this.tryFinalizeDrain();
+      return;
+    }
+
+    this.stopDrainTimer();
+    this.flushDrainWaiters();
+    this.onError(event);
+  }
+
+  async complete() {
+    this.state = chatStreamReducer(this.state, { type: 'stream_finished' });
+    await this.waitForDrainCompletion();
+  }
+
+  async waitForDrainCompletion() {
+    if (this.canFinalize()) {
+      this.tryFinalizeDrain();
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  abort() {
+    this.stopDrainTimer();
+    this.state = chatStreamReducer(this.state, { type: 'stream_aborted' });
+    this.flushDrainWaiters();
+  }
+
+  dispose() {
+    this.abort();
+    this.state = createInitialChatStreamState();
+  }
+
+  getSnapshot() {
+    return {
+      ...this.state,
+      timerActive: this.drainTimer !== null,
+    };
+  }
+
+  private drainNextSlice() {
+    if (this.state.queuedContent === '') {
+      this.tryFinalizeDrain();
+      return;
+    }
+
+    const nextText = this.state.queuedContent.slice(0, this.charsPerTick);
+    this.state = chatStreamReducer(this.state, {
+      type: 'content_drained',
+      charCount: this.charsPerTick,
+    });
+
+    this.flush(() => {
+      this.onAppendContent(nextText);
+    });
+    this.tryFinalizeDrain();
+  }
+
+  private ensureDrainTimer() {
+    if (this.drainTimer !== null) {
+      return;
+    }
+
+    this.drainTimer = setInterval(() => {
+      this.drainNextSlice();
+    }, this.tickMs);
+  }
+
+  private tryFinalizeDrain() {
+    if (this.state.queuedContent !== '') {
+      return;
+    }
+
+    this.stopDrainTimer();
+
+    if (!this.state.streamFinished) {
+      return;
+    }
+
+    const doneEvent = this.state.doneEvent;
+    if (doneEvent) {
+      this.state = chatStreamReducer(this.state, { type: 'done_applied' });
+      this.onDone(doneEvent);
+    }
+
+    this.flushDrainWaiters();
+  }
+
+  private canFinalize() {
+    return this.state.queuedContent === '' && this.state.streamFinished;
+  }
+
+  private stopDrainTimer() {
+    if (this.drainTimer === null) {
+      return;
+    }
+
+    clearInterval(this.drainTimer);
+    this.drainTimer = null;
+  }
+
+  private flushDrainWaiters() {
+    const waiters = this.waiters.splice(0);
+    waiters.forEach((resolve) => resolve());
+  }
+}


### PR DESCRIPTION
## Summary

- `chatStreamController.ts` を新規作成し、ストリーミング状態管理を `chatStreamReducer`（純粋関数）と `ChatStreamController`（副作用・タイマー管理）に分離
- `chatFeedback.ts` を新規作成し、フィードバック状態管理ロジックを `useChatMessages` から切り出し
- `ChatPanel.tsx` を `ChatComposer`・`ChatHistoryView`・`ChatMessageBubble`・`ChatMessagesView`・`MessageBody` の各コンポーネントに分割
- `useChatMessages.ts` から低レベルなタイマー操作・`ref` 管理を排除し、`ChatStreamController` に委譲することでフックをシンプル化
- `chatStreamController.test.ts`・`useChatMessages.test.ts` を追加

## Test plan

- [ ] チャットでメッセージ送信し、ストリーミング応答が正常に描画されること
- [ ] フィードバック（good/bad）が正しく切り替わること
- [ ] ストリーミング中に中断しても状態がリセットされること
- [ ] `npm test` でユニットテストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)