### PR TITLE
OAuth consent 画面を SPA の AuthLayout に揃え ja/en に対応

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR ${APP_HOME}
 
 RUN apt-get update && apt-get install -y \
     ffmpeg \
+    gettext \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./
@@ -16,6 +17,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 RUN python -m nltk.downloader -d /usr/local/nltk_data averaged_perceptron_tagger_eng punkt_tab
 
 COPY . .
+
+RUN python manage.py compilemessages
 
 EXPOSE 8000
 

--- a/backend/Dockerfile.lambda
+++ b/backend/Dockerfile.lambda
@@ -12,8 +12,8 @@ FROM public.ecr.aws/docker/library/python:3.12-slim
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0-rc1 /lambda-adapter /opt/extensions/lambda-adapter 
 WORKDIR /var/task
 
-# ffmpeg
-RUN apt-get update && apt-get install -y --no-install-recommends curl xz-utils \
+# ffmpeg + gettext (for compilemessages)
+RUN apt-get update && apt-get install -y --no-install-recommends curl xz-utils gettext \
     && curl -fsSL \
     "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz" \
     | tar -xJ --wildcards --strip-components=1 \
@@ -32,6 +32,9 @@ RUN python -m nltk.downloader -d /usr/local/nltk_data \
     averaged_perceptron_tagger_eng punkt_tab
 
 COPY . .
+
+# Django gettext message catalogs (.po → .mo) for OAuth consent screen i18n
+RUN python manage.py compilemessages
 
 # Django static files を収集
 RUN python manage.py collectstatic --noinput || true

--- a/backend/app/presentation/oauth/authorize_view.py
+++ b/backend/app/presentation/oauth/authorize_view.py
@@ -10,7 +10,7 @@ parameter so they can return to the consent screen after signing in.
 
 from __future__ import annotations
 
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from django.conf import settings
 from django.http import HttpResponseRedirect
@@ -36,6 +36,32 @@ class CookieAuthorizationView(AuthorizationView):
             return self._redirect_to_login(request)
 
         return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Surface the redirect_uri's host so the consent UI can show users
+        # *where* they're about to be sent. Without this the screen only
+        # shows the (attacker-controlled, DCR-supplied) client_name.
+        redirect_uri = None
+        form = context.get("form")
+        if form is not None:
+            initial = getattr(form, "initial", None) or {}
+            redirect_uri = initial.get("redirect_uri")
+            if not redirect_uri:
+                bound = form.data.get("redirect_uri") if hasattr(form, "data") else None
+                redirect_uri = bound
+        if not redirect_uri:
+            application = context.get("application")
+            if application is not None:
+                redirect_uri = getattr(application, "default_redirect_uri", None)
+        if redirect_uri:
+            try:
+                context["redirect_uri_host"] = (
+                    urlparse(redirect_uri).hostname or redirect_uri
+                )
+            except ValueError:
+                context["redirect_uri_host"] = redirect_uri
+        return context
 
     @staticmethod
     def _redirect_to_login(request) -> HttpResponseRedirect:

--- a/backend/app/templates/oauth2_provider/authorize.html
+++ b/backend/app/templates/oauth2_provider/authorize.html
@@ -1,82 +1,360 @@
 {% load i18n %}<!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE|default:'en' }}">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{% trans "Authorize" %} {{ application.name }} — VideoQ</title>
