### PR TITLE
リモートMCPのOAuthメタデータ経路を本番ドメインで疎通させる

### DIFF
--- a/infra/stacks/api_stack.py
+++ b/infra/stacks/api_stack.py
@@ -131,6 +131,11 @@ class ApiStack(Stack):
             "FRONTEND_URL": frontend_url,
             "ALLOWED_HOSTS": f".execute-api.{self.region}.amazonaws.com,localhost",
             "CORS_ALLOWED_ORIGINS": cors_origins,
+            # OAuth 2.1 issuer for the Remote MCP endpoint. Must be the
+            # public HTTPS origin Claude.ai's connector talks to; otherwise
+            # the WWW-Authenticate `resource_metadata` URL and the metadata
+            # documents themselves leak `http://localhost:8000`.
+            "OAUTH2_PROVIDER_ISSUER_URL": frontend_url,
             # Secrets Manager
             # DB_SECRET_ARN: {"DATABASE_URL": "postgresql://...@neon.tech/..."}
             "DB_SECRET_ARN": db_secret.secret_arn,

--- a/infra/stacks/cdn_stack.py
+++ b/infra/stacks/cdn_stack.py
@@ -61,6 +61,17 @@ class CdnStack(Stack):
                     origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
                     allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
                 ),
+                # RFC 8414 / RFC 9728: OAuth metadata documents must live at
+                # the well-known path under the resource origin. Route to the
+                # API Lambda instead of the SPA so Claude.ai's Remote MCP
+                # connector receives JSON, not the frontend index.html.
+                "/.well-known/*": cloudfront.BehaviorOptions(
+                    origin=api_origin,
+                    viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+                    cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
+                    origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+                    allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
+                ),
             },
         )
 


### PR DESCRIPTION
## Summary

Claude.ai のビルトイン Remote MCP コネクターから `https://videoq.jp` に接続すると、Dynamic Client Registration の前段で OAuth メタデータ取得が壊れ、UI に「videoqのサインインサービスへの登録ができませんでした」が出る状態でした。原因は #766 で実装した OAuth レイヤー自体ではなくインフラ側の経路設定2点です。

- **CloudFront に `/.well-known/*` ビヘイビアを追加** (`infra/stacks/cdn_stack.py`)
  これまで `additional_behaviors` には `/api/*` しか無く、RFC 8414 / RFC 9728 の well-known パスがデフォルトの Cloudflare Pages オリジン (SPA) に吸われていました。Claude.ai は JSON を期待しているのに `index.html` を受け取り、メタデータ解析で失敗していました。
- **API Lambda に `OAUTH2_PROVIDER_ISSUER_URL` を設定** (`infra/stacks/api_stack.py`)
  未設定だと `backend/videoq/settings.py:367` のデフォルト `http://localhost:8000` が使われ、保護リソースエンドポイントが返す `WWW-Authenticate: ... resource_metadata="http://localhost:8000/..."` ヘッダーと、メタデータドキュメントの絶対URLが localhost を指していました。`frontend_url` (= `https://${custom_domain}`) と同じ値を入れて、Claude.ai が辿れる公開オリジンに揃えます。

なお `/api/oauth/register/` に直接 POST すると 201 で client_id を返すため、DCR の Python 実装側は正常です。

## Root cause (再現)

```
$ curl -i https://videoq.jp/api/mcp/
HTTP/2 401
www-authenticate: Bearer realm="api",resource_metadata="http://localhost:8000/.well-known/oauth-protected-resource/api/mcp"

$ curl -i https://videoq.jp/.well-known/oauth-authorization-server
HTTP/2 200
content-type: text/html; charset=utf-8   ← SPA の index.html
```

## Test plan

- [ ] `cd infra && cdk diff` で `CdnStack` (新ビヘイビア) と `ApiStack` (Lambda 環境変数) の差分のみが出ることを確認
- [ ] `cdk deploy` 後、`curl -i https://videoq.jp/.well-known/oauth-authorization-server` が `content-type: application/json` で `issuer: "https://videoq.jp"` を返すことを確認
- [ ] `curl -i https://videoq.jp/.well-known/oauth-protected-resource/api/mcp` も同様に JSON を返すことを確認
- [ ] `curl -i https://videoq.jp/api/mcp/` の `WWW-Authenticate` ヘッダーが `resource_metadata="https://videoq.jp/..."` を指すことを確認
- [ ] Claude.ai のコネクター設定から `https://videoq.jp/api/mcp/` (もしくは案内している URL) を追加し、登録→認可→ツール一覧取得まで成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)