### PR TITLE
refactor(backend): use searchapi-python SDK for YouTube transcripts

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR ${APP_HOME}
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     gettext \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./

--- a/backend/app/infrastructure/external/tests/test_youtube_transcript_gateway.py
+++ b/backend/app/infrastructure/external/tests/test_youtube_transcript_gateway.py
@@ -1,18 +1,31 @@
 from unittest import TestCase
 from unittest.mock import patch
 
+from searchapi import APIConnectionError
+
 from app.infrastructure.external.youtube_transcript_gateway import YoutubeTranscriptGateway
 
 
-class _FakeTransport:
+class _FakeClient:
+    """Stands in for a ``searchapi.SearchApi`` client in tests."""
+
     def __init__(self, responses):
         self.responses = responses
-        self.calls: list[tuple[dict[str, str], str]] = []
+        self.calls: list[dict] = []
+        self.closed = False
 
-    def __call__(self, params: dict[str, str], api_key: str):
-        self.calls.append((params, api_key))
-        lookup_params = {key: value for key, value in params.items() if key != "engine"}
-        return self.responses.get(tuple(sorted(lookup_params.items())), {})
+    def search(self, engine, **params):
+        call = {"engine": engine, **params}
+        self.calls.append(call)
+        lookup = tuple(sorted((k, v) for k, v in params.items()))
+        return self.responses.get(lookup, {})
+
+    def close(self):
+        self.closed = True
+
+
+def _client_factory(client):
+    return lambda api_key: client
 
 
 class YoutubeTranscriptGatewayTests(TestCase):
@@ -22,10 +35,10 @@ class YoutubeTranscriptGatewayTests(TestCase):
             "1\n00:00:00,000 --> 00:00:01,500\nこんにちは\n",
             1,
         )
-        transport = _FakeTransport(
+        client = _FakeClient(
             {
                 (
-                    ("only_available", "true"),
+                    ("only_available", True),
                     ("transcript_type", "manual"),
                     ("video_id", "svm8hlhF8PA"),
                 ): {
@@ -35,26 +48,24 @@ class YoutubeTranscriptGatewayTests(TestCase):
                 }
             }
         )
-        gateway = YoutubeTranscriptGateway(transport=transport)
+        gateway = YoutubeTranscriptGateway(client_factory=_client_factory(client))
 
         result = gateway.run("svm8hlhF8PA", api_key="searchapi-test-key")
 
         self.assertIn("こんにちは", result)
         mock_apply_scene_splitting.assert_called_once()
         self.assertEqual(
-            transport.calls,
+            client.calls,
             [
-                (
-                    {
-                        "engine": "youtube_transcripts",
-                        "video_id": "svm8hlhF8PA",
-                        "transcript_type": "manual",
-                        "only_available": "true",
-                    },
-                    "searchapi-test-key",
-                )
+                {
+                    "engine": "youtube_transcripts",
+                    "video_id": "svm8hlhF8PA",
+                    "transcript_type": "manual",
+                    "only_available": True,
+                }
             ],
         )
+        self.assertTrue(client.closed)
 
     @patch("app.infrastructure.external.youtube_transcript_gateway.apply_scene_splitting")
     def test_falls_back_to_first_available_transcript(self, mock_apply_scene_splitting):
@@ -62,10 +73,10 @@ class YoutubeTranscriptGatewayTests(TestCase):
             "1\n00:00:00,000 --> 00:00:01,000\nhola\n",
             1,
         )