+  <title>{% blocktrans with app_name=application.name %}Authorize {{ app_name }} — VideoQ{% endblocktrans %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" />
   <style>
-    :root { color-scheme: light; }
+    :root {
+      color-scheme: light;
+      --green-dark: #00652c;
+      --green-mid: #15803d;
+      --green-pale: #d3ffd5;
+      --ink: #191c19;
+      --ink-soft: #3f493f;
+      --ink-mute: #6f7a6e;
+      --border: #e6e8e4;
+      --bg: #ffffff;
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
     body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
       margin: 0;
+      /* Match Tailwind's default font-sans stack used by the SPA body.
+         Plus Jakarta Sans is applied per-element to brand text only. */
+      font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+        "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+      color: var(--ink);
+      background: var(--bg);
+    }
+    main {
+      display: flex;
+      flex-direction: column;
       min-height: 100vh;
+    }
+    .brand-pane {
+      display: none;
+      position: relative;
+      background: var(--green-mid);
+      color: #ffffff;
+      padding: 48px;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+    .brand-pane::before,
+    .brand-pane::after {
+      content: "";
+      position: absolute;
+      width: 384px;
+      height: 384px;
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 50%;
+      filter: blur(64px);
+    }
+    .brand-pane::before { bottom: -96px; left: -96px; }
+    .brand-pane::after { top: -96px; right: -96px; }
+    .brand-stack {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
+    }
+    .brand-icon {
+      background: rgba(255, 255, 255, 0.1);
+      -webkit-backdrop-filter: blur(12px);
+      backdrop-filter: blur(12px);
+      padding: 16px;
+      border-radius: 16px;
+    }
+    .brand-text { text-align: center; }
+    .brand-name {
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-weight: 800;
+      font-size: 36px;
+      line-height: 40px;
+      letter-spacing: -0.025em;
+      margin: 0 0 8px;
+    }
+    .brand-tagline {
+      color: rgba(255, 255, 255, 0.7);
+      font-size: 14px;
+      line-height: 20px;
+      font-weight: 500;
+      letter-spacing: 0.025em;
+      margin: 0;
+    }
+    .form-pane {
+      flex: 1;
+      background: #ffffff;
       display: flex;
       align-items: center;
       justify-content: center;
-      background: #f7f8f4;
-      color: #191c19;
-      padding: 24px;
-    }
-    .card {
-      width: 100%;
-      max-width: 420px;
-      background: #ffffff;
-      border-radius: 16px;
-      box-shadow: 0 6px 30px rgba(28, 25, 23, 0.08);
       padding: 32px;
     }
-    .brand { font-weight: 700; color: #00652c; font-size: 14px; letter-spacing: 0.04em; }
-    h1 { font-size: 22px; margin: 12px 0 8px; }
-    p { color: #3f493f; line-height: 1.5; }
-    ul { background: #f2f4ef; border-radius: 12px; padding: 16px 24px; }
-    li { margin: 4px 0; color: #191c19; }
-    .actions { display: flex; gap: 12px; margin-top: 24px; }
+    .form-stack {
+      width: 100%;
+      max-width: 440px;
+      display: flex;
+      flex-direction: column;
+    }
+    .mobile-brand {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      justify-content: center;
+      margin-bottom: 32px;
+      color: var(--green-dark);
+    }
+    .mobile-brand-name {
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-weight: 800;
+      font-size: 24px;
+      line-height: 32px;
+      letter-spacing: -0.025em;
+    }
+    .intro { margin-bottom: 32px; }
+    .badge {
+      display: inline-flex;
+      padding: 6px 16px;
+      border-radius: 999px;
+      background: var(--green-pale);
+      color: #2c4e32;
+      font-size: 12px;
+      line-height: 16px;
+      font-weight: 700;
+      letter-spacing: 0.025em;
+      margin-bottom: 24px;
+    }
+    h1 {
+      font-weight: 800;
+      font-size: 30px;
+      line-height: 1.25;
+      letter-spacing: -0.025em;
+      color: var(--ink);
+      margin: 0;
+    }
+    .accent {
+      height: 6px;
+      width: 56px;
+      background: var(--green-dark);
+      border-radius: 999px;
+      margin: 16px 0 24px;
+    }
+    .lead {
+      color: var(--ink-mute);
+      font-size: 14px;
+      line-height: 1.625;
+      margin: 0;
+    }
+    .meta {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 8px 16px;
+      padding: 16px 20px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      margin: 0 0 24px;
+    }
+    .meta dt {
+      font-weight: 700;
+      color: #6b7280;
+      font-size: 12px;
+      line-height: 16px;
+      align-self: center;
+    }
+    .meta dd {
+      margin: 0;
+      color: var(--ink);
+      font-size: 14px;
+      line-height: 20px;
+      word-break: break-all;
+    }
+    .scopes {
+      list-style: none;
+      margin: 0 0 24px;
+      padding: 16px 20px;
+      background: #f2f4ef;
+      border-radius: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .scopes li {
+      color: var(--ink);
+      font-size: 14px;
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+    }
+    .scopes li::before {
+      content: "";
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--green-dark);
+      margin-top: 8px;
+      flex-shrink: 0;
+    }
+    .warning {
+      display: flex;
+      gap: 12px;
+      padding: 14px 16px;
+      background: #fff9e6;
+      border: 1px solid #f5d780;
+      border-radius: 12px;
+      color: #6b4f00;
+      font-size: 13px;
+      line-height: 1.5;
+      margin-bottom: 24px;
+    }
+    .warning svg { flex-shrink: 0; margin-top: 2px; }
+    .actions {
+      display: flex;
+      gap: 12px;
+      margin-top: 8px;
+    }
     button {
       flex: 1;
       border: 0;
       border-radius: 12px;
-      padding: 12px 16px;
+      padding: 16px;
       font-size: 14px;
       font-weight: 700;
+      font-family: inherit;
       cursor: pointer;
+      transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
     }
-    .cancel { background: #f2f4ef; color: #3f493f; }
-    .allow { background: #00652c; color: #ffffff; }
-    .allow:hover { background: #004b1f; }
-    .error { background: #fff0f0; color: #b91d1d; padding: 16px; border-radius: 12px; }
+    .cancel {
+      background: #f2f4ef;
+      color: var(--ink-soft);
+    }
+    .cancel:hover { background: #e6e8e0; }
+    .allow {
+      background: var(--green-dark);
+      color: #ffffff;
+      box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+    }
+    .allow:hover {
+      background: #005323;
+      transform: translateY(-2px);
+      box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+    }
+    .allow:active { transform: scale(0.98); }
+    .error-card {
+      background: #fef2f2;
+      color: #dc2626;
+      border: 1px solid #fecaca;
+      padding: 12px;
+      border-radius: 12px;
+      font-size: 14px;
+    }
+    .error-card strong { display: block; margin-bottom: 4px; }
+    .error-card p { margin: 0; line-height: 1.5; }
+    .footer {
+      margin-top: 64px;
+      text-align: center;
+      color: #9ca3af;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+    }
+    @media (min-width: 640px) {
+      .form-pane { padding: 48px; }
+    }
+    @media (min-width: 768px) {
+      main { flex-direction: row; }
+      .brand-pane { display: flex; width: 50%; }
+      .form-pane { width: 50%; }
+      .mobile-brand { display: none; }
+    }
   </style>
 </head>
 <body>
-  <div class="card">
-    <div class="brand">VideoQ</div>
-    {% if not error %}
-      <h1>{% blocktrans with app_name=application.name %}Authorize {{ app_name }}?{% endblocktrans %}</h1>
-      <p>{% trans "This app is requesting access to your VideoQ account with the following scope:" %}</p>
-      <ul>
-        {% for scope in scopes_descriptions %}
-          <li>{{ scope }}</li>
-        {% endfor %}
-      </ul>
-
-      <form id="authorizationForm" method="post">
-        {% csrf_token %}
-        {% for field in form %}
-          {% if field.is_hidden %}{{ field }}{% endif %}
-        {% endfor %}
-        {{ form.errors }}
-        {{ form.non_field_errors }}
-        <div class="actions">
-          <button class="cancel" type="submit" name="allow" value="">{% trans "Cancel" %}</button>
-          <button class="allow" type="submit" name="allow" value="True">{% trans "Authorize" %}</button>
+  <main>
+    <section class="brand-pane">
+      <div class="brand-stack">
+        <div class="brand-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"/><circle cx="12" cy="12" r="10"/></svg>
         </div>
-      </form>
-    {% else %}
-      <h1>{% trans "Authorization error" %}</h1>
-      <div class="error">
-        <strong>{{ error.error }}</strong>
-        <p>{{ error.description }}</p>
+        <div class="brand-text">
+          <h2 class="brand-name">VideoQ</h2>
+          <p class="brand-tagline">{% trans "Transform every video into the ultimate learning experience" %}</p>
+        </div>
       </div>
-    {% endif %}
-  </div>
+    </section>
+
+    <section class="form-pane">
+      <div class="form-stack">
+        <div class="mobile-brand">
+          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 9.003a1 1 0 0 1 1.517-.859l4.997 2.997a1 1 0 0 1 0 1.718l-4.997 2.997A1 1 0 0 1 9 14.996z"/><circle cx="12" cy="12" r="10"/></svg>
+          <span class="mobile-brand-name">VideoQ</span>
+        </div>
+
+        {% if not error %}
+          <div class="intro">
+            <span class="badge">{% trans "Connect a client" %}</span>
+            <h1>{% blocktrans with app_name=application.name %}Authorize {{ app_name }}?{% endblocktrans %}</h1>
+            <div class="accent"></div>
+            <p class="lead">{% trans "This app is requesting access to your VideoQ account with the following scopes." %}</p>
+          </div>
+
+          <dl class="meta">
+            <dt>{% trans "Client" %}</dt>
+            <dd>{{ application.name }}</dd>
+            {% if redirect_uri_host %}
+              <dt>{% trans "Redirects to" %}</dt>
+              <dd>{{ redirect_uri_host }}</dd>
+            {% endif %}
+          </dl>
+
+          <ul class="scopes">
+            {% for scope in scopes_descriptions %}
+              <li>{{ scope }}</li>
+            {% endfor %}
+          </ul>
+
+          {% if not application.user_id %}
+            <div class="warning" role="note">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              <span>{% trans "This client registered itself via Dynamic Client Registration and has not been reviewed by VideoQ. Make sure the client name and redirect destination match the app you expect before authorizing." %}</span>
+            </div>
+          {% endif %}
+
+          <form id="authorizationForm" method="post">
+            {% csrf_token %}
+            {% for field in form %}
+              {% if field.is_hidden %}{{ field }}{% endif %}
+            {% endfor %}
+            {{ form.errors }}
+            {{ form.non_field_errors }}
+            <div class="actions">
+              <button class="cancel" type="submit" name="allow" value="">{% trans "Cancel" %}</button>
+              <button class="allow" type="submit" name="allow" value="True">{% trans "Authorize" %}</button>
+            </div>
+          </form>
+        {% else %}
+          <div class="intro">
+            <span class="badge">{% trans "Connect a client" %}</span>
+            <h1>{% trans "Authorization error" %}</h1>
+            <div class="accent"></div>
+          </div>
+          <div class="error-card">
+            <strong>{{ error.error }}</strong>
+            <p>{{ error.description }}</p>
+          </div>
+        {% endif %}
+
+        <div class="footer">{% now "Y" as current_year %}{% blocktrans with year=current_year %}© {{ year }} VideoQ — Every learning moment{% endblocktrans %}</div>
+      </div>
+    </section>
+  </main>
 </body>
 </html>

--- a/backend/locale/en/LC_MESSAGES/django.po
+++ b/backend/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,57 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: videoq\n"
+"Report-Msgid-Bugs-To: \n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Authorize %(app_name)s — VideoQ"
+msgstr "Authorize %(app_name)s — VideoQ"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Transform every video into the ultimate learning experience"
+msgstr "Transform every video into the ultimate learning experience"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Connect a client"
+msgstr "Connect a client"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Authorize %(app_name)s?"
+msgstr "Authorize %(app_name)s?"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "This app is requesting access to your VideoQ account with the following scopes."
+msgstr "This app is requesting access to your VideoQ account with the following scopes."
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Client"
+msgstr "Client"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Redirects to"
+msgstr "Redirects to"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "This client registered itself via Dynamic Client Registration and has not been reviewed by VideoQ. Make sure the client name and redirect destination match the app you expect before authorizing."
+msgstr "This client registered itself via Dynamic Client Registration and has not been reviewed by VideoQ. Make sure the client name and redirect destination match the app you expect before authorizing."
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Cancel"
+msgstr "Cancel"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Authorize"
+msgstr "Authorize"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Authorization error"
+msgstr "Authorization error"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "© %(year)s VideoQ — Every learning moment"
+msgstr "© %(year)s VideoQ — Every learning moment"

--- a/backend/locale/ja/LC_MESSAGES/django.po
+++ b/backend/locale/ja/LC_MESSAGES/django.po
@@ -1,0 +1,57 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: videoq\n"
+"Report-Msgid-Bugs-To: \n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Authorize %(app_name)s — VideoQ"
+msgstr "%(app_name)s を許可 — VideoQ"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Transform every video into the ultimate learning experience"
+msgstr "あらゆるビデオを、最高の学びの体験へ"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Connect a client"
+msgstr "コネクター連携"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Authorize %(app_name)s?"
+msgstr "%(app_name)s を許可しますか？"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "This app is requesting access to your VideoQ account with the following scopes."
+msgstr "このアプリは次のスコープで VideoQ アカウントへのアクセスを求めています。"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Client"
+msgstr "クライアント"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Redirects to"
+msgstr "リダイレクト先"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "This client registered itself via Dynamic Client Registration and has not been reviewed by VideoQ. Make sure the client name and redirect destination match the app you expect before authorizing."
+msgstr "このクライアントは Dynamic Client Registration によって自動登録された未審査のアプリです。クライアント名とリダイレクト先が想定どおりであることを確認してから許可してください。"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Authorize"
+msgstr "許可する"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "Authorization error"
+msgstr "認可エラー"
+
+#: app/templates/oauth2_provider/authorize.html
+msgid "© %(year)s VideoQ — Every learning moment"
+msgstr "© %(year)s VideoQ — あらゆる学びのシーンに"

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -214,6 +214,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -226,7 +227,10 @@ ROOT_URLCONF = "videoq.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        # Listed before APP_DIRS lookup so our overrides (e.g. the OAuth
+        # consent screen at app/templates/oauth2_provider/authorize.html)
+        # win against the third-party defaults shipped by oauth2_provider.
+        "DIRS": [BASE_DIR / "app" / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -294,6 +298,13 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
 LANGUAGE_CODE = "en-us"
+
+LANGUAGES = [
+    ("en", "English"),
+    ("ja", "日本語"),
+]
+
+LOCALE_PATHS = [BASE_DIR / "locale"]
 
 TIME_ZONE = "America/Chicago"
 


### PR DESCRIPTION
## Summary
- Claude Desktop / claude.ai の Remote MCP コネクター登録時に表示される django-oauth-toolkit の同意画面を SPA (`LoginPage` / `AuthLayout`) と同じデザイン言語で書き直し
- これまで `INSTALLED_APPS` の順序で upstream の Bootstrap 製テンプレが先勝ちしており、既存の `app/templates/oauth2_provider/authorize.html` は **dead code 化**していたため、`TEMPLATES.DIRS` で明示的にオーバーライドが効くように修正
- `client_name` / `redirect_uri` のホスト名表示と DCR 自動登録クライアントの未審査警告を追加し、consent フィッシングを抑止
- gettext + `LocaleMiddleware` を有効化し、ja / en のカタログを追加

## Why
直近 PR #768 で DCR 対応した直後の consent 画面が、Bootstrap 2.3 のままの素っ気ない見た目で SPA とまったく別物だった。原因調査の過程で「override が一度も効いていなかった」ことも判明したため、デザイン刷新と同時に template 解決順序の不具合も修正している。

DCR は誰でも匿名で叩けるので、`client_name` を攻撃者が自由に設定した偽クライアントが consent でフィッシングを試みる余地がある。`redirect_uri` のホスト名と「Dynamic Client Registration 経由の未審査クライアント」警告を画面に明示し、ユーザーが許可前に検知できるようにした。

## What changed
- **`videoq/settings.py`**
  - `TEMPLATES.DIRS` に `BASE_DIR / "app" / "templates"` を追加（override が効くように）
  - `LocaleMiddleware` を MIDDLEWARE に追加
  - `LANGUAGES` / `LOCALE_PATHS` を定義
- **`app/templates/oauth2_provider/authorize.html`** — 全面書き換え
  - 2 ペイン構成（左 `#15803d` ブランド / 右 白フォーム）
  - `text-3xl/4xl/xs/sm` + `leading-tight/relaxed` + `tracking-tight/wide` を Tailwind の実数値で再現
  - Plus Jakarta Sans は VideoQ 文字にだけ適用（body は system sans）
  - lucide v0.560 の path 形式 `CirclePlay` を inline SVG として埋め込み
  - `client_name` / `redirect_uri` ホスト名表示 + DCR 未審査警告ボックス
- **`app/presentation/oauth/authorize_view.py`** — `CookieAuthorizationView.get_context_data` で `redirect_uri_host` を計算
- **`locale/{ja,en}/LC_MESSAGES/django.po`** — 新規追加（SPA の i18n key と同じ言い回し）
- **`Dockerfile` / `Dockerfile.lambda`** — `gettext` インストール + ビルド時 `compilemessages`

## Test plan
- [x] 既存 OAuth テスト 15/15 通過 (`docker compose run --rm backend python manage.py test app.presentation.oauth app.infrastructure.oauth`)
- [x] `Accept-Language: ja` / `en` 双方で `authorize.html` をレンダリングし、翻訳・未審査警告・ホスト名表示を確認
- [x] テンプレ origin を `get_template().origin.name` で確認し、`/app/app/templates/oauth2_provider/authorize.html` が優先される事を検証
- [ ] Lambda 環境にデプロイ後、Claude Desktop の Remote MCP コネクター登録フローで同意画面を実機確認
- [ ] PR マージ後、ja / en ブラウザで consent 画面の i18n を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)