### PR TITLE
ログインページが ?next= クエリパラメータを尊重するように修正

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { Link, useI18nNavigate } from '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
@@ -11,10 +12,21 @@ import { AuthLayout } from '@/components/layout/AuthLayout';
 import { AuthPageIntro } from '@/components/layout/AuthPageIntro';
 import { AuthPageFooter } from '@/components/layout/AuthPageFooter';
 
+// Only allow same-origin absolute paths to prevent open redirects to attacker
+// origins (e.g. ?next=//evil.com or ?next=https://evil.com).
+function getSafeNextPath(next: string | null): string | null {
+  if (!next) return null;
+  if (!next.startsWith('/')) return null;
+  if (next.startsWith('//') || next.startsWith('/\\')) return null;
+  return next;
+}
+
 export default function LoginPage() {
   const navigate = useI18nNavigate();
   const queryClient = useQueryClient();
   const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const nextPath = getSafeNextPath(searchParams.get('next'));
   const [showPassword, setShowPassword] = useState(false);
 
   const { formData, error, isLoading, handleChange, handleSubmit } = useAuthForm({
@@ -27,7 +39,16 @@ export default function LoginPage() {
       });
     },
     initialData: { username: '', password: '' },
-    onSuccessRedirect: () => navigate('/'),
+    onSuccessRedirect: () => {
+      if (nextPath) {
+        // Full-page navigation: `next` typically points at the Django
+        // OAuth authorize endpoint (/api/oauth/authorize/...) which the
+        // SPA router cannot serve.
+        window.location.href = nextPath;
+        return;
+      }
+      navigate('/');
+    },
   });
 
   return (

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -102,4 +102,79 @@ describe('LoginPage', () => {
     expect(container).toHaveClass('flex', 'min-h-screen', 'flex-col')
   })
 
+  describe('?next= redirect after login', () => {
+    let originalLocation: Location
+    let hrefSetter: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      originalLocation = window.location
+      hrefSetter = vi.fn()
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: new Proxy({ href: '' } as { href: string }, {
+          set(target, prop, value) {
+            if (prop === 'href') {
+              hrefSetter(value)
+              target.href = value
+              return true
+            }
+            return false
+          },
+          get(target, prop) {
+            return target[prop as keyof typeof target]
+          },
+        }),
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      })
+      globalThis.__setMockSearchParams('')
+    })
+
+    const submitLoginForm = async () => {
+      ;(apiClient.login as ReturnType<typeof vi.fn>).mockResolvedValue({})
+      render(<LoginPage />)
+      fireEvent.change(screen.getByPlaceholderText('auth.fields.username.placeholder'), { target: { value: 'u' } })
+      fireEvent.change(screen.getByPlaceholderText('auth.fields.password.placeholder'), { target: { value: 'p' } })
+      fireEvent.click(screen.getByText('auth.login.submit'))
+    }
+
+    it('redirects to the safe next path via full navigation', async () => {
+      globalThis.__setMockSearchParams('?next=%2Fapi%2Foauth%2Fauthorize%2F%3Fclient_id%3Dabc')
+
+      await submitLoginForm()
+
+      await waitFor(() => {
+        expect(hrefSetter).toHaveBeenCalledWith('/api/oauth/authorize/?client_id=abc')
+      })
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('ignores a protocol-relative next and falls back to home', async () => {
+      globalThis.__setMockSearchParams('?next=%2F%2Fevil.com%2Fphish')
+
+      await submitLoginForm()
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/')
+      })
+      expect(hrefSetter).not.toHaveBeenCalled()
+    })
+
+    it('ignores an absolute URL next and falls back to home', async () => {
+      globalThis.__setMockSearchParams('?next=https%3A%2F%2Fevil.com')
+
+      await submitLoginForm()
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/')
+      })
+      expect(hrefSetter).not.toHaveBeenCalled()
+    })
+  })
+
 })


### PR DESCRIPTION
## Summary

Claude.ai の Remote MCP コネクター追加で OAuth 認可フローが「Authorization with the MCP server failed. You can check your credentials and permissions.」で失敗していました (reference: ofid_c67efe6bd75bc37b)。原因の本命は **ログインページの `?next=` 無視** です。

未ログイン状態でコネクター追加を始めるとフローは次のように進みます:

1. Claude.ai → ブラウザ → \`https://videoq.jp/api/oauth/authorize/?...\`
2. \`CookieAuthorizationView\` は access_token cookie を見つけられず → 302 → \`https://videoq.jp/login?next=%2Fapi%2Foauth%2Fauthorize%2F%3F...\`
3. SPA の LoginPage 表示・ログイン成功
4. **\`onSuccessRedirect: () => navigate('/')\`** で next を無視してホームへ
5. 認可コードが Claude.ai に返らず、最終的にエラー表示

`/api/mcp/` 401 → `/.well-known/oauth-authorization-server` → DCR → authorize 302 → token 400(grant) → MCP 401 という個別 curl はすべて期待通りに動作することは確認済みなので、サーバーサイドの設定問題は無く、UI 側の遷移ロジックが唯一の食い違い点でした。

## Changes

`frontend/src/pages/LoginPage.tsx`
- `useSearchParams` で `next` を取得
- `getSafeNextPath()` でオープンリダイレクト対策:
  - `/` で始まらないものは reject (絶対URL対策)
  - `//` または `/\\` で始まるものは reject (protocol-relative URL 対策)
- 妥当な `next` があれば `window.location.href = next` で実ナビゲーション
  (next の宛先は通常 Django の `/api/oauth/authorize/` で SPA router では捌けないため)
- 不在や不正値の場合は従来通り `navigate('/')`

SignupPage や ForgotPassword 系は別の遷移ロジック (メール認証チェックページ等) を持つため対象外。

## Test plan

- [x] `npx vitest run src/pages/__tests__/LoginPage.test.tsx` — 11/11 pass (元の8 + 新規3: safe next, protocol-relative reject, absolute URL reject)
- [x] `npx tsc --noEmit` — pass
- [x] `npx eslint LoginPage.tsx LoginPage.test.tsx` — pass
- [ ] Cloudflare Pages にデプロイされた後、未ログイン状態で Claude.ai の Remote MCP コネクター追加 → videoq.jp ログイン → consent → ツール一覧取得まで成功すること
- [ ] 通常の `/login` 直アクセス (next 無し) でログイン → ホームに戻ることを確認 (リグレッション無し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)