### PR TITLE
動画一覧APIのページングをDBレベルに移す

### DIFF
--- a/backend/app/domain/video/repositories.py
+++ b/backend/app/domain/video/repositories.py
@@ -39,13 +39,24 @@ class VideoQueryRepository(ABC):
         self,
         user_id: int,
         criteria: Optional[VideoSearchCriteria] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
     ) -> List[VideoEntity]:
-        """List videos for a user with optional filters."""
+        """List videos for a user with optional filters.
+
+        Args:
+            limit: Maximum number of videos to return.
+            offset: Number of videos to skip.
+        """
         ...
 
     @abstractmethod
-    def count_for_user(self, user_id: int) -> int:
-        """Return the number of videos owned by the user."""
+    def count_for_user(
+        self,
+        user_id: int,
+        criteria: Optional[VideoSearchCriteria] = None,
+    ) -> int:
+        """Return the number of videos owned by the user with optional filters."""
         ...
 
     @abstractmethod

--- a/backend/app/infrastructure/repositories/django_video_repository.py
+++ b/backend/app/infrastructure/repositories/django_video_repository.py
@@ -6,7 +6,7 @@ import logging
 from typing import Dict, List, Optional, Tuple
 
 from django.db import IntegrityError, transaction
-from django.db.models import Count, Max, Prefetch
+from django.db.models import Count, Max, Prefetch, Q, QuerySet
 
 from app.domain.video.dto import (
     CreateGroupParams,
@@ -153,11 +153,30 @@ class DjangoVideoRepository(VideoRepository):
         self,
         user_id: int,
         criteria: Optional[VideoSearchCriteria] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
     ) -> List[VideoEntity]:
-        from django.db.models import Q
+        queryset = self._build_list_queryset(user_id=user_id, criteria=criteria)
 
+        if limit is not None:
+            queryset = queryset[offset : offset + limit]
+        elif offset:
+            queryset = queryset[offset:]
+        return [_video_to_entity(v) for v in queryset]
+
+    def count_for_user(
+        self,
+        user_id: int,
+        criteria: Optional[VideoSearchCriteria] = None,
+    ) -> int:
+        return self._build_list_queryset(user_id=user_id, criteria=criteria).count()
+
+    def _build_list_queryset(
+        self,
+        user_id: int,
+        criteria: Optional[VideoSearchCriteria] = None,
+    ) -> QuerySet:
         search = criteria or VideoSearchCriteria()
-
         queryset = QueryOptimizer.get_videos_with_metadata(user_id=user_id)
 
         if search.keyword:
@@ -188,7 +207,7 @@ class DjangoVideoRepository(VideoRepository):
         if search.sort_key in ordering_map:
             queryset = queryset.order_by(ordering_map[search.sort_key])
 
