### PR TITLE
gunicorn のアクセスログを CloudWatch に出して MCP/OAuth フローを診断する

### DIFF
--- a/backend/Dockerfile.lambda
+++ b/backend/Dockerfile.lambda
@@ -47,4 +47,6 @@ CMD ["gunicorn", "videoq.asgi:application", \
     "--threads", "4", \
     "--timeout", "0", \
     "--worker-tmp-dir", "/tmp", \
-    "--log-file", "-"]
+    "--log-file", "-", \
+    "--access-logfile", "-", \
+    "--access-logformat", "ACCESS \"%(r)s\" %(s)s %(D)sus origin=%({origin}i)s referer=%({referer}i)s ua=%({user-agent}i)s"]


### PR DESCRIPTION
## Why

Claude.ai の Remote MCP コネクター追加が「Authorization with the MCP server failed」で繰り返し失敗していますが、Lambda の CloudWatch Logs には gunicorn の起動行と START/REPORT しか出ておらず、Claude.ai がどのパスにどう叩いてどんなレスポンスをもらったかが見えません。推測ベースで PR を重ねるより、最短で実リクエストを観測する方が早いです。

## Change

`backend/Dockerfile.lambda` の gunicorn 起動コマンドに以下を追加:

\`\`\`
"--access-logfile", "-",
"--access-logformat", "ACCESS \"%(r)s\" %(s)s %(D)sus origin=%({origin}i)s referer=%({referer}i)s ua=%({user-agent}i)s"
\`\`\`

これで stdout に以下のような行が出力され、Lambda Web Adapter 経由で CloudWatch に流れます:

\`\`\`
ACCESS "POST /api/mcp/ HTTP/1.1" 200 18345us origin=- referer=- ua=Anthropic-MCP-Client/1.0
ACCESS "POST /api/oauth/token/ HTTP/1.1" 200 87234us origin=- referer=- ua=Anthropic-MCP-Client/1.0
ACCESS "GET /api/oauth/authorize/?response_type=code&... HTTP/1.1" 302 1234us origin=- referer=https://claude.ai/ ua=Mozilla/5.0
\`\`\`

**Authorization ヘッダーの値 (Bearer トークン) はログに含めません** — トークン漏洩を避けるため、access-logformat にはあえて含めていません。

## Test plan

- [ ] マージ後、CD 経由で Lambda が再デプロイされること
- [ ] 任意のリクエスト (例: `curl https://videoq.jp/api/health/`) 後に `aws logs tail /aws/lambda/videoq-api-prod --since 1m | grep ACCESS` で1行ヒットすること
- [ ] その後 Claude.ai のコネクター追加フローを実行 → CloudWatch で各リクエストの path/status を確認し根本原因を特定 → 別 PR で fix

## Cleanup

恒久的に access log を出したくない場合は、診断が終わった段階で revert (もしくは log level を絞る) する想定です。とはいえアクセスログは標準的なオブザーバビリティなので、そのまま残しても害はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)