-        transport = _FakeTransport(
+        client = _FakeClient(
             {
                 (
-                    ("only_available", "true"),
+                    ("only_available", True),
                     ("transcript_type", "manual"),
                     ("video_id", "abc123def45"),
                 ): {
@@ -75,19 +86,19 @@ class YoutubeTranscriptGatewayTests(TestCase):
                 }
             }
         )
-        gateway = YoutubeTranscriptGateway(transport=transport)
+        gateway = YoutubeTranscriptGateway(client_factory=_client_factory(client))
 
         result = gateway.run("abc123def45", api_key="searchapi-test-key")
 
         self.assertIn("hola", result)
-        self.assertEqual(len(transport.calls), 1)
-        self.assertEqual(transport.calls[0][0]["only_available"], "true")
+        self.assertEqual(len(client.calls), 1)
+        self.assertEqual(client.calls[0]["only_available"], True)
 
     def test_estimates_duration_from_last_transcript_segment(self):
-        transport = _FakeTransport(
+        client = _FakeClient(
             {
                 (
-                    ("only_available", "true"),
+                    ("only_available", True),
                     ("transcript_type", "manual"),
                     ("video_id", "abc123def45"),
                 ): {
@@ -98,7 +109,7 @@ class YoutubeTranscriptGatewayTests(TestCase):
                 }
             }
         )
-        gateway = YoutubeTranscriptGateway(transport=transport)
+        gateway = YoutubeTranscriptGateway(client_factory=_client_factory(client))
 
         result = gateway.estimate_duration_seconds("abc123def45", api_key="searchapi-test-key")
 
@@ -106,29 +117,30 @@ class YoutubeTranscriptGatewayTests(TestCase):
 
     @patch("app.infrastructure.external.youtube_transcript_gateway.apply_scene_splitting")
     def test_raises_when_no_transcripts_are_available(self, _mock_apply_scene_splitting):
-        transport = _FakeTransport({})
-        gateway = YoutubeTranscriptGateway(transport=transport)
+        client = _FakeClient({})
+        gateway = YoutubeTranscriptGateway(client_factory=_client_factory(client))
 
         with self.assertRaises(RuntimeError):
             gateway.run("abc123def45", api_key="searchapi-test-key")
 
     def test_raises_when_searchapi_api_key_is_missing(self):
-        gateway = YoutubeTranscriptGateway(transport=_FakeTransport({}))
+        gateway = YoutubeTranscriptGateway(client_factory=_client_factory(_FakeClient({})))
 
         with self.assertRaises(RuntimeError) as context:
             gateway.run("abc123def45")
 
         self.assertIn("SearchAPI API key", str(context.exception))
 
-    @patch("app.infrastructure.external.youtube_transcript_gateway.time.sleep")
-    @patch("app.infrastructure.external.youtube_transcript_gateway.urlopen")
-    def test_retries_when_timeout_occurs(self, mock_urlopen, mock_sleep):
-        mock_urlopen.side_effect = TimeoutError("The read operation timed out")
-        gateway = YoutubeTranscriptGateway(max_retries=1)
+    def test_raises_runtime_error_when_connection_fails(self):
+        class _FailingClient(_FakeClient):
+            def search(self, engine, **params):
+                raise APIConnectionError("timed out")
+
+        gateway = YoutubeTranscriptGateway(
+            client_factory=_client_factory(_FailingClient({}))
+        )
 
         with self.assertRaises(RuntimeError) as context:
             gateway.run("abc123def45", api_key="searchapi-test-key")
 
         self.assertIn("timed out", str(context.exception))
-        self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once_with(1.0)

--- a/backend/app/infrastructure/external/tests/test_youtube_transcript_gateway.py
+++ b/backend/app/infrastructure/external/tests/test_youtube_transcript_gateway.py
@@ -3,7 +3,9 @@ from unittest.mock import patch
 
 from searchapi import APIConnectionError
 
-from app.infrastructure.external.youtube_transcript_gateway import YoutubeTranscriptGateway
+from app.infrastructure.external.youtube_transcript_gateway import (
+    YoutubeTranscriptGateway,
+)
 
 
 class _FakeClient:

--- a/backend/app/infrastructure/external/youtube_transcript_gateway.py
+++ b/backend/app/infrastructure/external/youtube_transcript_gateway.py
@@ -1,37 +1,39 @@
 from __future__ import annotations
 
-import json
 import math
-import socket
-import time
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+from typing import Any, Callable, Optional
 
 from django.conf import settings
+from searchapi import (
+    APIConnectionError,
+    AuthenticationError,
+    SearchApi,
+    SearchApiError,
+)
 
 from app.domain.video.gateways import YoutubeTranscriptionGateway
 from app.infrastructure.transcription.srt_processing import apply_scene_splitting
+
+ClientFactory = Callable[[str], Any]
 
 
 class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
     def __init__(
         self,
         *,
-        base_url: str = "https://www.searchapi.io/api/v1/search",
+        base_url: str = "https://www.searchapi.io/api/v1",
         timeout_seconds: int | None = None,
         max_retries: int = 1,
-        transport=None,
+        client_factory: ClientFactory | None = None,
     ):
         self.base_url = base_url
         self.timeout_seconds = timeout_seconds or getattr(
             settings, "SEARCHAPI_TIMEOUT_SECONDS", 60
         )
         self.max_retries = max_retries
-        self._transport = transport
+        self._client_factory = client_factory
 
-    def run(self, youtube_video_id: str, api_key=None) -> str:
-        self._ensure_api_key(api_key)
+    def run(self, youtube_video_id: str, api_key: Optional[str] = None) -> str:
         transcript = self._select_transcript(youtube_video_id, api_key)
         blocks = []
         for index, item in enumerate(transcript, start=1):
@@ -55,8 +57,9 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
         )
         return scene_split_srt
 
-    def estimate_duration_seconds(self, youtube_video_id: str, api_key=None) -> int | None:
-        self._ensure_api_key(api_key)
+    def estimate_duration_seconds(
+        self, youtube_video_id: str, api_key: Optional[str] = None
+    ) -> int | None:
         transcript = self._select_transcript(youtube_video_id, api_key)
         max_end_seconds = 0.0
         for item in transcript:
@@ -67,6 +70,49 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
             return None
         return max(1, math.ceil(max_end_seconds))
 
+    def _select_transcript(self, youtube_video_id: str, api_key: str | None):
+        self._ensure_api_key(api_key)
+        attempts = [
+            {
+                "video_id": youtube_video_id,
+                "transcript_type": "manual",
+                "only_available": True,
+            },
+            {
+                "video_id": youtube_video_id,
+                "transcript_type": "auto",
+                "only_available": True,
+            },
+        ]
+
+        client = self._build_client(api_key)
+        try:
+            last_error: RuntimeError | None = None
+            for params in attempts:
+                response = self._search_transcripts(client, params)
+                transcripts = response.get("transcripts") or []
+                if transcripts:
+                    return transcripts
+
+                available_languages = response.get("available_languages") or []
+                if available_languages:
+                    last_error = RuntimeError(
+                        "No YouTube transcript was returned. Available languages: "
+                        + ", ".join(
+                            str(entry.get("lang") or entry.get("name"))
+                            for entry in available_languages
+                            if isinstance(entry, dict)
+                        )
+                    )
+
+            if last_error is not None:
+                raise last_error
+            raise RuntimeError("No transcript available for this YouTube video.")
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+
     def _ensure_api_key(self, api_key: str | None) -> None:
         if api_key:
             return
@@ -74,80 +120,29 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
             "SearchAPI API key is not configured. Set your SearchAPI API key in Settings before importing YouTube videos."
         )
 
