### PR TITLE
DCR で confidential クライアントに本物の client_secret を返す

### DIFF
--- a/backend/app/infrastructure/oauth/dot_client_gateway.py
+++ b/backend/app/infrastructure/oauth/dot_client_gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import cast
 
 from django.utils import timezone
+from oauth2_provider.generators import generate_client_secret
 from oauth2_provider.models import (
     AccessToken,
     Application,
@@ -32,6 +33,19 @@ class DOTOAuthClientGateway(OAuthClientGateway):
         else:
             client_type = ApplicationModel.CLIENT_CONFIDENTIAL
 
+        # django-oauth-toolkit hashes Application.client_secret on save when
+        # HASH_CLIENT_SECRET=True (default since 2.4). If we let create()
+        # auto-generate the secret and then read ``application.client_secret``,
+        # we get the PBKDF2 hash, not the plaintext, which we then leak to the
+        # client. The client stores the hash as its credential, sends it back
+        # on /api/oauth/token/, DOT re-hashes it, no match → invalid_client.
+        # Generate the plaintext ourselves and let save() hash it on the way in.
+        plaintext_secret: str | None
+        if client_type == ApplicationModel.CLIENT_CONFIDENTIAL:
+            plaintext_secret = generate_client_secret()
+        else:
+            plaintext_secret = None
+
         application: Application = ApplicationModel.objects.create(
             name=request.client_name or "MCP Client",
             client_type=client_type,
@@ -41,17 +55,14 @@ class DOTOAuthClientGateway(OAuthClientGateway):
             redirect_uris=" ".join(request.redirect_uris),
             # PKCE is required project-wide via OAUTH2_PROVIDER.PKCE_REQUIRED;
             # public clients use PKCE in place of a client_secret.
+            client_secret=plaintext_secret or "",
             skip_authorization=False,
         )
 
-        plaintext_secret: str | None
-        # django-oauth-toolkit returns the raw secret on create() before hashing.
-        raw_secret = getattr(application, "client_secret", "") or ""
-        if client_type == ApplicationModel.CLIENT_CONFIDENTIAL:
-            plaintext_secret = raw_secret
-        else:
-            plaintext_secret = None
-            # Public clients must not present a usable secret.
+        if client_type != ApplicationModel.CLIENT_CONFIDENTIAL:
+            # Public clients must not present a usable secret. Re-save with an
+            # empty secret so DOT's authenticate_client_id path is the only way
+            # to authenticate this client.
             application.client_secret = ""
             application.save(update_fields=["client_secret"])
 

--- a/backend/app/presentation/oauth/tests/test_oauth_endpoints.py
+++ b/backend/app/presentation/oauth/tests/test_oauth_endpoints.py
@@ -102,6 +102,39 @@ class DynamicClientRegistrationTests(TestCase):
         app = ApplicationModel.objects.get(client_id=payload["client_id"])
         self.assertEqual(app.client_type, ApplicationModel.CLIENT_PUBLIC)
 
+    def test_registers_confidential_client_returns_plaintext_secret(self):
+        # Regression for ofid_11632eb5d8076f28: when DCR auth method requires
+        # a client secret, the response must contain the plaintext so the
+        # client can use it on the token endpoint. Previously we returned
+        # the PBKDF2 hash that DOT writes to the DB on save(), which made
+        # token exchange always 401 with invalid_client.
+        body = {
+            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+            "client_name": "Confidential client",
+            "token_endpoint_auth_method": "client_secret_basic",
+        }
+        resp = self.client.post(
+            "/api/oauth/register/",
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        payload = resp.json()
+        self.assertIn("client_secret", payload)
+        secret = payload["client_secret"]
+        # Plaintext, not a PBKDF2 hash.
+        self.assertFalse(
+            secret.startswith("pbkdf2_"),
+            f"client_secret leaked as hash: {secret}",
+        )
+        # The DB row must actually validate the plaintext we returned: DOT
+        # stored it as a Django password hash on save(), so the stored value
+        # is not the plaintext and we verify it via the password hasher.
+        from django.contrib.auth.hashers import check_password
+        app = ApplicationModel.objects.get(client_id=payload["client_id"])
+        self.assertEqual(app.client_type, ApplicationModel.CLIENT_CONFIDENTIAL)
+        self.assertTrue(check_password(secret, app.client_secret))
+
     def test_rejects_non_localhost_http_redirect(self):
         body = {
             "redirect_uris": ["http://example.com/callback"],


### PR DESCRIPTION
## Root cause (PR #773 のアクセスログで特定)

PR #774 (bare /.well-known/oauth-protected-resource 対応) のデプロイ後、Claude.ai のフローは authorize 画面 → ユーザーの "Authorize" 押下まで進めるようになったものの、その直後の token exchange が失敗していました (reference: ofid_11632eb5d8076f28):

\`\`\`
13:26:21.715  POST /api/oauth/authorize/?...  → 302  (Authorize 押下)
13:26:24.195  POST /api/oauth/token/          → 401  ⚠️  invalid_client
\`\`\`

curl で確証を取りました:

\`\`\`
$ curl -sS https://videoq.jp/api/oauth/register/ -d '{...,"token_endpoint_auth_method":"client_secret_basic"}'
{"client_secret": "pbkdf2_sha256$1200000$gFKkOCiiRpWr6TN6scvhBu$Uaq7KL0FJzsl5..."}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
\`\`\`

DCR レスポンスの \`client_secret\` が **PBKDF2 ハッシュそのもの** になっていました。django-oauth-toolkit 2.4 以降、\`Application.save()\` は \`HASH_CLIENT_SECRET=True\` を既定として client_secret を Django の password hasher (\`pbkdf2_sha256\`) でハッシュ化します。我々の DCR ゲートウェイは

\`\`\`python
application = ApplicationModel.objects.create(...)              # ← この時点でハッシュ化済み
raw_secret = getattr(application, "client_secret", "") or ""    # ← ハッシュを取得
\`\`\`

の順で実装されていたため、本来クライアントに返すべきプレーンテキストの代わりに **ハッシュ文字列を返してしまっていました**。Claude.ai はそのハッシュをそのまま Basic 認証で送信 → DOT が再度ハッシュ化して比較 → 不一致 → \`invalid_client\` (401)。

これが「Authorization with the MCP server failed」の真の原因でした。

## Fix

DOT の \`generate_client_secret()\` でプレーンテキストを **先に** 生成し、\`create()\` に明示的に渡すことで、save() でハッシュ化される過程は維持しつつクライアントには使えるプレーンテキストを返す形にします。

\`\`\`python
from oauth2_provider.generators import generate_client_secret

if client_type == ApplicationModel.CLIENT_CONFIDENTIAL:
    plaintext_secret = generate_client_secret()
else:
    plaintext_secret = None

application = ApplicationModel.objects.create(
    ...
    client_secret=plaintext_secret or "",
)
\`\`\`

Public client (\`token_endpoint_auth_method=none\`) の挙動は不変。

## Regression test

新規テスト \`test_registers_confidential_client_returns_plaintext_secret\` で:
- レスポンスの client_secret が \`pbkdf2_\` で始まらないこと
- DB に保存された値が、返却したプレーンテキストを Django の \`check_password\` で正しく検証できること

を assert します。

## Test plan

- [x] \`docker compose run --rm backend python manage.py test app.presentation.oauth.tests\` — 15/15 pass
- [ ] デプロイ後、\`curl -X POST https://videoq.jp/api/oauth/register/ -d '...client_secret_basic'\` のレスポンスが \`pbkdf2_\` で始まらないこと
- [ ] そのまま返却された client_secret で Basic 認証して \`POST /api/oauth/token/\` を叩くと \`invalid_grant\` (= client auth 成功) になること (\`invalid_client\` でないこと)
- [ ] Claude.ai のコネクター追加でフロー全部 (discovery → DCR → authorize → consent → **token exchange** → MCP call) を通過すること

## あわせて確認すべきこと

PR #770 の cdk-deploy.yml と CI ワークフローの worker ジョブが ffmpeg ミラー (johnvansickle.com) の一過性 415 で連続失敗しています。今回の API Lambda 部分は \`Deploy Backend API\` ジョブが別建てなので影響なくデプロイされましたが、Worker ジョブの再現性のあるダウンロード元への切り替えは別件で検討する価値があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)