-        return [_video_to_entity(v) for v in queryset]
+        return queryset
 
     def create_pending(self, user_id: int, params: CreateVideoPendingParams) -> VideoEntity:
         video = Video.objects.create(
@@ -277,9 +296,6 @@ class DjangoVideoRepository(VideoRepository):
         orm_video.delete()
         if file_ref:
             transaction.on_commit(lambda: file_ref.delete(save=False))
-
-    def count_for_user(self, user_id: int) -> int:
-        return Video.objects.filter(user_id=user_id).count()
 
     def get_file_keys_for_ids(
         self, video_ids: List[int], user_id: int

--- a/backend/app/infrastructure/repositories/tests/test_django_video_repository.py
+++ b/backend/app/infrastructure/repositories/tests/test_django_video_repository.py
@@ -69,6 +69,17 @@ class DjangoVideoRepositoryTagFilterTests(TestCase):
         results = self.repo.list_for_user(self.user.id, VideoSearchCriteria())
         self.assertEqual(len(results), 3)
 
+    def test_list_for_user_applies_limit_and_offset(self):
+        criteria = VideoSearchCriteria(sort_key="title_asc")
+        results = self.repo.list_for_user(self.user.id, criteria, limit=2, offset=1)
+
+        self.assertEqual([video.title for video in results], ["Video AB", "Video B"])
+
+    def test_count_for_user_applies_filters_without_limit(self):
+        criteria = VideoSearchCriteria(tag_ids=[self.tag_a.id])
+
+        self.assertEqual(self.repo.count_for_user(self.user.id, criteria), 2)
+
 
 class DjangoVideoGroupRepositoryOrderTests(TestCase):
     """Tests for video group display ordering behavior."""

--- a/backend/app/presentation/video/tests/test_nplusone.py
+++ b/backend/app/presentation/video/tests/test_nplusone.py
@@ -36,7 +36,8 @@ class NPlusOneTestCase(TestCase):
 
         # 1. Main Video Query (includes User join)
         # 2. VideoTag Query (includes Tag join) - Prefetch
-        with self.assertNumQueries(2):
+        # 3. Count Query for paginated response metadata
+        with self.assertNumQueries(3):
             response = self.client.get(url)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from app.use_cases.video.dto import VideoGroupListPageResponseDTO
+from app.use_cases.video.dto import VideoGroupListPageResponseDTO, VideoListPageResponseDTO
 
 User = get_user_model()
 Tag = apps.get_model("app", "Tag")
@@ -1271,6 +1271,23 @@ class VideoListPaginationTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 1)
         self.assertIsNone(response.data["next"])
+
+    @patch("app.use_cases.video.list_videos.ListVideosUseCase.execute_page")
+    def test_limit_and_offset_are_passed_to_use_case(self, mock_execute_page):
+        mock_execute_page.return_value = VideoListPageResponseDTO(
+            count=5,
+            results=[],
+        )
+        url = reverse("video-list")
+
+        response = self.client.get(url, {"limit": 2, "offset": 4})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_execute_page.assert_called_once()
+        _, kwargs = mock_execute_page.call_args
+        self.assertEqual(kwargs["user_id"], self.user.id)
+        self.assertEqual(kwargs["limit"], 2)
+        self.assertEqual(kwargs["offset"], 4)
 
 
 class VideoGroupListPaginationTests(APITestCase):

--- a/backend/app/presentation/video/views.py
+++ b/backend/app/presentation/video/views.py
@@ -125,15 +125,22 @@ class VideoListView(DependencyResolverMixin, AuthenticatedViewMixin, generics.Ge
             sort_key=ordering,
             tag_ids=tag_ids,
         )
-        videos = use_case.execute(
+        paginator = StandardLimitOffsetPagination()
+        limit = paginator.get_limit(request)
+        offset = paginator.get_offset(request)
+        page = use_case.execute_page(
             user_id=request.user.id,
             input=input_dto,
+            limit=limit,
+            offset=offset,
         )
         ctx = {"request": request}
-        data = VideoListSerializer(videos, many=True, context=ctx).data
-        paginator = StandardLimitOffsetPagination()
-        page = paginator.paginate_queryset(data, request)
-        return paginator.get_paginated_response(page)
+        data = VideoListSerializer(page.results, many=True, context=ctx).data
+        paginator.request = request
+        paginator.limit = limit
+        paginator.offset = offset
+        paginator.count = page.count
+        return paginator.get_paginated_response(data)
 
     @extend_schema(
         request=VideoCreateSerializer,

--- a/backend/app/use_cases/video/dto.py
+++ b/backend/app/use_cases/video/dto.py
@@ -134,6 +134,14 @@ class VideoResponseDTO:
 
 
 @dataclass(frozen=True)
+class VideoListPageResponseDTO:
+    """Use-case output DTO for a paginated video list."""
+
+    count: int
+    results: List[VideoResponseDTO]
+
+
+@dataclass(frozen=True)
 class UploadRequestResponseDTO:
     """Output for RequestVideoUploadUseCase — video record + presigned upload URL."""
 

--- a/backend/app/use_cases/video/list_videos.py
+++ b/backend/app/use_cases/video/list_videos.py
@@ -6,7 +6,11 @@ from typing import List
 
 from app.domain.video.dto import VideoSearchCriteria
 from app.domain.video.repositories import VideoRepository
-from app.use_cases.video.dto import ListVideosInput, VideoResponseDTO
+from app.use_cases.video.dto import (
+    ListVideosInput,
+    VideoListPageResponseDTO,
+    VideoResponseDTO,
+)
 from app.use_cases.video.file_url import to_video_response_dtos
 
 
@@ -24,11 +28,33 @@ class ListVideosUseCase:
         user_id: int,
         input: ListVideosInput,
     ) -> List[VideoResponseDTO]:
-        criteria = VideoSearchCriteria(
+        criteria = self._to_search_criteria(input)
+        videos = self.video_repo.list_for_user(user_id=user_id, criteria=criteria)
+        return to_video_response_dtos(videos)
+
+    def execute_page(
+        self,
+        user_id: int,
+        input: ListVideosInput,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> VideoListPageResponseDTO:
+        criteria = self._to_search_criteria(input)
+        videos = self.video_repo.list_for_user(
+            user_id=user_id,
+            criteria=criteria,
+            limit=limit,
+            offset=offset,
+        )
+        return VideoListPageResponseDTO(
+            count=self.video_repo.count_for_user(user_id=user_id, criteria=criteria),
+            results=to_video_response_dtos(videos),
+        )
+
+    def _to_search_criteria(self, input: ListVideosInput) -> VideoSearchCriteria:
+        return VideoSearchCriteria(
             keyword=input.keyword,
             status_filter=input.status_filter,
             sort_key=input.sort_key,
             tag_ids=input.tag_ids,
         )
-        videos = self.video_repo.list_for_user(user_id=user_id, criteria=criteria)
-        return to_video_response_dtos(videos)


### PR DESCRIPTION
## Summary
- 動画一覧APIに `execute_page` を追加し、limit/offset をユースケースからリポジトリへ渡すよう変更
- 動画一覧の count を検索条件込みでDB側から取得し、既存のページングレスポンス形式を維持
- ページング伝播、DBレベルの limit/offset、N+1 クエリ数のテストを更新

## Tests
- docker compose run --rm backend python manage.py test app.presentation.video.tests.test_views app.presentation.video.tests.test_nplusone app.infrastructure.repositories.tests.test_django_video_repository --keepdb
- docker compose run --rm backend python manage.py test app.tests.test_import_rules --keepdb
- python -m py_compile backend/app/use_cases/video/dto.py backend/app/domain/video/repositories.py backend/app/use_cases/video/list_videos.py backend/app/infrastructure/repositories/django_video_repository.py backend/app/presentation/video/views.py backend/app/presentation/video/tests/test_views.py backend/app/presentation/video/tests/test_nplusone.py backend/app/infrastructure/repositories/tests/test_django_video_repository.py
- git diff --check

Closes #762