-    def _select_transcript(self, youtube_video_id: str, api_key: str):
-        attempts = [
-            {
-                "video_id": youtube_video_id,
-                "transcript_type": "manual",
-                "only_available": "true",
-            },
-            {
-                "video_id": youtube_video_id,
-                "transcript_type": "auto",
-                "only_available": "true",
-            },
-        ]
-
-        last_error: RuntimeError | None = None
-        for params in attempts:
-            response = self._fetch_transcript_response(params, api_key)
-            transcripts = response.get("transcripts") or []
-            if transcripts:
-                return transcripts
-
-            available_languages = response.get("available_languages") or []
-            if available_languages:
-                last_error = RuntimeError(
-                    "No YouTube transcript was returned. Available languages: "
-                    + ", ".join(
-                        str(entry.get("lang") or entry.get("name"))
-                        for entry in available_languages
-                        if isinstance(entry, dict)
-                    )
-                )
-
-        if last_error is not None:
-            raise last_error
-        raise RuntimeError("No transcript available for this YouTube video.")
-
-    def _fetch_transcript_response(self, params: dict[str, str], api_key: str) -> dict:
-        query = {"engine": "youtube_transcripts", **params}
-        if self._transport is not None:
-            return self._transport(query, api_key)
-
-        request = Request(
-            f"{self.base_url}?{urlencode(query)}",
-            headers={
-                "Accept": "application/json",
-                "Authorization": f"Bearer {api_key}",
-            },
+    def _build_client(self, api_key: str):
+        if self._client_factory is not None:
+            return self._client_factory(api_key)
+        return SearchApi(
+            api_key=api_key,
+            base_url=self.base_url,
+            timeout=self.timeout_seconds,
+            max_retries=self.max_retries,
         )
-        attempts = self.max_retries + 1
-        last_error: Exception | None = None
 
-        for attempt in range(attempts):
-            try:
-                with urlopen(request, timeout=self.timeout_seconds) as response:
-                    return json.loads(response.read().decode("utf-8"))
-            except HTTPError as exc:
-                detail = exc.read().decode("utf-8", errors="ignore")
-                message = detail or exc.reason
-                raise RuntimeError(f"SearchAPI request failed: {message}") from exc
-            except (TimeoutError, socket.timeout) as exc:
-                last_error = exc
-            except URLError as exc:
-                if isinstance(exc.reason, (TimeoutError, socket.timeout)):
-                    last_error = exc
-                else:
-                    raise RuntimeError(f"SearchAPI request failed: {exc.reason}") from exc
-
-            if attempt < self.max_retries:
-                time.sleep(1.0)
-
-        raise RuntimeError(
-            f"SearchAPI request timed out after {attempts} attempts. "
-            "Please try again in a moment."
-        ) from last_error
+    def _search_transcripts(self, client, params: dict[str, Any]) -> dict:
+        try:
+            return client.search("youtube_transcripts", **params)
+        except AuthenticationError as exc:
+            raise RuntimeError(
+                "SearchAPI rejected the API key. Please check your SearchAPI API key in Settings."
+            ) from exc
+        except APIConnectionError as exc:
+            raise RuntimeError(
+                "SearchAPI request timed out or could not be reached. Please try again in a moment."
+            ) from exc
+        except SearchApiError as exc:
+            raise RuntimeError(f"SearchAPI request failed: {exc}") from exc
 
 
 def _format_srt_time(total_ms: int) -> str:

--- a/backend/app/infrastructure/external/youtube_transcript_gateway.py
+++ b/backend/app/infrastructure/external/youtube_transcript_gateway.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 from django.conf import settings
 from searchapi import (
@@ -33,7 +34,7 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
         self.max_retries = max_retries
         self._client_factory = client_factory
 
-    def run(self, youtube_video_id: str, api_key: Optional[str] = None) -> str:
+    def run(self, youtube_video_id: str, api_key: str | None = None) -> str:
         transcript = self._select_transcript(youtube_video_id, api_key)
         blocks = []
         for index, item in enumerate(transcript, start=1):
@@ -58,7 +59,7 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
         return scene_split_srt
 
     def estimate_duration_seconds(
-        self, youtube_video_id: str, api_key: Optional[str] = None
+        self, youtube_video_id: str, api_key: str | None = None
     ) -> int | None:
         transcript = self._select_transcript(youtube_video_id, api_key)
         max_end_seconds = 0.0
@@ -71,7 +72,7 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
         return max(1, math.ceil(max_end_seconds))
 
     def _select_transcript(self, youtube_video_id: str, api_key: str | None):
-        self._ensure_api_key(api_key)
+        validated_api_key = self._ensure_api_key(api_key)
         attempts = [
             {
                 "video_id": youtube_video_id,
@@ -85,7 +86,7 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
             },
         ]
 
-        client = self._build_client(api_key)
+        client = self._build_client(validated_api_key)
         try:
             last_error: RuntimeError | None = None
             for params in attempts:
@@ -113,9 +114,9 @@ class YoutubeTranscriptGateway(YoutubeTranscriptionGateway):
             if callable(close):
                 close()
 
-    def _ensure_api_key(self, api_key: str | None) -> None:
+    def _ensure_api_key(self, api_key: str | None) -> str:
         if api_key:
-            return
+            return api_key
         raise RuntimeError(
             "SearchAPI API key is not configured. Set your SearchAPI API key in Settings before importing YouTube videos."
         )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,7 +23,7 @@ openai>=2.6.1
 psycopg2-binary>=2.9.11
 ragas>=0.4.3
 redis>=7.0.0
-searchapi-python @ git+https://github.com/yukiharada1228/searchapi-python.git
+searchapi-python @ git+https://github.com/yukiharada1228/searchapi-python.git@128cf43017a5aaccee1551d0f2de0770e5749168
 scikit-learn>=1.7.2
 uvicorn-worker>=0.4.0
 uvicorn>=0.38.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,6 +23,7 @@ openai>=2.6.1
 psycopg2-binary>=2.9.11
 ragas>=0.4.3
 redis>=7.0.0
+searchapi-python @ git+https://github.com/yukiharada1228/searchapi-python.git
 scikit-learn>=1.7.2
 uvicorn-worker>=0.4.0
 uvicorn>=0.38.0


### PR DESCRIPTION
## 概要

YouTube 文字起こし取得を、自前の `urllib` 実装から [`searchapi-python`](https://github.com/yukiharada1228/searchapi-python) SDK 経由に置き換えます。取得フロー（manual→auto フォールバック → SRT整形 → otsu シーン分割）と、SearchAPI キー未設定時のエラー契約はそのまま維持しています。

## 変更内容

- **`YoutubeTranscriptGateway`** — 手書きの HTTP リクエスト / リトライ / タイムアウト / バックオフ（`_fetch_transcript_response`）を撤去し、`SearchApi.search("youtube_transcripts", ...)` に委譲。リトライ・指数バックオフは SDK 側に任せる。
- **例外の翻訳** — SDK の `AuthenticationError` / `APIConnectionError` / `SearchApiError` を、アプリ既存の `RuntimeError` 契約にマッピング（認証エラー・タイムアウトでメッセージを出し分け）。
- **パラメータ** — `only_available` を SDK 準拠の `bool`（`True`）に変更。`"true"/"false"` 変換は SDK が担当。
- **テストのシーム変更** — 注入口を `transport`（生クエリ関数）から `client_factory`（`SearchApi` 互換クライアント）に変更。接続失敗ケースを `APIConnectionError → RuntimeError` の検証に更新。
- **依存追加** — `requirements.txt` に `searchapi-python`(git 依存) を追加し、`git+https` インストールのため Dockerfile に `git` を追加。

## SDK採用のメリット

- 自前のリトライ/タイムアウト/バックオフ実装（約40行）を削除でき保守面積が縮小
- 例外が型で構造化され、認証エラー/レート制限などの出し分けが将来容易
- `client.search(engine, ...)` がジェネリックなので他エンジンへの拡張が容易

## テスト

- `test_youtube_transcript_gateway`（6件）✅
- `test_create_youtube_video` / `test_run_transcription`（計25件）✅
- `docker compose build backend` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)