### PR TITLE
保護リソースメタデータを bare /.well-known/oauth-protected-resource でも返す

### DIFF
--- a/backend/app/presentation/oauth/tests/test_oauth_endpoints.py
+++ b/backend/app/presentation/oauth/tests/test_oauth_endpoints.py
@@ -68,6 +68,17 @@ class WellKnownMetadataTests(TestCase):
         self.assertEqual(body["resource"], "http://testserver/api/mcp/")
         self.assertIn("http://testserver", body["authorization_servers"])
 
+    def test_protected_resource_metadata_also_served_at_bare_path(self):
+        # Claude.ai's Remote MCP connector probes the bare
+        # ``/.well-known/oauth-protected-resource`` path in addition to the
+        # path-concatenated form. A 404 there causes the connector to
+        # abort discovery before opening the authorize URL.
+        resp = self.client.get("/.well-known/oauth-protected-resource")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["resource"], "http://testserver/api/mcp/")
+        self.assertIn("http://testserver", body["authorization_servers"])
+
 
 @override_settings(OAUTH2_PROVIDER_ISSUER_URL="http://testserver")
 class DynamicClientRegistrationTests(TestCase):

--- a/backend/videoq/urls.py
+++ b/backend/videoq/urls.py
@@ -63,6 +63,17 @@ urlpatterns = [
         ProtectedResourceMetadataView.as_view(),
         name="oauth-protected-resource-metadata",
     ),
+    # Also serve the same document at the bare ``/.well-known/oauth-protected-resource``
+    # path. RFC 9728 path-concatenates the resource path onto the well-known
+    # prefix, but Claude.ai's Remote MCP connector additionally probes the bare
+    # path and treats a 404 here as "server is not an MCP-compliant resource",
+    # giving up before it even opens the authorize URL (observed via gunicorn
+    # access logs during the ofid_5a2b07ad211b3330 attempt).
+    path(
+        ".well-known/oauth-protected-resource",
+        ProtectedResourceMetadataView.as_view(),
+        name="oauth-protected-resource-metadata-bare",
+    ),
     path("api/", include("app.urls")),
     path("api/v1/", include("app.presentation.chat.openai_urls")),
 ]


### PR DESCRIPTION
## Why (PR #773 で観測した実トラフィック)

PR #773 で gunicorn のアクセスログを CloudWatch に流せるようにしたところ、Claude.ai の Remote MCP コネクター追加が **DCR まで完了したあと /api/oauth/authorize/ も /api/oauth/token/ も叩かずに諦めている** ことが判明しました (reference: ofid_5a2b07ad211b3330)。

実トラフィック (時系列):

\`\`\`
13:06:46.761  GET  /.well-known/oauth-protected-resource          → 404 ⚠️
13:06:46.824  GET  /.well-known/oauth-protected-resource/api/mcp  → 200
13:06:47.346  GET  /.well-known/oauth-authorization-server        → 200
13:06:48.610  POST /api/oauth/register/                           → 201 (DCR 成功)
13:06:49.018  POST /api/mcp                                       → 401
13:06:50.103  POST /api/mcp                                       → 401
(以降 authorize / token への遷移なし)
\`\`\`

つまり Claude.ai の連携 UI 側でユーザーをブラウザの認可画面にリダイレクトする手前で打ち切られていて、これが UI には「Couldn't reach the MCP server」として表示されています。

## Root cause

RFC 9728 §3.1 は protected resource metadata の well-known URL を「prefix + resource-path」で組み立てるよう定めており、我々の `https://videoq.jp/.well-known/oauth-protected-resource/api/mcp` はその通り (200) です。一方 Claude.ai は互換性確保のため **`/.well-known/oauth-protected-resource` (resource-path 抜き) も並行プローブし、404 が返ると「サーバが MCP 仕様非準拠」と判断して discovery 全体を打ち切る** 挙動になっていました。

`WWW-Authenticate` で suffix 付き URL をヒントとして返しているので本来必要ないはずですが、Claude.ai の実装が両方を要求しているため、ここで合わせます。

## Fix

`videoq/urls.py` で同じ `ProtectedResourceMetadataView` を bare path にも公開:

\`\`\`python
path(
    ".well-known/oauth-protected-resource",
    ProtectedResourceMetadataView.as_view(),
    name="oauth-protected-resource-metadata-bare",
),
\`\`\`

レスポンス内容は従来の suffix 付き版と完全に同じ:

\`\`\`json
{
  "resource": "https://videoq.jp/api/mcp/",
  "authorization_servers": ["https://videoq.jp"],
  "bearer_methods_supported": ["header"],
  "scopes_supported": ["read"],
  ...
}
\`\`\`

回帰テスト `test_protected_resource_metadata_also_served_at_bare_path` を追加。

## Test plan

- [x] `docker compose run --rm backend python manage.py test app.presentation.oauth.tests` — 14/14 pass
- [ ] デプロイ後、`curl -sS https://videoq.jp/.well-known/oauth-protected-resource | jq` で 200 + 正しい JSON
- [ ] 既存の `/.well-known/oauth-protected-resource/api/mcp` も従来通り 200 (リグレッション無し)
- [ ] Claude.ai のコネクター追加で `https://videoq.jp/api/mcp` (もしくは `/api/mcp/`) を入力 → DCR の先の authorize → consent → ツール一覧取得まで進めること

🤖 Generated with [Claude Code](https://claude.com/claude-code)