### PR TITLE
VideoDetail / VideoGroupDetailを責務分割

### DIFF
--- a/frontend/src/components/video/detail/VideoDetailView.tsx
+++ b/frontend/src/components/video/detail/VideoDetailView.tsx
@@ -1,0 +1,718 @@
+import type { Dispatch, RefObject, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  AlignLeft,
+  ArrowLeft,
+  Calendar,
+  CheckCircle,
+  Pencil,
+  Play,
+  Save,
+  Search,
+  Trash2,
+  Video as VideoIcon,
+  X,
+} from 'lucide-react';
+import { Link, useLocale } from '@/lib/i18n';
+import { apiClient, type Tag, type Video } from '@/lib/api';
+import { buildYoutubeEmbedSrc } from '@/lib/video/embed';
+import { formatDate } from '@/lib/utils/video';
+import type { TranscriptSegment } from '@/lib/transcript/srt';
+import { AppNav } from '@/components/layout/AppNav';
+import { InlineSpinner } from '@/components/common/InlineSpinner';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { TagCreateDialog } from '@/components/video/TagCreateDialog';
+import { TagSelector } from '@/components/video/TagSelector';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+type MobileTab = 'transcript' | 'video';
+
+interface VideoDetailViewProps {
+  video: Video | null;
+  isLoading: boolean;
+  error: string | null;
+  videoRef: RefObject<HTMLVideoElement | null>;
+  youtubeStartSeconds: number | null;
+  onVideoLoaded: () => void;
+  isMobile: boolean;
+  mobileTab: MobileTab;
+  onMobileTabChange: (tab: MobileTab) => void;
+  tags: Tag[];
+  isCreateDialogOpen: boolean;
+  onCreateDialogOpenChange: (open: boolean) => void;
+  onCreateTag: (name: string, color: string) => Promise<void> | void;
+  isEditing: boolean;
+  editedTitle: string;
+  editedDescription: string;
+  editedTagIds: number[];
+  onEditedTitleChange: (title: string) => void;
+  onEditedDescriptionChange: (description: string) => void;
+  onEditedTagIdsChange: Dispatch<SetStateAction<number[]>>;
+  onStartEditing: () => void;
+  onCancelEdit: () => void;
+  onUpdateVideo: () => void;
+  isUpdating: boolean;
+  updateError: string | null;
+  deleteError: string | null;
+  isDeleting: boolean;
+  onDeleteVideo: () => void;
+  transcriptSearch: string;
+  onTranscriptSearchChange: (value: string) => void;
+  isTranscriptEditing: boolean;
+  onStartTranscriptEditing: () => void;
+  onCancelTranscriptEditing: () => void;
+  editedTranscript: string;
+  onEditedTranscriptChange: (value: string) => void;
+  onSaveTranscript: () => void;
+  isTranscriptSaving: boolean;
+  transcriptSaveError: string | null;
+  filteredSegments: TranscriptSegment[];
+  activeSegmentIdx: number | null;
+  onSeek: (seconds: number, idx: number) => void;
+  isPlainTextTranscript: boolean;
+}
+
+function getStatusClassName(status: Video['status']): string {
+  switch (status) {
+    case 'completed':
+      return 'bg-[#d3ffd5] text-[#006d30]';
+    case 'error':
+      return 'bg-red-100 text-red-700';
+    case 'indexing':
+    case 'processing':
+      return 'bg-[#ffdcc3] text-[#2f1500]';
+    default:
+      return 'bg-gray-100 text-gray-500';
+  }
+}
+
+function VideoDetailEditDialog({
+  isOpen,
+  tags,
+  editedTitle,
+  editedDescription,
+  editedTagIds,
+  isUpdating,
+  updateError,
+  onOpenChange,
+  onEditedTitleChange,
+  onEditedDescriptionChange,
+  onEditedTagIdsChange,
+  onCreateNewTag,
+  onSave,
+}: {
+  isOpen: boolean;
+  tags: Tag[];
+  editedTitle: string;
+  editedDescription: string;
+  editedTagIds: number[];
+  isUpdating: boolean;
+  updateError: string | null;
+  onOpenChange: (open: boolean) => void;
+  onEditedTitleChange: (title: string) => void;
+  onEditedDescriptionChange: (description: string) => void;
+  onEditedTagIdsChange: Dispatch<SetStateAction<number[]>>;
+  onCreateNewTag: () => void;
+  onSave: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('videos.detail.editButton')}</DialogTitle>
+          <DialogDescription>
+            {t('videos.detail.editDescriptionLabel')}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          {updateError && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">{updateError}</div>
+          )}
+          <div className="space-y-1">
+            <label className="text-xs font-bold text-[#3f493f]">{t('videos.detail.editTitleLabel')}</label>
+            <input
+              type="text"
+              value={editedTitle}
+              onChange={(event) => onEditedTitleChange(event.target.value)}
+              disabled={isUpdating}
+              className="w-full px-3 py-2.5 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-bold text-[#3f493f]">{t('videos.detail.editDescriptionLabel')}</label>
+            <textarea
+              value={editedDescription}
+              onChange={(event) => onEditedDescriptionChange(event.target.value)}
+              disabled={isUpdating}
+              rows={4}
+              className="w-full px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all resize-none"
+            />
+          </div>
+          <div className="space-y-1">
+            <TagSelector
+              tags={tags}
+              selectedTagIds={editedTagIds}
+              onToggle={(tagId) =>
+                onEditedTagIdsChange((prev) =>
+                  prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId],
+                )
+              }
+              onCreateNew={onCreateNewTag}
+              disabled={isUpdating}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <button
+            onClick={() => onOpenChange(false)}
+            disabled={isUpdating}
+            className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] rounded-xl text-sm font-bold hover:bg-[#f2f4ef] transition-colors disabled:opacity-50"
+          >
+            <X className="w-3.5 h-3.5" />
+            {t('common.actions.cancel')}
+          </button>
+          <button
+            onClick={onSave}
+            disabled={isUpdating || !editedTitle.trim()}
+            className="flex items-center gap-1.5 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
+          >
+            {isUpdating ? <InlineSpinner className="w-3.5 h-3.5" /> : <Save className="w-3.5 h-3.5" />}
+            {isUpdating ? t('common.actions.saving') : t('common.actions.save')}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function VideoDetailMobileTabs({
+  activeTab,
+  onChange,
+}: {
+  activeTab: MobileTab;
+  onChange: (tab: MobileTab) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mt-16 flex border-b border-stone-200 bg-white shrink-0">
+      <button
+        onClick={() => onChange('video')}
+        className={`flex-1 flex items-center justify-center gap-2 py-3 text-sm font-semibold transition-colors ${
+          activeTab === 'video'
+            ? 'text-[#00652c] border-b-2 border-[#00652c]'
+            : 'text-stone-500 hover:text-stone-700'
+        }`}
+      >
+        <Play className="w-4 h-4" />
+        {t('videos.detail.video')}
+      </button>
+      <button
+        onClick={() => onChange('transcript')}
+        className={`flex-1 flex items-center justify-center gap-2 py-3 text-sm font-semibold transition-colors ${
+          activeTab === 'transcript'
+            ? 'text-[#00652c] border-b-2 border-[#00652c]'
+            : 'text-stone-500 hover:text-stone-700'
+        }`}
+      >
+        <AlignLeft className="w-4 h-4" />
+        {t('videos.detail.transcriptSection')}
+      </button>
+    </div>
+  );
+}
+
+function VideoPlayerPanel({
+  video,
+  videoRef,
+  youtubeStartSeconds,
+  onVideoLoaded,
+}: {
+  video: Video;
+  videoRef: RefObject<HTMLVideoElement | null>;
+  youtubeStartSeconds: number | null;
+  onVideoLoaded: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="w-full aspect-video bg-[#1a1c1c] rounded-xl overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
+      {video.source_type === 'youtube' && video.youtube_embed_url ? (
+        <iframe
+          key={`${video.id}-${youtubeStartSeconds ?? 0}`}
+          className="w-full h-full"
+          src={buildYoutubeEmbedSrc(video.youtube_embed_url, youtubeStartSeconds)}
+          title={video.title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+      ) : video.file ? (
+        <video
+          ref={videoRef}
+          controls
+          className="w-full h-full object-contain"
+          src={apiClient.getVideoUrl(video.file)}
+          onLoadedMetadata={onVideoLoaded}
+        >
+          {t('common.messages.browserNoVideoSupport')}
+        </video>
+      ) : (
+        <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-gray-500">
+          <VideoIcon className="w-16 h-16 text-gray-600" />
+          <p className="text-sm">{t('common.messages.videoFileMissing')}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VideoMetaPanel({
+  video,
+  deleteError,
+  isDeleting,
+  onEdit,
+  onDelete,
+}: {
+  video: Video;
+  deleteError: string | null;
+  isDeleting: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const statusClassName = getStatusClassName(video.status);
+  const pipelineSteps = [
+    { key: 'upload', label: t('videos.detail.pipeline.upload'), doneStatuses: ['processing', 'indexing', 'completed', 'error'] },
+    { key: 'transcript', label: t('videos.detail.pipeline.transcript'), doneStatuses: ['indexing', 'completed'] },
+    { key: 'aiAnalysis', label: t('videos.detail.pipeline.aiAnalysis'), doneStatuses: ['completed'] },
+  ] as { key: string; label: string; doneStatuses: Video['status'][] }[];
+
+  return (
+    <div className="bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] p-6 flex flex-col gap-4">
+      <div className="flex justify-between items-start gap-4">
+        <div>
+          <h1 className="font-bold text-xl text-[#191c19] leading-tight mb-1">
+            {video.title}
+          </h1>
+          <div className="flex items-center gap-2 text-sm text-[#6f7a6e]">
+            <Calendar className="w-3.5 h-3.5 shrink-0" />
+            <span>{formatDate(video.uploaded_at, 'full', locale)}</span>
+          </div>
+        </div>
+        <span className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-bold ${statusClassName}`}>
+          {video.status === 'completed' && <CheckCircle className="w-3 h-3" />}
+          {t(`common.status.${video.status}`, video.status)}
+        </span>
+      </div>
+
+      {video.tags && video.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {video.tags.map((tag) => (
+            <span
+              key={tag.id}
+              className="px-3 py-1 rounded-full text-[11px] font-bold uppercase"
+              style={{ backgroundColor: `${tag.color}20`, color: tag.color }}
+            >
+              {tag.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="border-t border-[#e1e3de]/50 pt-4 flex items-center gap-3 flex-wrap">
+        <span className="text-xs font-bold text-[#6f7a6e] uppercase tracking-widest shrink-0">
+          {t('videos.detail.statusSection')}
+        </span>
+        {pipelineSteps.map(({ key, label, doneStatuses }, index) => {
+          const done = doneStatuses.includes(video.status);
+          return (
+            <div key={key} className="flex items-center gap-2">
+              {index > 0 && <div className="w-6 h-px bg-[#e1e3de]" />}
+              <div className="flex items-center gap-1.5">
+                <div
+                  className={`w-5 h-5 rounded-full flex items-center justify-center shrink-0 ${
+                    done ? 'bg-[#15803d]' : 'bg-[#e1e3de]'
+                  }`}
+                >
+                  {done ? (
+                    <CheckCircle className="w-3 h-3 text-white" />
+                  ) : (
+                    <div className="w-1.5 h-1.5 rounded-full bg-[#becabc]" />
+                  )}
+                </div>
+                <span className={`text-xs font-semibold ${done ? 'text-[#191c19]' : 'text-[#becabc]'}`}>
+                  {label}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {video.error_message && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-xl">
+          <p className="text-xs text-red-700 leading-relaxed">{video.error_message}</p>
+        </div>
+      )}
+
+      {video.description && (
+        <div className="border-t border-[#e1e3de]/50 pt-4">
+          <p className="text-sm text-[#3f493f] leading-relaxed">{video.description}</p>
+        </div>
+      )}
+
+      {deleteError && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-xl">
+          <p className="text-xs text-red-700 leading-relaxed">{deleteError}</p>
+        </div>
+      )}
+
+      <div className="border-t border-[#e1e3de]/50 pt-4 flex items-center gap-2">
+        <button
+          onClick={onEdit}
+          className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] text-[#3f493f] text-sm font-bold rounded-xl hover:bg-[#f2f4ef] transition-colors"
+        >
+          <Pencil className="w-3.5 h-3.5" />
+          {t('videos.detail.editButton')}
+        </button>
+        <button
+          onClick={onDelete}
+          disabled={isDeleting}
+          className="flex items-center gap-1.5 px-4 py-2 text-red-600 text-sm font-bold rounded-xl hover:bg-red-50 transition-colors disabled:opacity-50"
+        >
+          {isDeleting ? <InlineSpinner className="w-3.5 h-3.5" /> : <Trash2 className="w-3.5 h-3.5" />}
+          {isDeleting ? t('common.actions.deleting') : t('videos.detail.deleteButton')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function TranscriptPanel({
+  video,
+  isMobile,
+  mobileTab,
+  transcriptSearch,
+  onTranscriptSearchChange,
+  isTranscriptEditing,
+  onStartTranscriptEditing,
+  onCancelTranscriptEditing,
+  editedTranscript,
+  onEditedTranscriptChange,
+  onSaveTranscript,
+  isTranscriptSaving,
+  transcriptSaveError,
+  filteredSegments,
+  activeSegmentIdx,
+  onSeek,
+  isPlainTextTranscript,
+}: {
+  video: Video;
+  isMobile: boolean;
+  mobileTab: MobileTab;
+  transcriptSearch: string;
+  onTranscriptSearchChange: (value: string) => void;
+  isTranscriptEditing: boolean;
+  onStartTranscriptEditing: () => void;
+  onCancelTranscriptEditing: () => void;
+  editedTranscript: string;
+  onEditedTranscriptChange: (value: string) => void;
+  onSaveTranscript: () => void;
+  isTranscriptSaving: boolean;
+  transcriptSaveError: string | null;
+  filteredSegments: TranscriptSegment[];
+  activeSegmentIdx: number | null;
+  onSeek: (seconds: number, idx: number) => void;
+  isPlainTextTranscript: boolean;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={`lg:col-span-4 flex flex-col bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] ${
+        isMobile ? 'min-h-[500px]' : 'h-[calc(100vh-64px)] sticky top-16'
+      } ${isMobile && mobileTab !== 'transcript' ? 'hidden' : ''}`}
+    >
+      <div className="p-4 border-b border-stone-100 flex flex-col gap-3 shrink-0">
+        <div className="flex justify-between items-center">
+          <h2 className="font-extrabold text-[#191c19]">{t('videos.detail.transcriptSection')}</h2>
+          {!isTranscriptEditing && (
+            <button
+              type="button"
+              onClick={onStartTranscriptEditing}
+              disabled={!video.transcript}
+              className="inline-flex items-center gap-1.5 rounded-xl border border-[#e1e3de] bg-white px-3 py-1.5 text-xs font-bold text-[#3f493f] shadow-sm transition-colors hover:bg-[#f8faf5] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              {t('videos.detail.editTranscriptButton')}
+            </button>
+          )}
+        </div>
+        {!isTranscriptEditing && (
+          <div className="relative w-full">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-[#6f7a6e] w-3.5 h-3.5" />
+            <input
+              type="text"
+              value={transcriptSearch}
+              onChange={(event) => onTranscriptSearchChange(event.target.value)}
+              placeholder={t('videos.detail.transcriptSearchPlaceholder')}
+              className="w-full h-9 pl-9 pr-3 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:outline-none focus:border-[#00652c] focus:ring-2 focus:ring-[#00652c]/20 transition-all placeholder:text-[#3f493f]/60"
+            />
+          </div>
+        )}
+      </div>
+
+      {isTranscriptEditing ? (
+        <div className="flex-1 overflow-hidden flex flex-col">
+          <div className="flex shrink-0 flex-col gap-3 border-b border-stone-100 bg-[#f8faf5] p-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex shrink-0 gap-2">
+              <button
+                type="button"
+                onClick={onCancelTranscriptEditing}
+                disabled={isTranscriptSaving}
+                className="rounded-xl border border-[#e1e3de] bg-white px-3 py-1.5 text-xs font-bold text-[#3f493f] transition-colors hover:bg-[#f8faf5] disabled:opacity-50"
+              >
+                {t('videos.detail.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={onSaveTranscript}
+                disabled={isTranscriptSaving}
+                className="inline-flex items-center justify-center gap-1.5 rounded-xl bg-[#00652c] px-3 py-1.5 text-xs font-bold text-white transition-colors hover:bg-[#005323] disabled:opacity-50"
+              >
+                {isTranscriptSaving ? <InlineSpinner className="h-3 w-3" /> : <Save className="h-3 w-3" />}
+                {isTranscriptSaving ? t('videos.detail.saving') : t('videos.detail.saveTranscriptButton')}
+              </button>
+            </div>
+          </div>
+          {transcriptSaveError && (
+            <p className="shrink-0 px-3 py-2 text-xs text-red-700 bg-red-50 border-b border-red-200">
+              {transcriptSaveError}
+            </p>
+          )}
+          <textarea
+            value={editedTranscript}
+            onChange={(event) => onEditedTranscriptChange(event.target.value)}
+            disabled={isTranscriptSaving}
+            spellCheck={false}
+            className="min-h-0 flex-1 resize-none border-0 bg-white p-4 font-mono text-xs leading-relaxed text-[#191c19] outline-none focus:ring-2 focus:ring-inset focus:ring-[#00652c]/20 disabled:opacity-60"
+          />
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto p-2 flex flex-col gap-1">
+          {filteredSegments.length > 0 ? (
+            filteredSegments.map((segment, index) => (
+              <div
+                key={index}
+                onClick={() => onSeek(segment.seconds, index)}
+                className={`flex gap-4 p-3 rounded-xl cursor-pointer transition-all group ${
+                  activeSegmentIdx === index
+                    ? 'bg-[#f0fdf4] border-l-4 border-[#00652c]'
+                    : 'hover:bg-stone-50'
+                }`}
+              >
+                <span className="text-[#00652c] font-mono text-[11px] mt-0.5 shrink-0 bg-[#00652c]/8 px-2 py-0.5 rounded-lg h-fit whitespace-nowrap font-semibold">
+                  {segment.timestamp}
+                </span>
+                <p
+                  className={`text-sm leading-relaxed ${
+                    activeSegmentIdx === index
+                      ? 'text-[#191c19] font-medium'
+                      : 'text-[#3f493f] group-hover:text-[#191c19]'
+                  }`}
+                >
+                  {segment.text}
+                </p>
+              </div>
+            ))
+          ) : isPlainTextTranscript ? (
+            <div className="p-4 bg-white rounded-xl">
+              <p className="text-sm text-[#3f493f] whitespace-pre-wrap leading-relaxed">
+                {video.transcript}
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-16 text-[#6f7a6e]">
+              <div className="w-16 h-16 bg-[#f2f4ef] rounded-full flex items-center justify-center mb-4">
+                <Search className="w-8 h-8 text-[#becabc]" />
+              </div>
+              <p className="text-sm font-medium text-center px-4">
+                {transcriptSearch
+                  ? t('videos.detail.transcriptNotFound')
+                  : (() => {
+                      const statusMsgs: Partial<Record<Video['status'], string>> = {
+                        pending: t('videos.detail.transcriptStatus.pending'),
+                        processing: t('videos.detail.transcriptStatus.processing'),
+                        indexing: t('videos.detail.transcriptStatus.indexing'),
+                        error: t('videos.detail.transcriptStatus.error'),
+                      };
+                      return statusMsgs[video.status] ?? t('videos.detail.transcriptStatus.unavailable');
+                    })()}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function VideoDetailView({
+  video,
+  isLoading,
+  error,
+  videoRef,
+  youtubeStartSeconds,
+  onVideoLoaded,
+  isMobile,
+  mobileTab,
+  onMobileTabChange,
+  tags,
+  isCreateDialogOpen,
+  onCreateDialogOpenChange,
+  onCreateTag,
+  isEditing,
+  editedTitle,
+  editedDescription,
+  editedTagIds,
+  onEditedTitleChange,
+  onEditedDescriptionChange,
+  onEditedTagIdsChange,
+  onStartEditing,
+  onCancelEdit,
+  onUpdateVideo,
+  isUpdating,
+  updateError,
+  deleteError,
+  isDeleting,
+  onDeleteVideo,
+  transcriptSearch,
+  onTranscriptSearchChange,
+  isTranscriptEditing,
+  onStartTranscriptEditing,
+  onCancelTranscriptEditing,
+  editedTranscript,
+  onEditedTranscriptChange,
+  onSaveTranscript,
+  isTranscriptSaving,
+  transcriptSaveError,
+  filteredSegments,
+  activeSegmentIdx,
+  onSeek,
+  isPlainTextTranscript,
+}: VideoDetailViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="bg-[#f8faf5] flex flex-col min-h-screen"
+      style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+    >
+      <AppNav activePage="videos" />
+
+      {isLoading ? (
+        <div className="flex-1 flex items-center justify-center">
+          <LoadingSpinner />
+        </div>
+      ) : error && !video ? (
+        <div className="flex-1 flex flex-col items-center justify-center gap-4">
+          <p className="text-red-500">{error}</p>
+          <Link href="/videos" className="text-[#00652c] font-bold hover:underline flex items-center gap-1">
+            <ArrowLeft className="w-4 h-4" />
+            {t('common.actions.backToList')}
+          </Link>
+        </div>
+      ) : !video ? (
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-[#3f493f]">{t('common.messages.videoNotFound')}</p>
+        </div>
+      ) : (
+        <>
+          <VideoDetailEditDialog
+            isOpen={isEditing}
+            tags={tags}
+            editedTitle={editedTitle}
+            editedDescription={editedDescription}
+            editedTagIds={editedTagIds}
+            isUpdating={isUpdating}
+            updateError={updateError}
+            onOpenChange={(open) => !open && onCancelEdit()}
+            onEditedTitleChange={onEditedTitleChange}
+            onEditedDescriptionChange={onEditedDescriptionChange}
+            onEditedTagIdsChange={onEditedTagIdsChange}
+            onCreateNewTag={() => onCreateDialogOpenChange(true)}
+            onSave={onUpdateVideo}
+          />
+
+          {isMobile && (
+            <VideoDetailMobileTabs activeTab={mobileTab} onChange={onMobileTabChange} />
+          )}
+
+          <main
+            className={`flex-grow max-w-screen-xl mx-auto w-full px-6 lg:px-8 py-6 flex flex-col gap-6 ${
+              isMobile ? 'mt-0' : 'mt-16'
+            }`}
+          >
+            <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+              <div
+                className={`lg:col-span-8 flex flex-col gap-4 ${
+                  isMobile && mobileTab !== 'video' ? 'hidden' : ''
+                }`}
+              >
+                <VideoPlayerPanel
+                  video={video}
+                  videoRef={videoRef}
+                  youtubeStartSeconds={youtubeStartSeconds}
+                  onVideoLoaded={onVideoLoaded}
+                />
+                <VideoMetaPanel
+                  video={video}
+                  deleteError={deleteError}
+                  isDeleting={isDeleting}
+                  onEdit={onStartEditing}
+                  onDelete={onDeleteVideo}
+                />
+              </div>
+
+              <TranscriptPanel
+                video={video}
+                isMobile={isMobile}
+                mobileTab={mobileTab}
+                transcriptSearch={transcriptSearch}
+                onTranscriptSearchChange={onTranscriptSearchChange}
+                isTranscriptEditing={isTranscriptEditing}
+                onStartTranscriptEditing={onStartTranscriptEditing}
+                onCancelTranscriptEditing={onCancelTranscriptEditing}
+                editedTranscript={editedTranscript}
+                onEditedTranscriptChange={onEditedTranscriptChange}
+                onSaveTranscript={onSaveTranscript}
+                isTranscriptSaving={isTranscriptSaving}
+                transcriptSaveError={transcriptSaveError}
+                filteredSegments={filteredSegments}
+                activeSegmentIdx={activeSegmentIdx}
+                onSeek={onSeek}
+                isPlainTextTranscript={isPlainTextTranscript}
+              />
+            </div>
+          </main>
+
+          <TagCreateDialog
+            isOpen={isCreateDialogOpen}
+            onClose={() => onCreateDialogOpenChange(false)}
+            onCreate={onCreateTag}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/video/detail/VideoDetailView.tsx
+++ b/frontend/src/components/video/detail/VideoDetailView.tsx
@@ -47,7 +47,7 @@ interface VideoDetailViewProps {
   tags: Tag[];
   isCreateDialogOpen: boolean;
   onCreateDialogOpenChange: (open: boolean) => void;
-  onCreateTag: (name: string, color: string) => Promise<void> | void;
+  onCreateTag: (name: string, color: string) => Promise<void>;
   isEditing: boolean;
   editedTitle: string;
   editedDescription: string;

--- a/frontend/src/components/video/group-detail/VideoGroupDetailView.tsx
+++ b/frontend/src/components/video/group-detail/VideoGroupDetailView.tsx
@@ -1,0 +1,931 @@
+import { useCallback, useEffect, useState, type ChangeEvent, type RefObject } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type SensorDescriptor,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle,
+  Clock,
+  Copy,
+  GripVertical,
+  List,
+  Pencil,
+  Play,
+  Plus,
+  Save,
+  Trash2,
+  X,
+} from 'lucide-react';
+import { apiClient, type VideoGroup, type VideoInGroup } from '@/lib/api';
+import { buildYoutubeEmbedSrc } from '@/lib/video/embed';
+import { handleAsyncError } from '@/lib/utils/errorHandling';
+import type { SelectedVideo } from '@/lib/utils/videoConversion';
+import { Link } from '@/lib/i18n';
+import { AppNav } from '@/components/layout/AppNav';
+import { ChatPanel } from '@/components/chat/ChatPanel';
+import { DashboardButton } from '@/components/dashboard/DashboardButton';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { InlineSpinner } from '@/components/common/InlineSpinner';
+import { useToast } from '@/components/common/feedback';
+import { TagFilterPanel } from '@/components/video/TagFilterPanel';
+import { TagManagementModal } from '@/components/video/TagManagementModal';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useTags } from '@/hooks/useTags';
+import {
+  useAddableVideosQuery,
+  useAddVideosToGroupMutation,
+} from '@/hooks/useVideoGroupDetailData';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MOBILE_SENSORS: SensorDescriptor<any>[] = [];
+
+type MobileTab = 'videos' | 'player';
+
+const ORDERING_OPTIONS = [
+  'uploaded_at_desc',
+  'uploaded_at_asc',
+  'title_asc',
+  'title_desc',
+] as const;
+type OrderingOption = (typeof ORDERING_OPTIONS)[number];
+
+interface VideoGroupDetailViewProps {
+  group: VideoGroup | null;
+  groupId: number | null;
+  isLoading: boolean;
+  error: string | null;
+  selectedVideo: SelectedVideo | null;
+  deleteError: string | null;
+  isDeleting: boolean;
+  isEditing: boolean;
+  editedName: string;
+  editedDescription: string;
+  updateError: string | null;
+  isUpdating: boolean;
+  isAddModalOpen: boolean;
+  mobileTab: MobileTab;
+  isMobile: boolean;
+  videoRef: RefObject<HTMLVideoElement | null>;
+  youtubeStartSeconds: number | null;
+  shareSlug: string;
+  shareLink: string | null;
+  isGeneratingLink: boolean;
+  isCopied: boolean;
+  onMobileTabChange: (tab: MobileTab) => void;
+  onOpenAddModalChange: (open: boolean) => void;
+  onStartEditing: () => void;
+  onCancelEdit: () => void;
+  onEditedNameChange: (name: string) => void;
+  onEditedDescriptionChange: (description: string) => void;
+  onUpdateGroup: () => void;
+  onDeleteGroup: () => void;
+  onVideoSelect: (videoId: number) => void;
+  onRemoveVideo: (videoId: number) => Promise<void> | void;
+  onDragEnd: (event: DragEndEvent) => Promise<void> | void;
+  onVideoCanPlay: () => void;
+  onVideoPlayFromTime: (videoId: number, seconds: number) => void;
+  onGenerateShareLink: (shareSlug: string) => Promise<void> | void;
+  onDeleteShareLink: () => void;
+  onCopyShareLink: () => void;
+}
+
+function VideoStatusBadge({ status }: { status: VideoInGroup['status'] }) {
+  const { t } = useTranslation();
+
+  if (status === 'completed') {
+    return (
+      <span className="inline-flex items-center gap-0.5 text-[10px] font-bold text-[#00652c] mt-1">
+        <CheckCircle className="w-3 h-3 fill-current" />
+        {t('videos.groupDetail.status.completed')}
+      </span>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <span className="inline-flex items-center gap-0.5 text-[10px] font-bold text-red-500 mt-1">
+        <AlertCircle className="w-3 h-3" />
+        {t('videos.groupDetail.status.error')}
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-0.5 text-[10px] font-bold text-[#904d00] bg-[#ffdcc3]/40 px-1.5 py-0.5 rounded-full mt-1">
+      <Clock className="w-3 h-3" />
+      {t('videos.groupDetail.status.processing')}
+    </span>
+  );
+}
+
+interface SortableVideoItemProps {
+  video: VideoInGroup;
+  isSelected: boolean;
+  onSelect: (videoId: number) => void;
+  onRemove: (videoId: number) => void;
+  isMobile?: boolean;
+}
+
+function SortableVideoItem({
+  video,
+  isSelected,
+  onSelect,
+  onRemove,
+  isMobile = false,
+}: SortableVideoItemProps) {
+  const { t } = useTranslation();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: video.id,
+    disabled: isMobile,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      onClick={() => onSelect(video.id)}
+      className={`flex items-center gap-2 p-3 rounded-xl cursor-pointer group transition-colors ${
+        isSelected
+          ? 'bg-[#f0fdf4] border-l-4 border-[#00652c]'
+          : 'hover:bg-stone-50'
+      } ${isDragging ? 'shadow-lg z-50' : ''}`}
+    >
+      {!isMobile && (
+        <span
+          {...attributes}
+          {...listeners}
+          onClick={(event) => event.stopPropagation()}
+          className="text-stone-300 cursor-grab active:cursor-grabbing shrink-0"
+        >
+          <GripVertical className="w-4 h-4" />
+        </span>
+      )}
+      <div className="flex-1 min-w-0">
+        <p className={`text-sm truncate leading-tight ${isSelected ? 'font-bold text-[#00652c]' : 'font-medium text-[#191c19]'}`}>
+          {video.title}
+        </p>
+        <VideoStatusBadge status={video.status} />
+      </div>
+      <button
+        onClick={(event) => {
+          event.stopPropagation();
+          onRemove(video.id);
+        }}
+        onPointerDown={(event) => event.stopPropagation()}
+        onMouseDown={(event) => event.stopPropagation()}
+        aria-label={t('videos.groupDetail.removeFromGroup')}
+        className="inline-flex items-center rounded-lg p-1.5 text-red-600 hover:bg-red-50 transition-colors shrink-0"
+      >
+        <Trash2 className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}
+
+function ShareLinkPanel({
+  shareSlug,
+  shareLink,
+  isGeneratingLink,
+  isCopied,
+  onGenerate,
+  onDelete,
+  onCopy,
+}: {
+  shareSlug: string;
+  shareLink: string | null;
+  isGeneratingLink: boolean;
+  isCopied: boolean;
+  onGenerate: (shareSlug: string) => Promise<void> | void;
+  onDelete: () => void;
+  onCopy: () => void;
+}) {
+  const { t } = useTranslation();
+  const [inputValue, setInputValue] = useState(shareSlug);
+
+  useEffect(() => {
+    setInputValue(shareSlug);
+  }, [shareSlug]);
+
+  return (
+    <div className="bg-white rounded-xl p-4 flex flex-col lg:flex-row lg:items-center gap-3 lg:gap-4 shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
+      <div className="flex-1 min-w-0 space-y-2">
+        <div className="flex flex-col lg:flex-row lg:items-center gap-2 lg:gap-3">
+          <div className="flex-1 bg-[#f2f4ef] rounded-xl px-4 py-2 border border-[#e1e3de]/40 min-w-0">
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(event) => setInputValue(event.target.value)}
+              placeholder={t('videos.groupDetail.shareSlugPlaceholder')}
+              className="w-full bg-transparent text-[#3f493f] text-sm outline-none"
+            />
+          </div>
+          <p className="text-xs text-[#6f7a6e] whitespace-nowrap">
+            {t('videos.groupDetail.shareSlugHelp')}
+          </p>
+        </div>
+        <div className="flex flex-col lg:flex-row lg:items-center gap-2 lg:gap-3">
+          <span className="text-sm font-bold text-[#3f493f] whitespace-nowrap shrink-0">
+            {t('videos.groupDetail.shareLinkLabel')}
+          </span>
+          {shareLink ? (
+            <div className="flex-1 min-w-0 bg-white rounded-xl px-4 py-2 border border-[#e1e3de]/40">
+              <input
+                type="text"
+                value={shareLink}
+                readOnly
+                className="w-full bg-transparent text-[#6f7a6e] text-sm outline-none cursor-default"
+              />
+            </div>
+          ) : (
+            <p className="text-sm text-[#6f7a6e]">{t('videos.groupDetail.share.disabled')}</p>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0 self-start lg:self-center">
+        {shareLink && (
+          <button
+            onClick={onCopy}
+            className="flex items-center gap-2 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity"
+          >
+            <Copy className="w-3.5 h-3.5" />
+            {isCopied ? t('videos.groupDetail.copied') : t('videos.groupDetail.copyButton')}
+          </button>
+        )}
+        <button
+          onClick={() => {
+            void onGenerate(inputValue);
+          }}
+          disabled={isGeneratingLink || !inputValue.trim()}
+          className="flex items-center gap-2 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0"
+        >
+          {isGeneratingLink ? <InlineSpinner className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
+          {isGeneratingLink ? t('videos.groupDetail.generating') : t('common.actions.save')}
+        </button>
+        {shareLink && (
+          <button
+            onClick={onDelete}
+            className="px-4 py-2 text-red-600 text-sm font-bold hover:bg-red-50 rounded-xl transition-colors"
+          >
+            {t('videos.groupDetail.disable')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface AddVideosDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  groupId: number | null;
+  group: VideoGroup | null;
+  onVideosAdded?: () => void;
+}
+
+function AddVideosDialog({
+  isOpen,
+  onOpenChange,
+  groupId,
+  group,
+  onVideosAdded,
+}: AddVideosDialogProps) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const { tags } = useTags();
+
+  const [videoSearchInput, setVideoSearchInput] = useState('');
+  const [videoSearch, setVideoSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('');
+  const [ordering, setOrdering] = useState<OrderingOption>('uploaded_at_desc');
+  const [selectedVideos, setSelectedVideos] = useState<number[]>([]);
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
+  const [isTagManagementOpen, setIsTagManagementOpen] = useState(false);
+
+  const handleOrderingChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value as OrderingOption;
+    if (ORDERING_OPTIONS.includes(value)) setOrdering(value);
+  }, []);
+
+  const handleTagToggle = useCallback((tagId: number) => {
+    setSelectedTagIds((prev) =>
+      prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId],
+    );
+  }, []);
+
+  const handleTagClear = useCallback(() => setSelectedTagIds([]), []);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setVideoSearch(videoSearchInput), 300);
+    return () => clearTimeout(handler);
+  }, [videoSearchInput]);
+
+  const availableVideosQuery = useAddableVideosQuery({
+    isOpen,
+    groupId,
+    group,
+    q: videoSearch.trim(),
+    status: statusFilter,
+    ordering,
+    tagIds: selectedTagIds,
+  });
+
+  const availableVideos = availableVideosQuery.data ?? [];
+  const isLoadingVideos = availableVideosQuery.isLoading || availableVideosQuery.isFetching;
+  const addVideosMutation = useAddVideosToGroupMutation(groupId, onVideosAdded);
+
+  const handleAddVideos = async () => {
+    if (!groupId || selectedVideos.length === 0) return;
+    try {
+      const result = await addVideosMutation.mutateAsync(selectedVideos);
+      onOpenChange(false);
+      setSelectedVideos([]);
+      if (result.skipped_count > 0) {
+        toast({
+          message: t('videos.groupDetail.addResult', { added: result.added_count, skipped: result.skipped_count }),
+          variant: 'info',
+        });
+      }
+    } catch (err) {
+      handleAsyncError(err, t('videos.groupDetail.addError'), () => {});
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={isOpen} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-[95vw] lg:max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{t('videos.groupDetail.addVideos')}</DialogTitle>
+            <DialogDescription>
+              {t('videos.groupDetail.addVideosDescription', 'Select videos to add to this group.')}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                placeholder={t('videos.groupDetail.searchPlaceholder')}
+                value={videoSearchInput}
+                onChange={(event) => setVideoSearchInput(event.target.value)}
+                className="w-full md:w-1/2 px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm outline-none focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c]"
+              />
+              <select
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value)}
+                className="px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm outline-none"
+              >
+                <option value="">{t('videos.groupDetail.statusFilter.all')}</option>
+                <option value="completed">{t('videos.groupDetail.statusFilter.completed')}</option>
+                <option value="processing">{t('videos.groupDetail.statusFilter.processing')}</option>
+                <option value="indexing">{t('videos.groupDetail.statusFilter.indexing')}</option>
+                <option value="pending">{t('videos.groupDetail.statusFilter.pending')}</option>
+                <option value="error">{t('videos.groupDetail.statusFilter.error')}</option>
+              </select>
+              <select
+                value={ordering}
+                onChange={handleOrderingChange}
+                className="px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm outline-none"
+              >
+                <option value="uploaded_at_desc">{t('videos.groupDetail.ordering.uploadedDesc')}</option>
+                <option value="uploaded_at_asc">{t('videos.groupDetail.ordering.uploadedAsc')}</option>
+                <option value="title_asc">{t('videos.groupDetail.ordering.titleAsc')}</option>
+                <option value="title_desc">{t('videos.groupDetail.ordering.titleDesc')}</option>
+              </select>
+              <button
+                onClick={() => setSelectedVideos(availableVideos.map((video) => video.id))}
+                disabled={!availableVideos.length}
+                className="px-3 py-2 border border-[#e1e3de] rounded-xl text-sm font-medium hover:bg-[#f2f4ef] disabled:opacity-40"
+              >
+                {t('videos.groupDetail.selectAll')}
+              </button>
+              <button
+                onClick={() => setSelectedVideos([])}
+                disabled={selectedVideos.length === 0}
+                className="px-3 py-2 border border-[#e1e3de] rounded-xl text-sm font-medium hover:bg-[#f2f4ef] disabled:opacity-40"
+              >
+                {t('videos.groupDetail.clearSelection')}
+              </button>
+            </div>
+            <TagFilterPanel
+              tags={tags}
+              selectedTagIds={selectedTagIds}
+              onToggle={handleTagToggle}
+              onClear={handleTagClear}
+              onManageTags={() => setIsTagManagementOpen(true)}
+              disabled={isLoadingVideos}
+            />
+            {isLoadingVideos ? (
+              <div className="flex justify-center py-8"><LoadingSpinner /></div>
+            ) : availableVideos.length === 0 ? (
+              <p className="text-center text-[#6f7a6e] py-8">{t('videos.groupDetail.noAvailableVideos')}</p>
+            ) : (
+              <div className="space-y-2 max-h-[400px] overflow-y-auto">
+                {availableVideos.map((video) => (
+                  <div key={video.id} className="flex items-center gap-3 p-3 border border-[#e1e3de] rounded-xl hover:bg-[#f2f4ef] transition-colors">
+                    <Checkbox
+                      id={`video-${video.id}`}
+                      checked={selectedVideos.includes(video.id)}
+                      onCheckedChange={(checked: boolean | 'indeterminate') => {
+                        if (checked === true) setSelectedVideos([...selectedVideos, video.id]);
+                        else if (checked === false) setSelectedVideos(selectedVideos.filter((id) => id !== video.id));
+                      }}
+                    />
+                    <label htmlFor={`video-${video.id}`} className="flex-1 cursor-pointer">
+                      <div className="text-sm font-medium text-[#191c19]">{video.title}</div>
+                      <div className="text-xs text-[#6f7a6e]">{video.description || t('common.messages.noDescription')}</div>
+                    </label>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <button
+              onClick={() => onOpenChange(false)}
+              className="px-4 py-2 border border-[#e1e3de] rounded-xl text-sm font-bold hover:bg-[#f2f4ef] transition-colors"
+            >
+              {t('common.actions.cancel')}
+            </button>
+            <button
+              onClick={handleAddVideos}
+              disabled={addVideosMutation.isPending || selectedVideos.length === 0}
+              className="flex items-center gap-2 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              {addVideosMutation.isPending && <InlineSpinner className="w-3.5 h-3.5" />}
+              {addVideosMutation.isPending ? t('videos.groupDetail.adding') : t('videos.groupDetail.add')}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <TagManagementModal isOpen={isTagManagementOpen} onClose={() => setIsTagManagementOpen(false)} />
+    </>
+  );
+}
+
+function GroupEditDialog({
+  isOpen,
+  editedName,
+  editedDescription,
+  updateError,
+  isUpdating,
+  onOpenChange,
+  onNameChange,
+  onDescriptionChange,
+  onSave,
+}: {
+  isOpen: boolean;
+  editedName: string;
+  editedDescription: string;
+  updateError: string | null;
+  isUpdating: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNameChange: (name: string) => void;
+  onDescriptionChange: (description: string) => void;
+  onSave: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('videos.groupDetail.editTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('videos.groupDetail.editDescription', 'Update the group name and description.')}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          {updateError && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">{updateError}</div>
+          )}
+          <div className="space-y-1">
+            <label className="text-xs font-bold text-[#3f493f]">{t('videos.groups.nameLabel')}</label>
+            <input
+              type="text"
+              value={editedName}
+              onChange={(event) => onNameChange(event.target.value)}
+              disabled={isUpdating}
+              className="w-full px-3 py-2.5 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-bold text-[#3f493f]">{t('videos.groups.descriptionLabel')}</label>
+            <textarea
+              value={editedDescription}
+              onChange={(event) => onDescriptionChange(event.target.value)}
+              disabled={isUpdating}
+              rows={3}
+              className="w-full px-3 py-2.5 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all resize-none"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <button
+            onClick={() => onOpenChange(false)}
+            disabled={isUpdating}
+            className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] rounded-xl text-sm font-bold hover:bg-[#f2f4ef] transition-colors disabled:opacity-50"
+          >
+            <X className="w-3.5 h-3.5" />
+            {t('common.actions.cancel')}
+          </button>
+          <button
+            onClick={onSave}
+            disabled={isUpdating || !editedName.trim()}
+            className="flex items-center gap-1.5 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
+          >
+            {isUpdating ? <InlineSpinner className="w-3.5 h-3.5" /> : <Save className="w-3.5 h-3.5" />}
+            {isUpdating ? t('common.actions.saving') : t('common.actions.save')}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function GroupVideoList({
+  group,
+  selectedVideo,
+  deleteError,
+  isDeleting,
+  isMobile,
+  mobileTab,
+  sensors,
+  onOpenAdd,
+  onStartEditing,
+  onDeleteGroup,
+  onVideoSelect,
+  onMobileTabChange,
+  onRemoveVideo,
+  onDragEnd,
+}: {
+  group: VideoGroup;
+  selectedVideo: SelectedVideo | null;
+  deleteError: string | null;
+  isDeleting: boolean;
+  isMobile: boolean;
+  mobileTab: MobileTab;
+  sensors: SensorDescriptor[];
+  onOpenAdd: () => void;
+  onStartEditing: () => void;
+  onDeleteGroup: () => void;
+  onVideoSelect: (videoId: number) => void;
+  onMobileTabChange: (tab: MobileTab) => void;
+  onRemoveVideo: (videoId: number) => Promise<void> | void;
+  onDragEnd: (event: DragEndEvent) => Promise<void> | void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <aside className={`lg:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
+      <div className="bg-white rounded-xl flex flex-col h-full overflow-hidden shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
+        {deleteError && (
+          <div className="px-4 pt-3 shrink-0">
+            <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">{deleteError}</div>
+          </div>
+        )}
+        <div className="p-4 border-b border-stone-100 flex items-center justify-between gap-2 shrink-0">
+          <h2 className="font-extrabold text-[#191c19] truncate flex-1 min-w-0">{group.name}</h2>
+          <div className="flex items-center gap-2 shrink-0">
+            <span className="text-xs bg-[#f2f4ef] px-2 py-0.5 rounded-full text-[#6f7a6e] font-medium">
+              {t('videos.groupDetail.videoCount', { count: group.videos?.length ?? 0 })}
+            </span>
+            <button
+              onClick={onOpenAdd}
+              className="flex items-center gap-1 px-2 py-1 rounded-lg bg-white border border-[#e1e3de] hover:bg-[#f2f4ef] transition-colors text-[#191c19] text-xs font-bold shadow-sm"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              <span className="hidden sm:inline">{t('videos.groupDetail.add')}</span>
+            </button>
+            <button
+              onClick={onStartEditing}
+              className="p-1.5 text-[#3f493f] hover:bg-stone-100 rounded-lg transition-colors"
+              title={t('videos.groupDetail.editTitle')}
+            >
+              <Pencil className="w-3.5 h-3.5" />
+            </button>
+            <button
+              onClick={onDeleteGroup}
+              disabled={isDeleting}
+              className="p-1.5 text-red-500 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+              title={t('videos.groupDetail.delete')}
+            >
+              {isDeleting ? <InlineSpinner className="w-3.5 h-3.5" /> : <Trash2 className="w-3.5 h-3.5" />}
+            </button>
+          </div>
+        </div>
+        <div className="flex-1 overflow-y-auto p-2 space-y-1">
+          {group.videos && group.videos.length > 0 ? (
+            <DndContext
+              sensors={isMobile ? MOBILE_SENSORS : sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={onDragEnd}
+            >
+              <SortableContext items={group.videos.map((video) => video.id)} strategy={verticalListSortingStrategy}>
+                {group.videos.map((video) => (
+                  <SortableVideoItem
+                    key={video.id}
+                    video={video}
+                    isSelected={selectedVideo?.id === video.id}
+                    isMobile={isMobile}
+                    onSelect={(videoId) => {
+                      onVideoSelect(videoId);
+                      if (isMobile) onMobileTabChange('player');
+                    }}
+                    onRemove={onRemoveVideo}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
+          ) : (
+            <p className="text-center text-[#6f7a6e] py-8 text-sm">
+              {t('videos.groupDetail.videoListEmpty')}
+            </p>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function GroupPlayerPanel({
+  groupId,
+  selectedVideo,
+  mobileTab,
+  videoRef,
+  youtubeStartSeconds,
+  onVideoCanPlay,
+  onVideoPlayFromTime,
+}: {
+  groupId: number | null;
+  selectedVideo: SelectedVideo | null;
+  mobileTab: MobileTab;
+  videoRef: RefObject<HTMLVideoElement | null>;
+  youtubeStartSeconds: number | null;
+  onVideoCanPlay: () => void;
+  onVideoPlayFromTime: (videoId: number, seconds: number) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <section className={`lg:col-span-2 flex flex-col gap-3 lg:min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden lg:flex'}`}>
+      <div className="bg-white rounded-xl flex flex-col lg:flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
+        <div className="p-4 border-b border-stone-100 shrink-0 flex items-center justify-between gap-3 min-w-0">
+          <h1 className="font-extrabold text-[#191c19] text-lg truncate flex-1 min-w-0">
+            {selectedVideo ? selectedVideo.title : t('videos.groupDetail.playerPlaceholder')}
+          </h1>
+          <div className="flex items-center gap-2 shrink-0">
+            {groupId && <DashboardButton groupId={groupId} size="sm" />}
+          </div>
+        </div>
+        <div className="aspect-video lg:aspect-auto lg:flex-1 bg-[#1a1c1c] flex items-center justify-center lg:min-h-0">
+          {selectedVideo ? (
+            selectedVideo.source_type === 'youtube' && selectedVideo.youtube_embed_url ? (
+              <iframe
+                key={`${selectedVideo.id}-${youtubeStartSeconds ?? 0}`}
+                className="w-full h-full"
+                src={buildYoutubeEmbedSrc(selectedVideo.youtube_embed_url, youtubeStartSeconds)}
+                title={selectedVideo.title}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            ) : selectedVideo.file ? (
+              <video
+                ref={videoRef}
+                key={selectedVideo.id}
+                controls
+                className="w-full h-full object-contain"
+                src={apiClient.getVideoUrl(selectedVideo.file)}
+                onCanPlay={onVideoCanPlay}
+              >
+                {t('common.messages.browserNoVideoSupport')}
+              </video>
+            ) : (
+              <p className="text-stone-400 text-sm">{t('videos.groupDetail.videoNoFile')}</p>
+            )
+          ) : (
+            <p className="text-stone-400 text-sm text-center px-4">{t('videos.groupDetail.playerPlaceholder')}</p>
+          )}
+        </div>
+      </div>
+      <div className="lg:hidden">
+        <ChatPanel
+          groupId={groupId ?? undefined}
+          onVideoPlay={onVideoPlayFromTime}
+          className="h-[480px] shadow-[0_4px_20px_rgba(28,25,23,0.04)]"
+        />
+      </div>
+    </section>
+  );
+}
+
+function GroupMobileNav({
+  mobileTab,
+  onChange,
+}: {
+  mobileTab: MobileTab;
+  onChange: (tab: MobileTab) => void;
+}) {
+  const { t } = useTranslation();
+  const mobileTabIcon: Record<MobileTab, typeof List> = { videos: List, player: Play };
+  const mobileTabLabel: Record<MobileTab, string> = {
+    videos: t('videos.groupDetail.mobileTabs.videos'),
+    player: t('videos.groupDetail.mobileTabs.player'),
+  };
+
+  return (
+    <nav className="fixed bottom-0 left-0 w-full z-50 lg:hidden flex justify-around items-center h-16 bg-white border-t border-stone-100 shadow-[0_-4px_20px_rgba(28,25,23,0.06)] rounded-t-2xl px-4">
+      {(['videos', 'player'] as MobileTab[]).map((tab) => {
+        const Icon = mobileTabIcon[tab];
+        const isActive = mobileTab === tab;
+        return (
+          <button
+            key={tab}
+            onClick={() => onChange(tab)}
+            className={`flex flex-col items-center justify-center gap-1 px-4 py-1 rounded-xl transition-colors ${
+              isActive
+                ? 'bg-[#f0fdf4] text-[#00652c]'
+                : 'text-stone-400 hover:text-[#00652c]'
+            }`}
+          >
+            <Icon className="w-5 h-5" />
+            <span className="text-[11px] font-medium">{mobileTabLabel[tab]}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function VideoGroupDetailView({
+  group,
+  groupId,
+  isLoading,
+  error,
+  selectedVideo,
+  deleteError,
+  isDeleting,
+  isEditing,
+  editedName,
+  editedDescription,
+  updateError,
+  isUpdating,
+  isAddModalOpen,
+  mobileTab,
+  isMobile,
+  videoRef,
+  youtubeStartSeconds,
+  shareSlug,
+  shareLink,
+  isGeneratingLink,
+  isCopied,
+  onMobileTabChange,
+  onOpenAddModalChange,
+  onStartEditing,
+  onCancelEdit,
+  onEditedNameChange,
+  onEditedDescriptionChange,
+  onUpdateGroup,
+  onDeleteGroup,
+  onVideoSelect,
+  onRemoveVideo,
+  onDragEnd,
+  onVideoCanPlay,
+  onVideoPlayFromTime,
+  onGenerateShareLink,
+  onDeleteShareLink,
+  onCopyShareLink,
+}: VideoGroupDetailViewProps) {
+  const { t } = useTranslation();
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  return (
+    <div
+      className="bg-[#f8faf5] flex flex-col"
+      style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
+    >
+      <AppNav activePage="groups" />
+
+      {isLoading ? (
+        <div className="mt-16 min-h-[calc(100dvh-64px)] flex items-center justify-center">
+          <LoadingSpinner />
+        </div>
+      ) : error && !group ? (
+        <div className="mt-16 min-h-[calc(100dvh-64px)] flex flex-col items-center justify-center gap-4">
+          <p className="text-red-500">{error}</p>
+          <Link href="/videos/groups" className="text-[#00652c] font-bold hover:underline flex items-center gap-1">
+            <ArrowLeft className="w-4 h-4" />
+            {t('common.actions.backToList')}
+          </Link>
+        </div>
+      ) : !group ? (
+        <div className="mt-16 min-h-[calc(100dvh-64px)] flex items-center justify-center">
+          <p className="text-[#3f493f]">{t('common.messages.groupNotFound')}</p>
+        </div>
+      ) : (
+        <>
+          <GroupEditDialog
+            isOpen={isEditing}
+            editedName={editedName}
+            editedDescription={editedDescription}
+            updateError={updateError}
+            isUpdating={isUpdating}
+            onOpenChange={(open) => !open && onCancelEdit()}
+            onNameChange={onEditedNameChange}
+            onDescriptionChange={onEditedDescriptionChange}
+            onSave={onUpdateGroup}
+          />
+
+          <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-4 lg:h-[calc(100dvh-64px)] lg:overflow-hidden">
+            <ShareLinkPanel
+              shareSlug={shareSlug}
+              shareLink={shareLink}
+              isGeneratingLink={isGeneratingLink}
+              isCopied={isCopied}
+              onGenerate={onGenerateShareLink}
+              onDelete={onDeleteShareLink}
+              onCopy={onCopyShareLink}
+            />
+
+            <div className="flex flex-col lg:grid lg:grid-cols-4 gap-6 lg:flex-1 lg:min-h-0 lg:items-stretch">
+              <GroupVideoList
+                group={group}
+                selectedVideo={selectedVideo}
+                deleteError={deleteError}
+                isDeleting={isDeleting}
+                isMobile={isMobile}
+                mobileTab={mobileTab}
+                sensors={sensors}
+                onOpenAdd={() => onOpenAddModalChange(true)}
+                onStartEditing={onStartEditing}
+                onDeleteGroup={onDeleteGroup}
+                onVideoSelect={onVideoSelect}
+                onMobileTabChange={onMobileTabChange}
+                onRemoveVideo={onRemoveVideo}
+                onDragEnd={onDragEnd}
+              />
+
+              <GroupPlayerPanel
+                groupId={groupId}
+                selectedVideo={selectedVideo}
+                mobileTab={mobileTab}
+                videoRef={videoRef}
+                youtubeStartSeconds={youtubeStartSeconds}
+                onVideoCanPlay={onVideoCanPlay}
+                onVideoPlayFromTime={onVideoPlayFromTime}
+              />
+
+              <aside className="hidden lg:flex lg:col-span-1 flex-col min-h-0">
+                <ChatPanel
+                  groupId={groupId ?? undefined}
+                  onVideoPlay={onVideoPlayFromTime}
+                  className="flex-1 min-h-0 shadow-[0_4px_20px_rgba(28,25,23,0.04)]"
+                />
+              </aside>
+            </div>
+          </main>
+
+          <GroupMobileNav mobileTab={mobileTab} onChange={onMobileTabChange} />
+
+          <AddVideosDialog
+            isOpen={isAddModalOpen}
+            onOpenChange={onOpenAddModalChange}
+            groupId={groupId}
+            group={group}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/video/group-detail/VideoGroupDetailView.tsx
+++ b/frontend/src/components/video/group-detail/VideoGroupDetailView.tsx
@@ -8,7 +8,6 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
-  type SensorDescriptor,
 } from '@dnd-kit/core';
 import {
   SortableContext,
@@ -60,8 +59,7 @@ import {
   useAddVideosToGroupMutation,
 } from '@/hooks/useVideoGroupDetailData';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const MOBILE_SENSORS: SensorDescriptor<any>[] = [];
+const MOBILE_SENSORS: ReturnType<typeof useSensors> = [];
 
 type MobileTab = 'videos' | 'player';
 
@@ -107,7 +105,7 @@ interface VideoGroupDetailViewProps {
   onRemoveVideo: (videoId: number) => Promise<void> | void;
   onDragEnd: (event: DragEndEvent) => Promise<void> | void;
   onVideoCanPlay: () => void;
-  onVideoPlayFromTime: (videoId: number, seconds: number) => void;
+  onVideoPlayFromTime: (videoId: number, startTime: string) => void;
   onGenerateShareLink: (shareSlug: string) => Promise<void> | void;
   onDeleteShareLink: () => void;
   onCopyShareLink: () => void;
@@ -593,7 +591,7 @@ function GroupVideoList({
   isDeleting: boolean;
   isMobile: boolean;
   mobileTab: MobileTab;
-  sensors: SensorDescriptor[];
+  sensors: ReturnType<typeof useSensors>;
   onOpenAdd: () => void;
   onStartEditing: () => void;
   onDeleteGroup: () => void;
@@ -691,7 +689,7 @@ function GroupPlayerPanel({
   videoRef: RefObject<HTMLVideoElement | null>;
   youtubeStartSeconds: number | null;
   onVideoCanPlay: () => void;
-  onVideoPlayFromTime: (videoId: number, seconds: number) => void;
+  onVideoPlayFromTime: (videoId: number, startTime: string) => void;
 }) {
   const { t } = useTranslation();
 

--- a/frontend/src/lib/transcript/__tests__/srt.test.ts
+++ b/frontend/src/lib/transcript/__tests__/srt.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { filterTranscriptSegments, isSrtFormat, parseSrtTranscript } from '../srt';
+
+describe('parseSrtTranscript', () => {
+  it('parses SRT blocks into seekable transcript segments', () => {
+    const srt = [
+      '1',
+      '00:00:01,250 --> 00:00:03,000',
+      'Hello',
+      'world',
+      '',
+      '2',
+      '00:01:02.500 --> 00:01:04.000',
+      'Second segment',
+    ].join('\n');
+
+    expect(parseSrtTranscript(srt)).toEqual([
+      { timestamp: '00:00:01', seconds: 1, text: 'Hello world' },
+      { timestamp: '00:01:02', seconds: 62, text: 'Second segment' },
+    ]);
+  });
+
+  it('ignores malformed or empty caption blocks', () => {
+    const srt = [
+      'not a caption',
+      '',
+      '2',
+      '00:00:10,000 --> 00:00:12,000',
+      '',
+      '3',
+      '00:00:13,000 --> 00:00:15,000',
+      'Valid caption',
+    ].join('\n');
+
+    expect(parseSrtTranscript(srt)).toEqual([
+      { timestamp: '00:00:13', seconds: 13, text: 'Valid caption' },
+    ]);
+  });
+});
+
+describe('isSrtFormat', () => {
+  it('detects SRT timing lines with comma or dot millisecond separators', () => {
+    expect(isSrtFormat('00:00:01,000 --> 00:00:02,000\nText')).toBe(true);
+    expect(isSrtFormat('00:00:01.000 --> 00:00:02.000\nText')).toBe(true);
+    expect(isSrtFormat('plain transcript')).toBe(false);
+  });
+});
+
+describe('filterTranscriptSegments', () => {
+  const segments = [
+    { timestamp: '00:00:01', seconds: 1, text: 'Opening remarks' },
+    { timestamp: '00:00:05', seconds: 5, text: 'Deep dive into React patterns' },
+  ];
+
+  it('returns all segments for blank queries', () => {
+    expect(filterTranscriptSegments(segments, '  ')).toEqual(segments);
+  });
+
+  it('filters segments case-insensitively by text', () => {
+    expect(filterTranscriptSegments(segments, 'react')).toEqual([segments[1]]);
+  });
+});

--- a/frontend/src/lib/transcript/srt.ts
+++ b/frontend/src/lib/transcript/srt.ts
@@ -1,0 +1,55 @@
+export interface TranscriptSegment {
+  timestamp: string;
+  seconds: number;
+  text: string;
+}
+
+export function isSrtFormat(text: string): boolean {
+  return /\d{2}:\d{2}:\d{2}[,.]\d{3}\s*-->\s*\d{2}:\d{2}:\d{2}[,.]\d{3}/.test(text);
+}
+
+export function parseSrtTranscript(srt: string): TranscriptSegment[] {
+  const segments: TranscriptSegment[] = [];
+  const blocks = srt.trim().split(/\n\s*\n/);
+
+  for (const block of blocks) {
+    const lines = block.trim().split('\n');
+    const timingLine = lines.find((line) => line.includes('-->'));
+    if (!timingLine) continue;
+
+    const match = timingLine.match(/(\d{2}):(\d{2}):(\d{2})[,.](\d{3})/);
+    if (!match) continue;
+
+    const hours = Number.parseInt(match[1], 10);
+    const minutes = Number.parseInt(match[2], 10);
+    const secondsPart = Number.parseInt(match[3], 10);
+    const seconds = hours * 3600 + minutes * 60 + secondsPart;
+    const timestamp = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(secondsPart).padStart(2, '0')}`;
+
+    const timingLineIndex = lines.indexOf(timingLine);
+    const text = lines
+      .slice(timingLineIndex + 1)
+      .filter((line) => !/^\d+$/.test(line.trim()))
+      .join(' ')
+      .trim();
+
+    if (text) {
+      segments.push({ timestamp, seconds, text });
+    }
+  }
+
+  return segments;
+}
+
+export function filterTranscriptSegments(
+  segments: TranscriptSegment[],
+  query: string,
+): TranscriptSegment[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return segments;
+  }
+  return segments.filter((segment) =>
+    segment.text.toLowerCase().includes(normalizedQuery),
+  );
+}

--- a/frontend/src/lib/video/embed.ts
+++ b/frontend/src/lib/video/embed.ts
@@ -1,0 +1,6 @@
+export function buildYoutubeEmbedSrc(embedUrl: string, startSeconds: number | null): string {
+  if (startSeconds === null) {
+    return embedUrl;
+  }
+  return `${embedUrl}?autoplay=1&start=${startSeconds}`;
+}

--- a/frontend/src/pages/VideoDetailPage.tsx
+++ b/frontend/src/pages/VideoDetailPage.tsx
@@ -1,90 +1,19 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Link, useI18nNavigate, useLocale } from '@/lib/i18n';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useVideo } from '@/hooks/useVideos';
+import { useI18nNavigate } from '@/lib/i18n';
 import { apiClient } from '@/lib/api';
-import { LoadingSpinner } from '@/components/common/LoadingSpinner';
-import { InlineSpinner } from '@/components/common/InlineSpinner';
-import { formatDate } from '@/lib/utils/video';
-import { TagSelector } from '@/components/video/TagSelector';
-import { TagCreateDialog } from '@/components/video/TagCreateDialog';
+import { filterTranscriptSegments, isSrtFormat, parseSrtTranscript } from '@/lib/transcript/srt';
+import { invalidateAfterTranscriptEdit } from '@/lib/cacheInvalidation';
+import { useConfirm } from '@/components/common/feedback';
+import { VideoDetailView } from '@/components/video/detail/VideoDetailView';
 import { useTags } from '@/hooks/useTags';
+import { useVideo } from '@/hooks/useVideos';
 import { useVideoEditing } from '@/hooks/useVideoEditing';
 import { useVideoDetailPageMutations } from '@/hooks/useVideoDetailPageData';
-import { invalidateAfterTranscriptEdit } from '@/lib/cacheInvalidation';
-import { AppNav } from '@/components/layout/AppNav';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { useConfirm } from '@/components/common/feedback';
-import {
-  ArrowLeft, Calendar, CheckCircle, Search,
-  Trash2, Pencil, X, Save, Video as VideoIcon,
-  Play, AlignLeft,
-} from 'lucide-react';
 
-// ── Transcript parser ─────────────────────────────────────────────────────────
-
-interface TranscriptSegment {
-  timestamp: string;
-  seconds: number;
-  text: string;
-}
-
-function buildYoutubeEmbedSrc(embedUrl: string, startSeconds: number | null): string {
-  if (startSeconds === null) {
-    return embedUrl;
-  }
-  return `${embedUrl}?autoplay=1&start=${startSeconds}`;
-}
-
-function isSRTFormat(text: string): boolean {
-  return /\d{2}:\d{2}:\d{2}[,.]\d{3}\s*-->\s*\d{2}:\d{2}:\d{2}[,.]\d{3}/.test(text);
-}
-
-function parseSRTTranscript(srt: string): TranscriptSegment[] {
-  const segments: TranscriptSegment[] = [];
-  const blocks = srt.trim().split(/\n\s*\n/);
-
-  for (const block of blocks) {
-    const lines = block.trim().split('\n');
-    const timingLine = lines.find((l) => l.includes('-->'));
-    if (!timingLine) continue;
-
-    const match = timingLine.match(/(\d{2}):(\d{2}):(\d{2})[,.](\d{3})/);
-    if (!match) continue;
-
-    const h = parseInt(match[1], 10);
-    const m = parseInt(match[2], 10);
-    const s = parseInt(match[3], 10);
-    const seconds = h * 3600 + m * 60 + s;
-    const timestamp = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-
-    const timingLineIdx = lines.indexOf(timingLine);
-    const text = lines
-      .slice(timingLineIdx + 1)
-      .filter((l) => !/^\d+$/.test(l.trim()))
-      .join(' ')
-      .trim();
-
-    if (text) segments.push({ timestamp, seconds, text });
-  }
-  return segments;
-}
-
-// ── Status helpers ────────────────────────────────────────────────────────────
-
-function getStatusClassName(status: string): string {
-  switch (status) {
-    case 'completed': return 'bg-[#d3ffd5] text-[#006d30]';
-    case 'error':     return 'bg-red-100 text-red-700';
-    case 'indexing':
-    case 'processing':return 'bg-[#ffdcc3] text-[#2f1500]';
-    default:          return 'bg-gray-100 text-gray-500';
-  }
-}
-
-// ── Main page ─────────────────────────────────────────────────────────────────
+type MobileTab = 'transcript' | 'video';
 
 export default function VideoDetailPage() {
   const params = useParams<{ id: string }>();
@@ -96,7 +25,6 @@ export default function VideoDetailPage() {
   const [manualYoutubeStartSeconds, setManualYoutubeStartSeconds] = useState<number | null>(null);
   const { t } = useTranslation();
   const requestConfirmation = useConfirm();
-  const locale = useLocale();
   const queryClient = useQueryClient();
 
   const [transcriptSearch, setTranscriptSearch] = useState('');
@@ -104,7 +32,7 @@ export default function VideoDetailPage() {
   const [editedTranscript, setEditedTranscript] = useState('');
   const [transcriptSaveError, setTranscriptSaveError] = useState<string | null>(null);
   const [activeSegmentIdx, setActiveSegmentIdx] = useState<number | null>(null);
-  const [mobileTab, setMobileTab] = useState<'transcript' | 'video'>('video');
+  const [mobileTab, setMobileTab] = useState<MobileTab>('video');
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -217,18 +145,16 @@ export default function VideoDetailPage() {
     setIsTranscriptEditing(false);
   };
 
-  // Transcript parsing
   const transcript = video?.transcript ?? null;
-  const transcriptSegments = useMemo<TranscriptSegment[]>(() => {
-    if (!transcript || !isSRTFormat(transcript)) return [];
-    return parseSRTTranscript(transcript);
+  const transcriptSegments = useMemo(() => {
+    if (!transcript || !isSrtFormat(transcript)) return [];
+    return parseSrtTranscript(transcript);
   }, [transcript]);
 
-  const filteredSegments = useMemo(() => {
-    const q = transcriptSearch.trim().toLowerCase();
-    if (!q) return transcriptSegments;
-    return transcriptSegments.filter((s) => s.text.toLowerCase().includes(q));
-  }, [transcriptSegments, transcriptSearch]);
+  const filteredSegments = useMemo(
+    () => filterTranscriptSegments(transcriptSegments, transcriptSearch),
+    [transcriptSegments, transcriptSearch],
+  );
 
   const handleSeek = (seconds: number, idx: number) => {
     if (video?.source_type === 'youtube') {
@@ -240,429 +166,52 @@ export default function VideoDetailPage() {
     setActiveSegmentIdx(idx);
   };
 
-  const statusClassName = video ? getStatusClassName(video.status) : '';
-  const isPlainTextTranscript = video?.transcript?.trim() && !isSRTFormat(video.transcript ?? '');
-
-  const pipelineSteps = [
-    { key: 'upload',     label: t('videos.detail.pipeline.upload'),     doneStatuses: ['processing', 'indexing', 'completed', 'error'] },
-    { key: 'transcript', label: t('videos.detail.pipeline.transcript'), doneStatuses: ['indexing', 'completed'] },
-    { key: 'aiAnalysis', label: t('videos.detail.pipeline.aiAnalysis'), doneStatuses: ['completed'] },
-  ] as { key: string; label: string; doneStatuses: string[] }[];
+  const isPlainTextTranscript = Boolean(video?.transcript?.trim()) && !isSrtFormat(video?.transcript ?? '');
 
   return (
-    <>
-      <div
-        className="bg-[#f8faf5] flex flex-col min-h-screen"
-        style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
-      >
-        {/* ── Header ───────────────────────────────────────────────────────── */}
-        <AppNav activePage="videos" />
-
-        {/* ── Loading / error states ─────────────────────────────────────── */}
-        {isLoading ? (
-          <div className="flex-1 flex items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        ) : error && !video ? (
-          <div className="flex-1 flex flex-col items-center justify-center gap-4">
-            <p className="text-red-500">{error}</p>
-            <Link href="/videos" className="text-[#00652c] font-bold hover:underline flex items-center gap-1">
-              <ArrowLeft className="w-4 h-4" />
-              {t('common.actions.backToList')}
-            </Link>
-          </div>
-        ) : !video ? (
-          <div className="flex-1 flex items-center justify-center">
-            <p className="text-[#3f493f]">{t('common.messages.videoNotFound')}</p>
-          </div>
-        ) : (
-          <>
-        {/* ── Edit Modal ───────────────────────────────────────────────────── */}
-        <Dialog open={isEditing} onOpenChange={(open) => !open && handleCancelEdit()}>
-          <DialogContent className="max-w-md">
-            <DialogHeader>
-              <DialogTitle>{t('videos.detail.editButton')}</DialogTitle>
-              <DialogDescription>
-                {t('videos.detail.editDescriptionLabel')}
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-4 py-2">
-              {updateError && (
-                <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">{updateError}</div>
-              )}
-              <div className="space-y-1">
-                <label className="text-xs font-bold text-[#3f493f]">{t('videos.detail.editTitleLabel')}</label>
-                <input
-                  type="text"
-                  value={editedTitle}
-                  onChange={(e) => setEditedTitle(e.target.value)}
-                  disabled={isUpdating}
-                  className="w-full px-3 py-2.5 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-bold text-[#3f493f]">{t('videos.detail.editDescriptionLabel')}</label>
-                <textarea
-                  value={editedDescription}
-                  onChange={(e) => setEditedDescription(e.target.value)}
-                  disabled={isUpdating}
-                  rows={4}
-                  className="w-full px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all resize-none"
-                />
-              </div>
-              <div className="space-y-1">
-                <TagSelector
-                  tags={tags}
-                  selectedTagIds={editedTagIds}
-                  onToggle={(tagId) =>
-                    setEditedTagIds((prev) =>
-                      prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId],
-                    )
-                  }
-                  onCreateNew={() => setIsCreateDialogOpen(true)}
-                  disabled={isUpdating}
-                />
-              </div>
-            </div>
-            <DialogFooter>
-              <button
-                onClick={handleCancelEdit}
-                disabled={isUpdating}
-                className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] rounded-xl text-sm font-bold hover:bg-[#f2f4ef] transition-colors disabled:opacity-50"
-              >
-                <X className="w-3.5 h-3.5" />
-                {t('common.actions.cancel')}
-              </button>
-              <button
-                onClick={() => updateMutation.mutate()}
-                disabled={isUpdating || !editedTitle.trim()}
-                className="flex items-center gap-1.5 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
-              >
-                {isUpdating ? <InlineSpinner className="w-3.5 h-3.5" /> : <Save className="w-3.5 h-3.5" />}
-                {isUpdating ? t('common.actions.saving') : t('common.actions.save')}
-              </button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
-        {/* ── Mobile tabs ───────────────────────────────────────────────────── */}
-        {isMobile && (
-          <div className="mt-16 flex border-b border-stone-200 bg-white shrink-0">
-            <button
-              onClick={() => setMobileTab('video')}
-              className={`flex-1 flex items-center justify-center gap-2 py-3 text-sm font-semibold transition-colors ${
-                mobileTab === 'video'
-                  ? 'text-[#00652c] border-b-2 border-[#00652c]'
-                  : 'text-stone-500 hover:text-stone-700'
-              }`}
-            >
-              <Play className="w-4 h-4" />
-              {t('videos.detail.video')}
-            </button>
-            <button
-              onClick={() => setMobileTab('transcript')}
-              className={`flex-1 flex items-center justify-center gap-2 py-3 text-sm font-semibold transition-colors ${
-                mobileTab === 'transcript'
-                  ? 'text-[#00652c] border-b-2 border-[#00652c]'
-                  : 'text-stone-500 hover:text-stone-700'
-              }`}
-            >
-              <AlignLeft className="w-4 h-4" />
-              {t('videos.detail.transcriptSection')}
-            </button>
-          </div>
-        )}
-
-        {/* ── Main Content ──────────────────────────────────────────────────── */}
-        <main
-          className={`flex-grow max-w-screen-xl mx-auto w-full px-6 lg:px-8 py-6 flex flex-col gap-6 ${
-            isMobile ? 'mt-0' : 'mt-16'
-          }`}
-        >
-          <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-          {/* ── Left Column: Video + Info ──────────────────────────────────── */}
-          <div
-            className={`lg:col-span-8 flex flex-col gap-4 ${
-              isMobile && mobileTab !== 'video' ? 'hidden' : ''
-            }`}
-          >
-            {/* Video Player */}
-            <div className="w-full aspect-video bg-[#1a1c1c] rounded-xl overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
-              {video.source_type === 'youtube' && video.youtube_embed_url ? (
-                <iframe
-                  key={`${video.id}-${youtubeStartSeconds ?? 0}`}
-                  className="w-full h-full"
-                  src={buildYoutubeEmbedSrc(video.youtube_embed_url, youtubeStartSeconds)}
-                  title={video.title}
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowFullScreen
-                />
-              ) : video.file ? (
-                <video
-                  ref={videoRef}
-                  controls
-                  className="w-full h-full object-contain"
-                  src={apiClient.getVideoUrl(video.file)}
-                  onLoadedMetadata={handleVideoLoaded}
-                >
-                  {t('common.messages.browserNoVideoSupport')}
-                </video>
-              ) : (
-                <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-gray-500">
-                  <VideoIcon className="w-16 h-16 text-gray-600" />
-                  <p className="text-sm">{t('common.messages.videoFileMissing')}</p>
-                </div>
-              )}
-            </div>
-
-            {/* Info Card */}
-            <div className="bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] p-6 flex flex-col gap-4">
-              {/* Title + Status */}
-              <div className="flex justify-between items-start gap-4">
-                <div>
-                  <h1 className="font-bold text-xl text-[#191c19] leading-tight mb-1">
-                    {video.title}
-                  </h1>
-                  <div className="flex items-center gap-2 text-sm text-[#6f7a6e]">
-                    <Calendar className="w-3.5 h-3.5 shrink-0" />
-                    <span>{formatDate(video.uploaded_at, 'full', locale)}</span>
-                  </div>
-                </div>
-                <span className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-bold ${statusClassName}`}>
-                  {video.status === 'completed' && <CheckCircle className="w-3 h-3" />}
-                  {t(`common.status.${video.status}`, video.status)}
-                </span>
-              </div>
-
-              {/* Tags */}
-              {video.tags && video.tags.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {video.tags.map((tag) => (
-                    <span
-                      key={tag.id}
-                      className="px-3 py-1 rounded-full text-[11px] font-bold uppercase"
-                      style={{ backgroundColor: `${tag.color}20`, color: tag.color }}
-                    >
-                      {tag.name}
-                    </span>
-                  ))}
-                </div>
-              )}
-
-              {/* Status Pipeline (horizontal) */}
-              <div className="border-t border-[#e1e3de]/50 pt-4 flex items-center gap-3 flex-wrap">
-                <span className="text-xs font-bold text-[#6f7a6e] uppercase tracking-widest shrink-0">
-                  {t('videos.detail.statusSection')}
-                </span>
-                {pipelineSteps.map(({ key, label, doneStatuses }, idx) => {
-                  const done = doneStatuses.includes(video.status);
-                  return (
-                    <div key={key} className="flex items-center gap-2">
-                      {idx > 0 && <div className="w-6 h-px bg-[#e1e3de]" />}
-                      <div className="flex items-center gap-1.5">
-                        <div
-                          className={`w-5 h-5 rounded-full flex items-center justify-center shrink-0 ${
-                            done ? 'bg-[#15803d]' : 'bg-[#e1e3de]'
-                          }`}
-                        >
-                          {done ? (
-                            <CheckCircle className="w-3 h-3 text-white" />
-                          ) : (
-                            <div className="w-1.5 h-1.5 rounded-full bg-[#becabc]" />
-                          )}
-                        </div>
-                        <span className={`text-xs font-semibold ${done ? 'text-[#191c19]' : 'text-[#becabc]'}`}>
-                          {label}
-                        </span>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-
-              {/* Video error message */}
-              {video.error_message && (
-                <div className="p-3 bg-red-50 border border-red-200 rounded-xl">
-                  <p className="text-xs text-red-700 leading-relaxed">{video.error_message}</p>
-                </div>
-              )}
-
-              {/* Description */}
-              {video.description && (
-                <div className="border-t border-[#e1e3de]/50 pt-4">
-                  <p className="text-sm text-[#3f493f] leading-relaxed">{video.description}</p>
-                </div>
-              )}
-
-              {/* Delete error */}
-              {deleteError && (
-                <div className="p-3 bg-red-50 border border-red-200 rounded-xl">
-                  <p className="text-xs text-red-700 leading-relaxed">{deleteError}</p>
-                </div>
-              )}
-
-              {/* Actions */}
-              <div className="border-t border-[#e1e3de]/50 pt-4 flex items-center gap-2">
-                <button
-                  onClick={startEditing}
-                  className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] text-[#3f493f] text-sm font-bold rounded-xl hover:bg-[#f2f4ef] transition-colors"
-                >
-                  <Pencil className="w-3.5 h-3.5" />
-                  {t('videos.detail.editButton')}
-                </button>
-                <button
-                  onClick={handleDeleteVideo}
-                  disabled={isDeleting}
-                  className="flex items-center gap-1.5 px-4 py-2 text-red-600 text-sm font-bold rounded-xl hover:bg-red-50 transition-colors disabled:opacity-50"
-                >
-                  {isDeleting ? <InlineSpinner className="w-3.5 h-3.5" /> : <Trash2 className="w-3.5 h-3.5" />}
-                  {isDeleting ? t('common.actions.deleting') : t('videos.detail.deleteButton')}
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* ── Right Column: Transcript ───────────────────────────────────── */}
-          <div
-            className={`lg:col-span-4 flex flex-col bg-white rounded-xl shadow-[0_4px_20px_rgba(28,25,23,0.04)] ${
-              isMobile ? 'min-h-[500px]' : 'h-[calc(100vh-64px)] sticky top-16'
-            } ${isMobile && mobileTab !== 'transcript' ? 'hidden' : ''}`}
-          >
-            {/* Transcript Header */}
-            <div className="p-4 border-b border-stone-100 flex flex-col gap-3 shrink-0">
-              <div className="flex justify-between items-center">
-                <h2 className="font-extrabold text-[#191c19]">{t('videos.detail.transcriptSection')}</h2>
-                {!isTranscriptEditing && (
-                  <button
-                    type="button"
-                    onClick={startTranscriptEditing}
-                    disabled={!video.transcript}
-                    className="inline-flex items-center gap-1.5 rounded-xl border border-[#e1e3de] bg-white px-3 py-1.5 text-xs font-bold text-[#3f493f] shadow-sm transition-colors hover:bg-[#f8faf5] disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    <Pencil className="h-3.5 w-3.5" />
-                    {t('videos.detail.editTranscriptButton')}
-                  </button>
-                )}
-              </div>
-              {/* Search Bar */}
-              {!isTranscriptEditing && (
-                <div className="relative w-full">
-                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-[#6f7a6e] w-3.5 h-3.5" />
-                  <input
-                    type="text"
-                    value={transcriptSearch}
-                    onChange={(e) => setTranscriptSearch(e.target.value)}
-                    placeholder={t('videos.detail.transcriptSearchPlaceholder')}
-                    className="w-full h-9 pl-9 pr-3 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:outline-none focus:border-[#00652c] focus:ring-2 focus:ring-[#00652c]/20 transition-all placeholder:text-[#3f493f]/60"
-                  />
-                </div>
-              )}
-            </div>
-
-            {/* Transcript Body */}
-            {isTranscriptEditing ? (
-              <div className="flex-1 overflow-hidden flex flex-col">
-                <div className="flex shrink-0 flex-col gap-3 border-b border-stone-100 bg-[#f8faf5] p-3 lg:flex-row lg:items-center lg:justify-between">
-                  <div className="flex shrink-0 gap-2">
-                    <button
-                      type="button"
-                      onClick={cancelTranscriptEditing}
-                      disabled={transcriptUpdateMutation.isPending}
-                      className="rounded-xl border border-[#e1e3de] bg-white px-3 py-1.5 text-xs font-bold text-[#3f493f] transition-colors hover:bg-[#f8faf5] disabled:opacity-50"
-                    >
-                      {t('videos.detail.cancel')}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => transcriptUpdateMutation.mutate()}
-                      disabled={transcriptUpdateMutation.isPending}
-                      className="inline-flex items-center justify-center gap-1.5 rounded-xl bg-[#00652c] px-3 py-1.5 text-xs font-bold text-white transition-colors hover:bg-[#005323] disabled:opacity-50"
-                    >
-                      {transcriptUpdateMutation.isPending ? <InlineSpinner className="h-3 w-3" /> : <Save className="h-3 w-3" />}
-                      {transcriptUpdateMutation.isPending ? t('videos.detail.saving') : t('videos.detail.saveTranscriptButton')}
-                    </button>
-                  </div>
-                </div>
-                {transcriptSaveError && (
-                  <p className="shrink-0 px-3 py-2 text-xs text-red-700 bg-red-50 border-b border-red-200">
-                    {transcriptSaveError}
-                  </p>
-                )}
-                <textarea
-                  value={editedTranscript}
-                  onChange={(event) => setEditedTranscript(event.target.value)}
-                  disabled={transcriptUpdateMutation.isPending}
-                  spellCheck={false}
-                  className="min-h-0 flex-1 resize-none border-0 bg-white p-4 font-mono text-xs leading-relaxed text-[#191c19] outline-none focus:ring-2 focus:ring-inset focus:ring-[#00652c]/20 disabled:opacity-60"
-                />
-              </div>
-            ) : (
-              <div className="flex-1 overflow-y-auto p-2 flex flex-col gap-1">
-                {filteredSegments.length > 0 ? (
-                  filteredSegments.map((seg, idx) => (
-                    <div
-                      key={idx}
-                      onClick={() => handleSeek(seg.seconds, idx)}
-                      className={`flex gap-4 p-3 rounded-xl cursor-pointer transition-all group ${
-                        activeSegmentIdx === idx
-                          ? 'bg-[#f0fdf4] border-l-4 border-[#00652c]'
-                          : 'hover:bg-stone-50'
-                      }`}
-                    >
-                      <span className="text-[#00652c] font-mono text-[11px] mt-0.5 shrink-0 bg-[#00652c]/8 px-2 py-0.5 rounded-lg h-fit whitespace-nowrap font-semibold">
-                        {seg.timestamp}
-                      </span>
-                      <p
-                        className={`text-sm leading-relaxed ${
-                          activeSegmentIdx === idx
-                            ? 'text-[#191c19] font-medium'
-                            : 'text-[#3f493f] group-hover:text-[#191c19]'
-                        }`}
-                      >
-                        {seg.text}
-                      </p>
-                    </div>
-                  ))
-                ) : isPlainTextTranscript ? (
-                  <div className="p-4 bg-white rounded-xl">
-                    <p className="text-sm text-[#3f493f] whitespace-pre-wrap leading-relaxed">
-                      {video.transcript}
-                    </p>
-                  </div>
-                ) : (
-                  <div className="flex flex-col items-center justify-center py-16 text-[#6f7a6e]">
-                    <div className="w-16 h-16 bg-[#f2f4ef] rounded-full flex items-center justify-center mb-4">
-                      <Search className="w-8 h-8 text-[#becabc]" />
-                    </div>
-                    <p className="text-sm font-medium text-center px-4">
-                      {transcriptSearch
-                        ? t('videos.detail.transcriptNotFound')
-                        : (() => {
-                            const statusMsgs: Record<string, string> = {
-                              pending: t('videos.detail.transcriptStatus.pending'),
-                              processing: t('videos.detail.transcriptStatus.processing'),
-                              indexing: t('videos.detail.transcriptStatus.indexing'),
-                              error: t('videos.detail.transcriptStatus.error'),
-                            };
-                            return statusMsgs[video.status] ?? t('videos.detail.transcriptStatus.unavailable');
-                          })()}
-                    </p>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-          </div>
-        </main>
-
-        <TagCreateDialog
-          isOpen={isCreateDialogOpen}
-          onClose={() => setIsCreateDialogOpen(false)}
-          onCreate={handleCreateTag}
-        />
-          </>
-        )}
-      </div>
-    </>
+    <VideoDetailView
+      video={video}
+      isLoading={isLoading}
+      error={error}
+      videoRef={videoRef}
+      youtubeStartSeconds={youtubeStartSeconds}
+      onVideoLoaded={handleVideoLoaded}
+      isMobile={isMobile}
+      mobileTab={mobileTab}
+      onMobileTabChange={setMobileTab}
+      tags={tags}
+      isCreateDialogOpen={isCreateDialogOpen}
+      onCreateDialogOpenChange={setIsCreateDialogOpen}
+      onCreateTag={handleCreateTag}
+      isEditing={isEditing}
+      editedTitle={editedTitle}
+      editedDescription={editedDescription}
+      editedTagIds={editedTagIds}
+      onEditedTitleChange={setEditedTitle}
+      onEditedDescriptionChange={setEditedDescription}
+      onEditedTagIdsChange={setEditedTagIds}
+      onStartEditing={startEditing}
+      onCancelEdit={handleCancelEdit}
+      onUpdateVideo={() => updateMutation.mutate()}
+      isUpdating={isUpdating}
+      updateError={updateError}
+      deleteError={deleteError}
+      isDeleting={isDeleting}
+      onDeleteVideo={handleDeleteVideo}
+      transcriptSearch={transcriptSearch}
+      onTranscriptSearchChange={setTranscriptSearch}
+      isTranscriptEditing={isTranscriptEditing}
+      onStartTranscriptEditing={startTranscriptEditing}
+      onCancelTranscriptEditing={cancelTranscriptEditing}
+      editedTranscript={editedTranscript}
+      onEditedTranscriptChange={setEditedTranscript}
+      onSaveTranscript={() => transcriptUpdateMutation.mutate()}
+      isTranscriptSaving={transcriptUpdateMutation.isPending}
+      transcriptSaveError={transcriptSaveError}
+      filteredSegments={filteredSegments}
+      activeSegmentIdx={activeSegmentIdx}
+      onSeek={handleSeek}
+      isPlainTextTranscript={isPlainTextTranscript}
+    />
   );
 }

--- a/frontend/src/pages/VideoGroupDetailPage.tsx
+++ b/frontend/src/pages/VideoGroupDetailPage.tsx
@@ -1,434 +1,21 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-  type SensorDescriptor,
-} from '@dnd-kit/core';
-import { TagManagementModal } from '@/components/video/TagManagementModal';
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-  useSortable,
-} from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
-
-import { apiClient, type VideoGroup, type VideoInGroup } from '@/lib/api';
-import { ChatPanel } from '@/components/chat/ChatPanel';
-import { DashboardButton } from '@/components/dashboard/DashboardButton';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Checkbox } from '@/components/ui/checkbox';
-import { LoadingSpinner } from '@/components/common/LoadingSpinner';
-import { InlineSpinner } from '@/components/common/InlineSpinner';
-import { Link, useI18nNavigate } from '@/lib/i18n';
+import { arrayMove } from '@dnd-kit/sortable';
+import type { DragEndEvent } from '@dnd-kit/core';
+import { useI18nNavigate } from '@/lib/i18n';
 import { handleAsyncError } from '@/lib/utils/errorHandling';
 import { convertVideoInGroupToSelectedVideo, type SelectedVideo } from '@/lib/utils/videoConversion';
 import { useAuth } from '@/hooks/useAuth';
-import { useTags } from '@/hooks/useTags';
 import { useShareLink } from '@/hooks/useShareLink';
 import { useVideoPlayback } from '@/hooks/useVideoPlayback';
 import { useMobileTab } from '@/hooks/useMobileTab';
 import {
-  useAddableVideosQuery,
-  useAddVideosToGroupMutation,
   useVideoGroupDetailMutations,
   useVideoGroupDetailQuery,
 } from '@/hooks/useVideoGroupDetailData';
-import { TagFilterPanel } from '@/components/video/TagFilterPanel';
-import { AppNav } from '@/components/layout/AppNav';
-import { useConfirm, useToast } from '@/components/common/feedback';
-import {
-  ArrowLeft, Plus, GripVertical,
-  CheckCircle, Clock, AlertCircle, Copy, Trash2,
-  Pencil, List, Play,
-  Save, X,
-} from 'lucide-react';
-
-function buildYoutubeEmbedSrc(embedUrl: string, startSeconds: number | null): string {
-  if (startSeconds === null) {
-    return embedUrl;
-  }
-  return `${embedUrl}?autoplay=1&start=${startSeconds}`;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const MOBILE_SENSORS: SensorDescriptor<any>[] = [];
-
-type MobileTab = 'videos' | 'player';
-
-const ORDERING_OPTIONS = [
-  'uploaded_at_desc',
-  'uploaded_at_asc',
-  'title_asc',
-  'title_desc',
-] as const;
-type OrderingOption = (typeof ORDERING_OPTIONS)[number];
-
-// ── Status badge ─────────────────────────────────────────────────────────────
-
-function VideoStatusBadge({ status }: { status: string }) {
-  const { t } = useTranslation();
-  if (status === 'completed') {
-    return (
-      <span className="inline-flex items-center gap-0.5 text-[10px] font-bold text-[#00652c] mt-1">
-        <CheckCircle className="w-3 h-3 fill-current" />
-        {t('videos.groupDetail.status.completed')}
-      </span>
-    );
-  }
-  if (status === 'error') {
-    return (
-      <span className="inline-flex items-center gap-0.5 text-[10px] font-bold text-red-500 mt-1">
-        <AlertCircle className="w-3 h-3" />
-        {t('videos.groupDetail.status.error')}
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center gap-0.5 text-[10px] font-bold text-[#904d00] bg-[#ffdcc3]/40 px-1.5 py-0.5 rounded-full mt-1">
-      <Clock className="w-3 h-3" />
-      {t('videos.groupDetail.status.processing')}
-    </span>
-  );
-}
-
-// ── Sortable video item ───────────────────────────────────────────────────────
-
-interface SortableVideoItemProps {
-  video: VideoInGroup;
-  isSelected: boolean;
-  onSelect: (videoId: number) => void;
-  onRemove: (videoId: number) => void;
-  isMobile?: boolean;
-}
-
-function SortableVideoItem({ video, isSelected, onSelect, onRemove, isMobile = false }: SortableVideoItemProps) {
-  const { t } = useTranslation();
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: video.id,
-    disabled: isMobile,
-  });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-  };
-
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      onClick={() => onSelect(video.id)}
-      className={`flex items-center gap-2 p-3 rounded-xl cursor-pointer group transition-colors ${
-        isSelected
-          ? 'bg-[#f0fdf4] border-l-4 border-[#00652c]'
-          : 'hover:bg-stone-50'
-      } ${isDragging ? 'shadow-lg z-50' : ''}`}
-    >
-      {!isMobile && (
-        <span
-          {...attributes}
-          {...listeners}
-          onClick={(e) => e.stopPropagation()}
-          className="text-stone-300 cursor-grab active:cursor-grabbing shrink-0"
-        >
-          <GripVertical className="w-4 h-4" />
-        </span>
-      )}
-      <div className="flex-1 min-w-0">
-        <p className={`text-sm truncate leading-tight ${isSelected ? 'font-bold text-[#00652c]' : 'font-medium text-[#191c19]'}`}>
-          {video.title}
-        </p>
-        <VideoStatusBadge status={video.status} />
-      </div>
-      <button
-        onClick={(e) => { e.stopPropagation(); onRemove(video.id); }}
-        onPointerDown={(e) => e.stopPropagation()}
-        onMouseDown={(e) => e.stopPropagation()}
-        aria-label={t('videos.groupDetail.removeFromGroup')}
-        className="inline-flex items-center rounded-lg p-1.5 text-red-600 hover:bg-red-50 transition-colors shrink-0"
-      >
-        <Trash2 className="w-3.5 h-3.5" />
-      </button>
-    </div>
-  );
-}
-
-// ── Share link panel ──────────────────────────────────────────────────────────
-
-interface ShareLinkPanelProps {
-  shareSlug: string;
-  shareLink: string | null;
-  isGeneratingLink: boolean;
-  isCopied: boolean;
-  onGenerate: (shareSlug: string) => Promise<void> | void;
-  onDelete: () => void;
-  onCopy: () => void;
-}
-
-function ShareLinkPanel({ shareSlug, shareLink, isGeneratingLink, isCopied, onGenerate, onDelete, onCopy }: ShareLinkPanelProps) {
-  const { t } = useTranslation();
-  const [inputValue, setInputValue] = useState(shareSlug);
-
-  useEffect(() => {
-    setInputValue(shareSlug);
-  }, [shareSlug]);
-
-  return (
-    <div className="bg-white rounded-xl p-4 flex flex-col lg:flex-row lg:items-center gap-3 lg:gap-4 shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
-      <div className="flex-1 min-w-0 space-y-2">
-        <div className="flex flex-col lg:flex-row lg:items-center gap-2 lg:gap-3">
-          <div className="flex-1 bg-[#f2f4ef] rounded-xl px-4 py-2 border border-[#e1e3de]/40 min-w-0">
-            <input
-              type="text"
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              placeholder={t('videos.groupDetail.shareSlugPlaceholder')}
-              className="w-full bg-transparent text-[#3f493f] text-sm outline-none"
-            />
-          </div>
-          <p className="text-xs text-[#6f7a6e] whitespace-nowrap">
-            {t('videos.groupDetail.shareSlugHelp')}
-          </p>
-        </div>
-        <div className="flex flex-col lg:flex-row lg:items-center gap-2 lg:gap-3">
-          <span className="text-sm font-bold text-[#3f493f] whitespace-nowrap shrink-0">
-            {t('videos.groupDetail.shareLinkLabel')}
-          </span>
-          {shareLink ? (
-            <div className="flex-1 min-w-0 bg-white rounded-xl px-4 py-2 border border-[#e1e3de]/40">
-              <input
-                type="text"
-                value={shareLink}
-                readOnly
-                className="w-full bg-transparent text-[#6f7a6e] text-sm outline-none cursor-default"
-              />
-            </div>
-          ) : (
-            <p className="text-sm text-[#6f7a6e]">{t('videos.groupDetail.share.disabled')}</p>
-          )}
-        </div>
-      </div>
-      <div className="flex items-center gap-2 shrink-0 self-start lg:self-center">
-        {shareLink && (
-          <button
-            onClick={onCopy}
-            className="flex items-center gap-2 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity"
-          >
-            <Copy className="w-3.5 h-3.5" />
-            {isCopied ? t('videos.groupDetail.copied') : t('videos.groupDetail.copyButton')}
-          </button>
-        )}
-        <button
-          onClick={() => { void onGenerate(inputValue); }}
-          disabled={isGeneratingLink || !inputValue.trim()}
-          className="flex items-center gap-2 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0"
-        >
-          {isGeneratingLink ? <InlineSpinner className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
-          {isGeneratingLink ? t('videos.groupDetail.generating') : t('common.actions.save')}
-        </button>
-        {shareLink && (
-          <button
-            onClick={onDelete}
-            className="px-4 py-2 text-red-600 text-sm font-bold hover:bg-red-50 rounded-xl transition-colors"
-          >
-            {t('videos.groupDetail.disable')}
-          </button>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ── Add videos dialog ─────────────────────────────────────────────────────────
-
-interface AddVideosDialogProps {
-  isOpen: boolean;
-  onOpenChange: (open: boolean) => void;
-  groupId: number | null;
-  group: VideoGroup | null;
-  onVideosAdded?: () => void;
-}
-
-function AddVideosDialog({ isOpen, onOpenChange, groupId, group, onVideosAdded }: AddVideosDialogProps) {
-  const { t } = useTranslation();
-  const toast = useToast();
-  const { tags } = useTags();
-
-  const [videoSearchInput, setVideoSearchInput] = useState('');
-  const [videoSearch, setVideoSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string>('');
-  const [ordering, setOrdering] = useState<OrderingOption>('uploaded_at_desc');
-  const [selectedVideos, setSelectedVideos] = useState<number[]>([]);
-  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
-  const [isTagManagementOpen, setIsTagManagementOpen] = useState(false);
-
-  const handleOrderingChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = event.target.value as OrderingOption;
-    if (ORDERING_OPTIONS.includes(value)) setOrdering(value);
-  }, []);
-
-  const handleTagToggle = useCallback((tagId: number) => {
-    setSelectedTagIds((prev) =>
-      prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId]
-    );
-  }, []);
-
-  const handleTagClear = useCallback(() => setSelectedTagIds([]), []);
-
-  useEffect(() => {
-    const handler = setTimeout(() => setVideoSearch(videoSearchInput), 300);
-    return () => clearTimeout(handler);
-  }, [videoSearchInput]);
-
-  const availableVideosQuery = useAddableVideosQuery({
-    isOpen, groupId, group,
-    q: videoSearch.trim(), status: statusFilter, ordering, tagIds: selectedTagIds,
-  });
-
-  const availableVideos = availableVideosQuery.data ?? [];
-  const isLoadingVideos = availableVideosQuery.isLoading || availableVideosQuery.isFetching;
-
-  const addVideosMutation = useAddVideosToGroupMutation(groupId, onVideosAdded);
-
-  const handleAddVideos = async () => {
-    if (!groupId || selectedVideos.length === 0) return;
-    try {
-      const result = await addVideosMutation.mutateAsync(selectedVideos);
-      onOpenChange(false);
-      setSelectedVideos([]);
-      if (result.skipped_count > 0) {
-        toast({
-          message: t('videos.groupDetail.addResult', { added: result.added_count, skipped: result.skipped_count }),
-          variant: 'info',
-        });
-      }
-    } catch (err) {
-      handleAsyncError(err, t('videos.groupDetail.addError'), () => {});
-    }
-  };
-
-  return (
-    <>
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-[95vw] lg:max-w-2xl max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>{t('videos.groupDetail.addVideos')}</DialogTitle>
-            <DialogDescription>
-              {t('videos.groupDetail.addVideosDescription', 'Select videos to add to this group.')}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4 py-4">
-            <div className="flex flex-wrap items-center gap-2">
-              <input
-                placeholder={t('videos.groupDetail.searchPlaceholder')}
-                value={videoSearchInput}
-                onChange={(e) => setVideoSearchInput(e.target.value)}
-                className="w-full md:w-1/2 px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm outline-none focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c]"
-              />
-              <select
-                value={statusFilter}
-                onChange={(e) => setStatusFilter(e.target.value)}
-                className="px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm outline-none"
-              >
-                <option value="">{t('videos.groupDetail.statusFilter.all')}</option>
-                <option value="completed">{t('videos.groupDetail.statusFilter.completed')}</option>
-                <option value="processing">{t('videos.groupDetail.statusFilter.processing')}</option>
-                <option value="indexing">{t('videos.groupDetail.statusFilter.indexing')}</option>
-                <option value="pending">{t('videos.groupDetail.statusFilter.pending')}</option>
-                <option value="error">{t('videos.groupDetail.statusFilter.error')}</option>
-              </select>
-              <select
-                value={ordering}
-                onChange={handleOrderingChange}
-                className="px-3 py-2 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm outline-none"
-              >
-                <option value="uploaded_at_desc">{t('videos.groupDetail.ordering.uploadedDesc')}</option>
-                <option value="uploaded_at_asc">{t('videos.groupDetail.ordering.uploadedAsc')}</option>
-                <option value="title_asc">{t('videos.groupDetail.ordering.titleAsc')}</option>
-                <option value="title_desc">{t('videos.groupDetail.ordering.titleDesc')}</option>
-              </select>
-              <button
-                onClick={() => setSelectedVideos(availableVideos?.map((v) => v.id) ?? [])}
-                disabled={!availableVideos?.length}
-                className="px-3 py-2 border border-[#e1e3de] rounded-xl text-sm font-medium hover:bg-[#f2f4ef] disabled:opacity-40"
-              >
-                {t('videos.groupDetail.selectAll')}
-              </button>
-              <button
-                onClick={() => setSelectedVideos([])}
-                disabled={selectedVideos.length === 0}
-                className="px-3 py-2 border border-[#e1e3de] rounded-xl text-sm font-medium hover:bg-[#f2f4ef] disabled:opacity-40"
-              >
-                {t('videos.groupDetail.clearSelection')}
-              </button>
-            </div>
-            <TagFilterPanel
-              tags={tags}
-              selectedTagIds={selectedTagIds}
-              onToggle={handleTagToggle}
-              onClear={handleTagClear}
-              onManageTags={() => setIsTagManagementOpen(true)}
-              disabled={isLoadingVideos}
-            />
-            {isLoadingVideos ? (
-              <div className="flex justify-center py-8"><LoadingSpinner /></div>
-            ) : availableVideos.length === 0 ? (
-              <p className="text-center text-[#6f7a6e] py-8">{t('videos.groupDetail.noAvailableVideos')}</p>
-            ) : (
-              <div className="space-y-2 max-h-[400px] overflow-y-auto">
-                {availableVideos.map((v) => (
-                  <div key={v.id} className="flex items-center gap-3 p-3 border border-[#e1e3de] rounded-xl hover:bg-[#f2f4ef] transition-colors">
-                    <Checkbox
-                      id={`video-${v.id}`}
-                      checked={selectedVideos.includes(v.id)}
-                      onCheckedChange={(checked: boolean | 'indeterminate') => {
-                        if (checked === true) setSelectedVideos([...selectedVideos, v.id]);
-                        else if (checked === false) setSelectedVideos(selectedVideos.filter((id) => id !== v.id));
-                      }}
-                    />
-                    <label htmlFor={`video-${v.id}`} className="flex-1 cursor-pointer">
-                      <div className="text-sm font-medium text-[#191c19]">{v.title}</div>
-                      <div className="text-xs text-[#6f7a6e]">{v.description || t('common.messages.noDescription')}</div>
-                    </label>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-          <DialogFooter>
-            <button
-              onClick={() => onOpenChange(false)}
-              className="px-4 py-2 border border-[#e1e3de] rounded-xl text-sm font-bold hover:bg-[#f2f4ef] transition-colors"
-            >
-              {t('common.actions.cancel')}
-            </button>
-            <button
-              onClick={handleAddVideos}
-              disabled={addVideosMutation.isPending || selectedVideos.length === 0}
-              className="flex items-center gap-2 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
-            >
-              {addVideosMutation.isPending && <InlineSpinner className="w-3.5 h-3.5" />}
-              {addVideosMutation.isPending ? t('videos.groupDetail.adding') : t('videos.groupDetail.add')}
-            </button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      <TagManagementModal isOpen={isTagManagementOpen} onClose={() => setIsTagManagementOpen(false)} />
-    </>
-  );
-}
-
-// ── Main page ─────────────────────────────────────────────────────────────────
+import { useConfirm } from '@/components/common/feedback';
+import { VideoGroupDetailView } from '@/components/video/group-detail/VideoGroupDetailView';
 
 export default function VideoGroupDetailPage() {
   const params = useParams<{ id: string }>();
@@ -445,23 +32,14 @@ export default function VideoGroupDetailPage() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [selectedVideoId, setSelectedVideoId] = useState<number | null>(null);
-  // autoVideoId stores the ID of the first-shown video for stability during reorders.
-  // Initialized once when group data first arrives using React's "derived state" pattern
-  // (react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).
   const [autoVideoId, setAutoVideoId] = useState<number | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [editedName, setEditedName] = useState('');
   const [editedDescription, setEditedDescription] = useState('');
 
-  // Keep autoVideoId in sync with the current video list using React's "derived state" pattern
-  // (react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).
-  // We update autoVideoId when:
-  //   - It is null (initial load)
-  //   - It refers to a video that is no longer in the list (e.g. after deletion or group change)
-  // This prevents the player from switching to videos[0] during reorders when autoVideoId is stale.
   const currentVideos = group?.videos;
   const firstVideoId = currentVideos?.[0]?.id ?? null;
-  const autoVideoInList = autoVideoId !== null && (currentVideos?.some((v) => v.id === autoVideoId) ?? false);
+  const autoVideoInList = autoVideoId !== null && (currentVideos?.some((video) => video.id === autoVideoId) ?? false);
   if (!autoVideoInList && firstVideoId !== null) {
     setAutoVideoId(firstVideoId);
   }
@@ -469,17 +47,17 @@ export default function VideoGroupDetailPage() {
   const selectedVideo = useMemo<SelectedVideo | null>(() => {
     const videos = group?.videos;
     if (!videos || videos.length === 0) return null;
-    // Explicit user selection takes priority
+
     if (selectedVideoId !== null) {
-      const found = videos.find((v) => v.id === selectedVideoId);
+      const found = videos.find((video) => video.id === selectedVideoId);
       if (found) return convertVideoInGroupToSelectedVideo(found);
     }
-    // Fall back to auto-selected video (stable across reorders thanks to autoVideoId)
-    const targetId = autoVideoId;
-    if (targetId !== null) {
-      const found = videos.find((v) => v.id === targetId);
+
+    if (autoVideoId !== null) {
+      const found = videos.find((video) => video.id === autoVideoId);
       if (found) return convertVideoInGroupToSelectedVideo(found);
     }
+
     return convertVideoInGroupToSelectedVideo(videos[0]);
   }, [group?.videos, selectedVideoId, autoVideoId]);
 
@@ -496,20 +74,12 @@ export default function VideoGroupDetailPage() {
     onMobileSwitch: () => setMobileTab('player'),
   });
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  );
-
   const { syncGroupDetail, setGroupDetailCache, removeVideoMutation, reorderVideosMutation, deleteGroupMutation, updateGroupMutation } =
     useVideoGroupDetailMutations({
       groupId,
       onDeleteSuccess: () => navigate('/videos/groups'),
       onUpdateSuccess: () => setIsEditing(false),
     });
-
-
-
 
   const handleRemoveVideo = async (videoId: number) => {
     if (!groupId) return;
@@ -531,13 +101,14 @@ export default function VideoGroupDetailPage() {
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id || !group?.videos || !groupId) return;
-    const oldIndex = group.videos.findIndex((v) => v.id === active.id);
-    const newIndex = group.videos.findIndex((v) => v.id === over.id);
+    const oldIndex = group.videos.findIndex((video) => video.id === active.id);
+    const newIndex = group.videos.findIndex((video) => video.id === over.id);
     if (oldIndex === -1 || newIndex === -1) return;
+
     const newVideos = arrayMove(group.videos, oldIndex, newIndex);
     setGroupDetailCache({ ...group, videos: newVideos });
     try {
-      await reorderVideosMutation.mutateAsync(newVideos.map((v) => v.id));
+      await reorderVideosMutation.mutateAsync(newVideos.map((video) => video.id));
     } catch (err) {
       handleAsyncError(err, t('videos.groupDetail.orderUpdateError'), () => {});
       await syncGroupDetail();
@@ -561,6 +132,13 @@ export default function VideoGroupDetailPage() {
     }
   };
 
+  const handleStartEdit = () => {
+    if (!group) return;
+    setEditedName(group.name);
+    setEditedDescription(group.description || '');
+    setIsEditing(true);
+  };
+
   const handleCancelEdit = () => {
     setIsEditing(false);
     updateGroupMutation.reset();
@@ -575,279 +153,45 @@ export default function VideoGroupDetailPage() {
   const isUpdating = updateGroupMutation.isPending;
   const updateError = updateGroupMutation.error instanceof Error ? updateGroupMutation.error.message : null;
 
-  const mobileTabIcon: Record<MobileTab, typeof List> = { videos: List, player: Play };
-  const mobileTabLabel: Record<MobileTab, string> = {
-    videos: t('videos.groupDetail.mobileTabs.videos'),
-    player: t('videos.groupDetail.mobileTabs.player'),
-  };
-
   return (
-    <>
-      <div
-        className="bg-[#f8faf5] flex flex-col"
-        style={{ fontFamily: "'Plus Jakarta Sans', sans-serif" }}
-      >
-      {/* ── Header ───────────────────────────────────────────────────────── */}
-      <AppNav activePage="groups" />
-
-      {/* ── Loading / error states ─────────────────────────────────────── */}
-      {isLoading ? (
-        <div className="mt-16 min-h-[calc(100dvh-64px)] flex items-center justify-center">
-          <LoadingSpinner />
-        </div>
-      ) : error && !group ? (
-        <div className="mt-16 min-h-[calc(100dvh-64px)] flex flex-col items-center justify-center gap-4">
-          <p className="text-red-500">{error}</p>
-          <Link href="/videos/groups" className="text-[#00652c] font-bold hover:underline flex items-center gap-1">
-            <ArrowLeft className="w-4 h-4" />
-            {t('common.actions.backToList')}
-          </Link>
-        </div>
-      ) : !group ? (
-        <div className="mt-16 min-h-[calc(100dvh-64px)] flex items-center justify-center">
-          <p className="text-[#3f493f]">{t('common.messages.groupNotFound')}</p>
-        </div>
-      ) : (
-        <>
-      {/* ── Edit Dialog ──────────────────────────────────────────────────── */}
-      <Dialog open={isEditing} onOpenChange={(open) => !open && handleCancelEdit()}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t('videos.groupDetail.editTitle')}</DialogTitle>
-            <DialogDescription>
-              {t('videos.groupDetail.editDescription', 'Update the group name and description.')}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4 py-2">
-            {updateError && (
-              <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">{updateError}</div>
-            )}
-            <div className="space-y-1">
-              <label className="text-xs font-bold text-[#3f493f]">{t('videos.groups.nameLabel')}</label>
-              <input
-                type="text"
-                value={editedName}
-                onChange={(e) => setEditedName(e.target.value)}
-                disabled={isUpdating}
-                className="w-full px-3 py-2.5 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all"
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs font-bold text-[#3f493f]">{t('videos.groups.descriptionLabel')}</label>
-              <textarea
-                value={editedDescription}
-                onChange={(e) => setEditedDescription(e.target.value)}
-                disabled={isUpdating}
-                rows={3}
-                className="w-full px-3 py-2.5 bg-[#f2f4ef] border border-[#e1e3de] rounded-xl text-sm focus:ring-2 focus:ring-[#00652c]/20 focus:border-[#00652c] outline-none transition-all resize-none"
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <button
-              onClick={handleCancelEdit}
-              disabled={isUpdating}
-              className="flex items-center gap-1.5 px-4 py-2 border border-[#e1e3de] rounded-xl text-sm font-bold hover:bg-[#f2f4ef] transition-colors disabled:opacity-50"
-            >
-              <X className="w-3.5 h-3.5" />
-              {t('common.actions.cancel')}
-            </button>
-            <button
-              onClick={() => updateGroupMutation.mutate({ name: editedName, description: editedDescription })}
-              disabled={isUpdating || !editedName.trim()}
-              className="flex items-center gap-1.5 px-4 py-2 bg-[#00652c] text-white rounded-xl text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
-            >
-              {isUpdating ? <InlineSpinner className="w-3.5 h-3.5" /> : <Save className="w-3.5 h-3.5" />}
-              {isUpdating ? t('common.actions.saving') : t('common.actions.save')}
-            </button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* ── Main ─────────────────────────────────────────────────────────── */}
-      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-16 lg:pb-4 lg:h-[calc(100dvh-64px)] lg:overflow-hidden">
-        {/* Share link panel */}
-        <ShareLinkPanel
-          shareSlug={group.share_slug ?? ''}
-          shareLink={shareLink}
-          isGeneratingLink={isGeneratingLink}
-          isCopied={isCopied}
-          onGenerate={generateShareLink}
-          onDelete={deleteShareLink}
-          onCopy={copyShareLink}
-        />
-
-        {/* 3-column grid */}
-        <div className="flex flex-col lg:grid lg:grid-cols-4 gap-6 lg:flex-1 lg:min-h-0 lg:items-stretch">
-
-          {/* LEFT: Video list */}
-          <aside className={`lg:col-span-1 flex flex-col min-h-0 ${mobileTab === 'videos' ? 'flex' : 'hidden lg:flex'}`}>
-            <div className="bg-white rounded-xl flex flex-col h-full overflow-hidden shadow-[0_4px_20px_rgba(28,25,23,0.04)]">
-              {deleteError && (
-                <div className="px-4 pt-3 shrink-0">
-                  <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">{deleteError}</div>
-                </div>
-              )}
-              <div className="p-4 border-b border-stone-100 flex items-center justify-between gap-2 shrink-0">
-                <h2 className="font-extrabold text-[#191c19] truncate flex-1 min-w-0">{group.name}</h2>
-                <div className="flex items-center gap-2 shrink-0">
-                  <span className="text-xs bg-[#f2f4ef] px-2 py-0.5 rounded-full text-[#6f7a6e] font-medium">
-                    {t('videos.groupDetail.videoCount', { count: group.videos?.length ?? 0 })}
-                  </span>
-                  <button
-                    onClick={() => setIsAddModalOpen(true)}
-                    className="flex items-center gap-1 px-2 py-1 rounded-lg bg-white border border-[#e1e3de] hover:bg-[#f2f4ef] transition-colors text-[#191c19] text-xs font-bold shadow-sm"
-                  >
-                    <Plus className="w-3.5 h-3.5" />
-                    <span className="hidden sm:inline">{t('videos.groupDetail.add')}</span>
-                  </button>
-                  <button
-                    onClick={() => {
-                      setEditedName(group.name);
-                      setEditedDescription(group.description || '');
-                      setIsEditing(true);
-                    }}
-                    className="p-1.5 text-[#3f493f] hover:bg-stone-100 rounded-lg transition-colors"
-                    title={t('videos.groupDetail.editTitle')}
-                  >
-                    <Pencil className="w-3.5 h-3.5" />
-                  </button>
-                  <button
-                    onClick={handleDelete}
-                    disabled={isDeleting}
-                    className="p-1.5 text-red-500 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
-                    title={t('videos.groupDetail.delete')}
-                  >
-                    {isDeleting ? <InlineSpinner className="w-3.5 h-3.5" /> : <Trash2 className="w-3.5 h-3.5" />}
-                  </button>
-                </div>
-              </div>
-              <div className="flex-1 overflow-y-auto p-2 space-y-1">
-                {group.videos && group.videos.length > 0 ? (
-                  <DndContext
-                    sensors={isMobile ? MOBILE_SENSORS : sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
-                  >
-                    <SortableContext items={group.videos.map((v) => v.id)} strategy={verticalListSortingStrategy}>
-                      {group.videos.map((v) => (
-                        <SortableVideoItem
-                          key={v.id}
-                          video={v}
-                          isSelected={selectedVideo?.id === v.id}
-                          isMobile={isMobile}
-                          onSelect={(videoId) => {
-                            handleVideoSelect(videoId);
-                            if (isMobile) setMobileTab('player');
-                          }}
-                          onRemove={handleRemoveVideo}
-                        />
-                      ))}
-                    </SortableContext>
-                  </DndContext>
-                ) : (
-                  <p className="text-center text-[#6f7a6e] py-8 text-sm">
-                    {t('videos.groupDetail.videoListEmpty')}
-                  </p>
-                )}
-              </div>
-            </div>
-          </aside>
-
-          {/* CENTER: Video player */}
-          <section className={`lg:col-span-2 flex flex-col gap-3 lg:min-h-0 ${mobileTab === 'player' ? 'flex' : 'hidden lg:flex'}`}>
-            <div className="bg-white rounded-xl flex flex-col lg:flex-1 overflow-hidden shadow-[0_8px_30px_rgba(28,25,23,0.08)]">
-              <div className="p-4 border-b border-stone-100 shrink-0 flex items-center justify-between gap-3 min-w-0">
-                <h1 className="font-extrabold text-[#191c19] text-lg truncate flex-1 min-w-0">
-                  {selectedVideo ? selectedVideo.title : t('videos.groupDetail.playerPlaceholder')}
-                </h1>
-                <div className="flex items-center gap-2 shrink-0">
-                  {groupId && <DashboardButton groupId={groupId} size="sm" />}
-                </div>
-              </div>
-              <div className="aspect-video lg:aspect-auto lg:flex-1 bg-[#1a1c1c] flex items-center justify-center lg:min-h-0">
-                {selectedVideo ? (
-                  selectedVideo.source_type === 'youtube' && selectedVideo.youtube_embed_url ? (
-                    <iframe
-                      key={`${selectedVideo.id}-${youtubeStartSeconds ?? 0}`}
-                      className="w-full h-full"
-                      src={buildYoutubeEmbedSrc(selectedVideo.youtube_embed_url, youtubeStartSeconds)}
-                      title={selectedVideo.title}
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                      allowFullScreen
-                    />
-                  ) : selectedVideo.file ? (
-                    <video
-                      ref={videoRef}
-                      key={selectedVideo.id}
-                      controls
-                      className="w-full h-full object-contain"
-                      src={apiClient.getVideoUrl(selectedVideo.file)}
-                      onCanPlay={handleVideoCanPlay}
-                    >
-                      {t('common.messages.browserNoVideoSupport')}
-                    </video>
-                  ) : (
-                    <p className="text-stone-400 text-sm">{t('videos.groupDetail.videoNoFile')}</p>
-                  )
-                ) : (
-                  <p className="text-stone-400 text-sm text-center px-4">{t('videos.groupDetail.playerPlaceholder')}</p>
-                )}
-              </div>
-            </div>
-            {/* Chat below player on mobile */}
-            <div className="lg:hidden">
-              <ChatPanel
-                groupId={groupId ?? undefined}
-                onVideoPlay={handleVideoPlayFromTime}
-                className="h-[480px] shadow-[0_4px_20px_rgba(28,25,23,0.04)]"
-              />
-            </div>
-          </section>
-
-          {/* RIGHT: Chat (desktop only) */}
-          <aside className="hidden lg:flex lg:col-span-1 flex-col min-h-0">
-            <ChatPanel
-              groupId={groupId ?? undefined}
-              onVideoPlay={handleVideoPlayFromTime}
-              className="flex-1 min-h-0 shadow-[0_4px_20px_rgba(28,25,23,0.04)]"
-            />
-          </aside>
-        </div>
-      </main>
-
-      {/* ── Mobile bottom nav ─────────────────────────────────────────────── */}
-      <nav className="fixed bottom-0 left-0 w-full z-50 lg:hidden flex justify-around items-center h-16 bg-white border-t border-stone-100 shadow-[0_-4px_20px_rgba(28,25,23,0.06)] rounded-t-2xl px-4">
-        {(['videos', 'player'] as MobileTab[]).map((tab) => {
-          const Icon = mobileTabIcon[tab];
-          const isActive = mobileTab === tab;
-          return (
-            <button
-              key={tab}
-              onClick={() => setMobileTab(tab)}
-              className={`flex flex-col items-center justify-center gap-1 px-4 py-1 rounded-xl transition-colors ${
-                isActive
-                  ? 'bg-[#f0fdf4] text-[#00652c]'
-                  : 'text-stone-400 hover:text-[#00652c]'
-              }`}
-            >
-              <Icon className="w-5 h-5" />
-              <span className="text-[11px] font-medium">{mobileTabLabel[tab]}</span>
-            </button>
-          );
-        })}
-      </nav>
-
-      {/* Add Videos Dialog */}
-      <AddVideosDialog
-        isOpen={isAddModalOpen}
-        onOpenChange={setIsAddModalOpen}
-        groupId={groupId}
-        group={group}
-      />
-        </>
-      )}
-      </div>
-    </>
+    <VideoGroupDetailView
+      group={group}
+      groupId={groupId}
+      isLoading={isLoading}
+      error={error}
+      selectedVideo={selectedVideo}
+      deleteError={deleteError}
+      isDeleting={isDeleting}
+      isEditing={isEditing}
+      editedName={editedName}
+      editedDescription={editedDescription}
+      updateError={updateError}
+      isUpdating={isUpdating}
+      isAddModalOpen={isAddModalOpen}
+      mobileTab={mobileTab}
+      isMobile={isMobile}
+      videoRef={videoRef}
+      youtubeStartSeconds={youtubeStartSeconds}
+      shareSlug={group?.share_slug ?? ''}
+      shareLink={shareLink}
+      isGeneratingLink={isGeneratingLink}
+      isCopied={isCopied}
+      onMobileTabChange={setMobileTab}
+      onOpenAddModalChange={setIsAddModalOpen}
+      onStartEditing={handleStartEdit}
+      onCancelEdit={handleCancelEdit}
+      onEditedNameChange={setEditedName}
+      onEditedDescriptionChange={setEditedDescription}
+      onUpdateGroup={() => updateGroupMutation.mutate({ name: editedName, description: editedDescription })}
+      onDeleteGroup={handleDelete}
+      onVideoSelect={handleVideoSelect}
+      onRemoveVideo={handleRemoveVideo}
+      onDragEnd={handleDragEnd}
+      onVideoCanPlay={handleVideoCanPlay}
+      onVideoPlayFromTime={handleVideoPlayFromTime}
+      onGenerateShareLink={generateShareLink}
+      onDeleteShareLink={deleteShareLink}
+      onCopyShareLink={copyShareLink}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- VideoDetailPageをcontainer化し、主要UIをVideoDetailViewへ分離
- VideoGroupDetailPageをcontainer化し、一覧・プレイヤー・共有リンク・追加ダイアログをpresentation componentへ分離
- SRT parser/filterを純粋関数としてlibへ移し、単体テストを追加
- YouTube embed URL helperを共通化

## Tests
- npm test
- npm run typecheck
- npm run lint
- git diff --check

Closes #740