### PR TITLE
docker compose で OAuth discovery が壊れていた問題を修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,16 @@ CORS_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1
 # This value is also passed to the frontend as VITE_USE_S3_STORAGE via docker-compose.
 USE_S3_STORAGE=False
 FRONTEND_URL=http://localhost
+
+# OAuth 2.1 issuer URL for the Remote MCP endpoint. Must be the *public*
+# origin clients reach the API on. Discovery (.well-known/oauth-authorization-server,
+# .well-known/oauth-protected-resource) returns absolute URLs built from this.
+# Wrong value here → Claude Desktop / claude.ai's connector flow fails because
+# the issued discovery URLs point somewhere the client browser can't reach.
+# Local docker compose serves the API via the nginx reverse proxy on port 80,
+# so use `http://localhost` (NOT `http://localhost:8000`, which is gunicorn's
+# internal port and is not published on the host).
+OAUTH2_PROVIDER_ISSUER_URL=http://localhost
 MAX_VIDEO_UPLOAD_SIZE_MB=500
 FFPROBE_VALIDATION_TIMEOUT_SECONDS=10
 FFMPEG_PROCESS_TIMEOUT_SECONDS=120


### PR DESCRIPTION
## Summary
- `docker compose` 環境で Claude Desktop / claude.ai の Remote MCP コネクター登録が discovery 段階で失敗していた問題を修正
- 原因は `OAUTH2_PROVIDER_ISSUER_URL` 未設定時のフォールバック値 `http://localhost:8000` が `.well-known/oauth-*` で advertise されること
- `.env.example` に `OAUTH2_PROVIDER_ISSUER_URL=http://localhost` を既定値として追加し、なぜこの値であるべきかを併記

## Why
`docker-compose.yml` では backend (gunicorn) は `8000/tcp` を internal ネットワークにしか expose しておらず、ホストから到達できるのは nginx 経由の `http://localhost:80` だけ。

`backend/videoq/settings.py:363-368` の `OAUTH2_PROVIDER_ISSUER_URL` フォールバックが `http://localhost:8000` のため、未設定だと以下の壊れた discovery 文書が返る：

\`\`\`json
{
  "issuer": "http://localhost:8000",
  "authorization_endpoint": "http://localhost:8000/api/oauth/authorize/",
  "token_endpoint": "http://localhost:8000/api/oauth/token/",
  ...
}
\`\`\`

ブラウザは `localhost:8000` に到達できないので、Claude Desktop が discovery を辿った瞬間にコネクターフローが切れる。本番環境では env で公開 HTTPS オリジンを設定済みのため気付かなかった。

## What changed
- **`.env.example`**: `OAUTH2_PROVIDER_ISSUER_URL=http://localhost` を追加し、本番との関係と「`:8000` ではない」理由をコメントで明記

(`.env` は gitignore のためコミット対象外。ローカル個人設定として同じ行を `.env` にも追記する必要あり)

## Test plan
- [x] `.env` に追記 → `docker compose up -d backend` で再起動
- [x] `curl http://localhost/.well-known/oauth-authorization-server` で `issuer` / `authorization_endpoint` / `token_endpoint` が全て `http://localhost` を指すことを確認
- [x] `curl http://localhost/.well-known/oauth-protected-resource` の `resource` / `authorization_servers` も同様に確認
- [x] `curl -X POST http://localhost/api/mcp/` の 401 レスポンスの `WWW-Authenticate` ヘッダの `resource_metadata` URL が `http://localhost/.well-known/...` を指すことを確認
- [ ] PR マージ後、ローカル環境で Claude Desktop の Remote MCP コネクター登録フローを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)