### PR TITLE
infra マージコミットで cdk-deploy がスキップされる問題を修正

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -1,12 +1,18 @@
 name: CDK Deploy
 
+# Trigger directly on push to main with a path filter rather than chaining
+# off the CI workflow_run. workflow_run + dorny/paths-filter silently
+# skips deploys on merge commits because the workflow_run payload has no
+# `before` SHA, so paths-filter falls back to `git log -n 1 HEAD` which
+# returns no files for a merge commit. The native push `paths:` filter
+# evaluates the actual push diff and handles merge commits correctly.
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
+  push:
     branches:
       - main
+    paths:
+      - 'infra/**'
+      - '.github/workflows/cdk-deploy.yml'
   workflow_dispatch:
 
 permissions:
@@ -17,36 +23,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    outputs:
-      infra: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.infra == 'true' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          fetch-depth: 2
-      - uses: dorny/paths-filter@v3
-        id: filter
-        if: github.event_name != 'workflow_dispatch'
-        with:
-          filters: |
-            infra:
-              - 'infra/**'
-              - '.github/workflows/cdk-deploy.yml'
-
   cdk-deploy:
     name: CDK Deploy (production)
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.infra == 'true'
     environment: production
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary

PR #769 のマージ後、`CDK Deploy` ワークフローは起動するものの `CDK Deploy (production)` ジョブが skipped となり、自動デプロイが動きませんでした。同じ仕組みで `1527aae` (SQS ロングポーリング) も7週間未デプロイで放置されていたことが判明しています。再発防止としてワークフローのトリガー方式を差し替えます。

## Root cause

`cdk-deploy.yml` は `workflow_run` (CI 完了イベント) を起点に `dorny/paths-filter` で `infra/` 配下の変更を検知していました。しかし `workflow_run` イベントペイロードには `before` SHA が含まれず、paths-filter はフォールバックで `git log -n 1 HEAD` を実行します。`push` to main の HEAD は通常マージコミットになり、デフォルトの git 表示では変更ファイルが出ない (マージ表示は `-m --first-parent` 等を要する) ため、paths-filter は `Detected 0 changed files` と判断して `infra = false` を出力 → 後続ジョブが常にスキップされていました。

実際の run id `27683849410` のログ:

\`\`\`
##[warning]'before' field is missing in event payload - changes will be detected from last commit
Change detection in last commit
[command]/usr/bin/git log --format= --no-renames --name-status -z -n 1
Detected 0 changed files
Filter infra = false
\`\`\`

## Fix

GitHub ネイティブの push `paths:` フィルタはマージコミットでも push 全体の差分を正しく評価するので、これに切り替えて paths-filter 依存を取り除きます。

- `on: workflow_run` → `on: push` (`branches: main`, `paths: ['infra/**', '.github/workflows/cdk-deploy.yml']`)
- `changes` 中継ジョブを削除し、`cdk-deploy` ジョブを直接実行
- `workflow_run.head_sha` 経由のチェックアウトも撤去 (push のデフォルト SHA で十分)

CI 完了を待たない構成になりますが、infra 変更は backend/frontend を巻き込まない (CI はほぼ skip される) ため実害はありません。手動再実行用の `workflow_dispatch` は維持しています。

## Test plan

- [ ] このPRがマージされた後、`infra/**` 配下に変更がある次のmain push (例: 何らかの infra コミット) で `CDK Deploy (production)` ジョブが起動することを確認
- [ ] `infra/` を触らない通常の PR マージでは workflow 自体が起動しないことを確認 (`paths:` 効果)
- [ ] `workflow_dispatch` での手動実行が引き続き使えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)