### PR TITLE
Add optional automatic HTTPS with Caddy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ CACHE_URL=redis://redis:6379/0
 DJANGO_ENV=development
 ALLOWED_HOSTS=localhost,127.0.0.1
 CORS_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1
+# Public address handled by Caddy. Keep the http:// prefix for local
+# development. In production, specify only the DNS name to enable automatic
+# HTTPS and Let's Encrypt renewal (for example: videoq.example.com).
+SITE_ADDRESS=http://localhost
 # Storage backend switch
 # - False: local file storage + multipart upload
 # - True: S3 / Cloudflare R2 + presigned upload

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,10 @@
+{
+	servers {
+		protocols h1 h2 h3
+	}
+}
+
+{$SITE_ADDRESS:http://localhost} {
+	encode zstd gzip
+	reverse_proxy nginx:80
+}

--- a/README.md
+++ b/README.md
@@ -256,6 +256,35 @@ Issue a `vq_...` integration key from "Integration API Keys" in the Settings scr
 
 ## MCP (Model Context Protocol) Integration
 
+### Optional HTTPS deployment on Sakura
+
+The default Docker Compose stack uses Caddy as its public gateway. Local development remains HTTP by default. Set a production DNS name to enable automatic Let's Encrypt certificate issuance, HTTP-to-HTTPS redirects, and certificate renewal; no Certbot container or renewal cron is required.
+
+1. Point the A/AAAA record for a stable subdomain (for example, `videoq.example.com`) to the Sakura server's public IP address.
+2. Allow inbound TCP ports 80 and 443. UDP 443 is optional and enables HTTP/3.
+3. Configure the production values in `.env`:
+
+```dotenv
+SITE_ADDRESS=videoq.example.com
+DJANGO_ENV=production
+ALLOWED_HOSTS=videoq.example.com
+CORS_ALLOWED_ORIGINS=https://videoq.example.com
+FRONTEND_URL=https://videoq.example.com
+OAUTH2_PROVIDER_ISSUER_URL=https://videoq.example.com
+SECRET_KEY=<a-long-random-value>
+```
+
+4. Run `docker compose up -d --build`. Once DNS is active and ports 80/443 are externally reachable, Caddy obtains and renews the certificate automatically.
+5. Verify the OAuth metadata endpoints below, then register the final URL as the Cowork custom connector:
+
+```text
+https://videoq.example.com/.well-known/oauth-authorization-server
+https://videoq.example.com/.well-known/oauth-protected-resource/api/mcp
+https://videoq.example.com/api/mcp/
+```
+
+Keeping the same DNS name means a later cloud migration only requires a DNS change; the connector URL remains unchanged.
+
 VideoQ exposes a built-in **analytics-only** remote MCP server at `POST /api/mcp/`. Any MCP client that speaks Streamable HTTP — Claude Code, Cursor, and any client that can launch `mcp-remote` — can connect with just a URL and an API key. No local process to install.
 
 > 🛡️ **Design policy:** Sending RAG chat questions is intentionally excluded. MCP access is limited to **reading and analyzing existing data**.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,8 +68,6 @@ services:
     image: nginx:alpine
     container_name: videoq-nginx
     command: /bin/sh -c "envsubst '$$MAX_VIDEO_UPLOAD_SIZE_MB' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
-    ports:
-      - "80:80"
     environment:
       - MAX_VIDEO_UPLOAD_SIZE_MB=${MAX_VIDEO_UPLOAD_SIZE_MB:-500}
     volumes:
@@ -82,9 +80,29 @@ services:
     networks:
       - videoq-network
 
+  gateway:
+    image: caddy:2-alpine
+    container_name: videoq-gateway
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    environment:
+      - SITE_ADDRESS=${SITE_ADDRESS:-http://localhost}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - nginx
+    networks:
+      - videoq-network
+
 volumes:
   staticfiles:
   postgres_data:
+  caddy_data:
+  caddy_config:
 
 
 networks:

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,6 +8,13 @@ http {
 
     client_max_body_size ${MAX_VIDEO_UPLOAD_SIZE_MB}M;
 
+    # Preserve the public scheme supplied by the TLS gateway. When nginx is
+    # used without a gateway, fall back to the scheme of the direct request.
+    map $http_x_forwarded_proto $proxy_forwarded_proto {
+        default $http_x_forwarded_proto;
+        ""      $scheme;
+    }
+
     upstream backend {
         server videoq-backend:8000;
     }
@@ -37,7 +44,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $proxy_forwarded_proto;
         }
 
         # OAuth 2.1 metadata (RFC 8414 / RFC 9728) must live at the host root,
@@ -47,7 +54,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $proxy_forwarded_proto;
         }
 
         # Japanese locale - rewrite OGP/title tags (mirrors Cloudflare Pages function)
@@ -56,7 +63,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $proxy_forwarded_proto;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
@@ -74,7 +81,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $proxy_forwarded_proto;
 
             # WebSocket support (upgrade headers)
             proxy_http_version 1.1;


### PR DESCRIPTION
## Summary

- add Caddy as the public gateway while retaining nginx for existing routing, protected media, and locale rewriting
- keep local development on HTTP by default and enable automatic HTTPS by setting `SITE_ADDRESS` to a production DNS name
- preserve the public forwarded scheme through nginx so Django correctly detects TLS
- document Sakura DNS, firewall, production environment, OAuth discovery, and Cowork connector setup

## Why both Caddy and nginx

Caddy is responsible only for TLS termination, automatic Let's Encrypt issuance and renewal, and HTTP-to-HTTPS redirects. The existing nginx layer remains responsible for API/frontend routing, protected media delivery, and `sub_filter` behavior. This keeps the HTTPS change scoped and avoids migrating nginx-specific behavior.

## HTTPS remains optional

The default `SITE_ADDRESS=http://localhost` serves plain HTTP for local development. Setting `SITE_ADDRESS=videoq.example.com` enables Caddy's automatic HTTPS in production.

## Validation

- `docker compose config --quiet`
- `git diff --check`
- Caddy configuration validation for local HTTP and a production domain
- nginx configuration validation after template expansion