### PR TITLE
MCPエンドポイントを末尾スラッシュ無しURLでも受け付ける

### DIFF
--- a/backend/app/presentation/mcp/tests/test_mcp_endpoint.py
+++ b/backend/app/presentation/mcp/tests/test_mcp_endpoint.py
@@ -54,6 +54,22 @@ class MCPEndpointTests(TestCase):
         response = self._post(self._jsonrpc("initialize"), auth=False)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_no_trailing_slash_url_does_not_redirect(self):
+        # Claude.ai's Remote MCP connector cannot follow a 301 on POST and
+        # surfaces "Couldn't reach the MCP server" when the user enters the
+        # URL without the trailing slash. ``/api/mcp`` must route to the
+        # same view as ``/api/mcp/`` rather than being 301'd by APPEND_SLASH.
+        response = self.client.post(
+            "/api/mcp",
+            data=json.dumps(self._jsonrpc("initialize")),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn("result", body)
+        self.assertEqual(body["result"]["serverInfo"]["name"], "videoq-api")
+
     def test_invalid_api_key_is_rejected(self):
         self.client.credentials(HTTP_AUTHORIZATION="Bearer vq_" + "x" * 32)
         response = self.client.post(

--- a/backend/app/presentation/mcp/urls.py
+++ b/backend/app/presentation/mcp/urls.py
@@ -21,8 +21,9 @@ _mcp_view = MCPEndpointView.as_view(
     evaluation_logs_use_case=eval_deps.get_list_chat_log_evaluations_use_case,
 )
 
-# Match the include() prefix exactly; trailing-slash tolerance comes from
-# registering the include twice in videoq/urls.py.
+# Match the include() prefix exactly. ``videoq/urls.py`` mounts this
+# include under both ``api/mcp/`` and ``api/mcp`` so the endpoint
+# responds to either form without an APPEND_SLASH 301 redirect.
 urlpatterns = [
     re_path(r"^$", _mcp_view, name="mcp-endpoint"),
 ]

--- a/backend/videoq/urls.py
+++ b/backend/videoq/urls.py
@@ -43,6 +43,13 @@ urlpatterns = [
     path("api/videos/", include("app.presentation.video.urls")),
     path("api/evaluation/", include("app.presentation.evaluation.urls")),
     path("api/mcp/", include("app.presentation.mcp.urls")),
+    # Tolerate ``/api/mcp`` (no trailing slash). Django's ``APPEND_SLASH``
+    # middleware would otherwise 301 to ``/api/mcp/``, which Claude.ai's
+    # Remote MCP connector cannot follow on a POST and surfaces as
+    # "Couldn't reach the MCP server". Registering the include twice
+    # routes both forms to the same view; the canonical with-slash form
+    # is registered first so ``reverse('mcp-endpoint')`` returns it.
+    path("api/mcp", include("app.presentation.mcp.urls")),
     path("api/oauth/", include("app.presentation.oauth.urls")),
     # OAuth metadata documents (RFC 8414 / RFC 9728). Per the specs these
     # must live at the well-known path under the resource origin.


### PR DESCRIPTION
## Summary

Claude.ai の Remote MCP コネクター追加で URL に末尾スラッシュを付け忘れて `https://videoq.jp/api/mcp` と入力すると、UI に「Couldn't reach the MCP server. You can check the server URL and verify the server is running.」 が出る現象 (reference: ofid_1cfdadd1dcf42e8b) の修正です。

## Root cause

```
$ curl -i https://videoq.jp/api/mcp
HTTP/2 301
location: /api/mcp/
content-type: text/html; charset=utf-8
```

`videoq/urls.py` は `path("api/mcp/", include(...))` だけを登録していたため、末尾スラッシュ無しの URL は Django の `APPEND_SLASH` ミドルウェアが 301 で `/api/mcp/` に飛ばします。

Claude.ai の MCP クライアントは **POST に対する 301 を追従しない** ため (HTTP 仕様上 301 で POST→GET 化されて body も落ちるため安全側の挙動)、初手の `initialize` リクエストがそもそも届かず、Claude.ai 側ではサーバが応答していないように見えて上記のエラーになります。

なお `app/presentation/mcp/urls.py` のコメントには既に "trailing-slash tolerance comes from registering the include twice in videoq/urls.py" と書かれていましたが、実際は片方しか登録されていない状態でした (実装漏れ)。

## Fix

- `videoq/urls.py` で MCP の include() を `api/mcp/` と `api/mcp` の両方にマウントし、どちらの URL でも同じビューが応答するようにする
- カノニカル URL (`reverse('mcp-endpoint')` の戻り値) は引き続き with-slash 形式 (先に登録しているため)
- `protected_resource_metadata` の `resource` 値は従来通り `/api/mcp/` のまま (RFC 9728 上のリソース識別子は1つに揃える方が安全)
- `app/presentation/mcp/urls.py` の説明コメントを実装に合わせて更新
- POST `/api/mcp` (末尾スラ無し) が 301 ではなく 200 で initialize を返すことを確認する回帰テストを追加

## Test plan

- [x] `docker compose run --rm backend python manage.py test app.presentation.mcp.tests` — 20/20 pass (新規 `test_no_trailing_slash_url_does_not_redirect` 含む)
- [x] `docker compose run --rm backend python manage.py test app.presentation.oauth.tests app.presentation.mcp.tests` — 33/33 pass
- [ ] デプロイ後、`curl -i -X POST https://videoq.jp/api/mcp` が 301 ではなく 401 (with `WWW-Authenticate`) を返すこと
- [ ] Claude.ai のコネクター追加で `https://videoq.jp/api/mcp` (末尾スラ無し) を入力 → 接続完了まで進めること
- [ ] 既存の `https://videoq.jp/api/mcp/` も引き続き動作すること (リグレッション無し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)