### PR TITLE
fix(cd): restore deploy by replacing broken ffmpeg download

### DIFF
--- a/backend/Dockerfile.lambda
+++ b/backend/Dockerfile.lambda
@@ -14,15 +14,8 @@ ENV NLTK_DATA=/usr/local/nltk_data
 WORKDIR /var/task
 
 # ffmpeg + gettext (for compilemessages)
-RUN apt-get update && apt-get install -y --no-install-recommends curl xz-utils gettext \
-    && curl -fsSL \
-    "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz" \
-    | tar -xJ --wildcards --strip-components=1 \
-    "ffmpeg-*-amd64-static/ffmpeg" \
-    "ffmpeg-*-amd64-static/ffprobe" \
-    && mv ffmpeg ffprobe /usr/local/bin/ \
-    && chmod +x /usr/local/bin/ffmpeg /usr/local/bin/ffprobe \
-    && apt-get purge -y curl xz-utils && apt-get autoremove -y \
+# Prefer distro ffmpeg so image builds do not depend on third-party download hosts.
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg gettext \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -9,16 +9,15 @@ ARG APP_HOME=/var/task
 ENV NLTK_DATA=/usr/local/nltk_data
 WORKDIR ${APP_HOME}
 
-# ffmpeg: AL2023 最小イメージには tar/xz が未インストールのため先にインストール
-RUN dnf install -y tar xz && dnf clean all
-
-RUN curl -fsSL \
-    "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz" \
-    | tar -xJ --wildcards --strip-components=1 \
-        "ffmpeg-*-amd64-static/ffmpeg" \
-        "ffmpeg-*-amd64-static/ffprobe" \
-    && mv ffmpeg ffprobe /usr/local/bin/ \
-    && chmod +x /usr/local/bin/ffmpeg /usr/local/bin/ffprobe
+# ffmpeg: AL2023 minimal image has neither package ffmpeg nor tar/xz by default.
+# johnvansickle.com is flaky from GitHub Actions (timeout / HTTP 415), so use BtbN.
+RUN dnf install -y tar xz \
+    && curl -fsSL -L \
+        "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz" \
+        | tar -xJ --strip-components=2 -C /usr/local \
+            --wildcards '*/bin/ffmpeg' '*/bin/ffprobe' \
+    && chmod +x /usr/local/bin/ffmpeg /usr/local/bin/ffprobe \
+    && dnf clean all
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --upgrade "pip>=26.0" \


### PR DESCRIPTION
## Summary
- CD Deploy Backend API / Worker failed because `johnvansickle.com` ffmpeg downloads timed out or returned HTTP 415
- That left production unable to roll the PLOG merge and caused login `502` from the frontend
- Lambda API image now installs ffmpeg via apt; worker image uses BtbN GitHub releases

## Test plan
- [ ] CD Deploy Backend API succeeds
- [ ] CD Deploy Worker succeeds
- [ ] Health check passes
- [ ] Login works on production


Made with [Cursor](https://cursor.com)