### PR TITLE
fix(backend): worker で OpenAI キーが解決されず字幕分割が degrade する問題を修正

### DIFF
--- a/backend/app/infrastructure/common/provider_registry.py
+++ b/backend/app/infrastructure/common/provider_registry.py
@@ -1,5 +1,6 @@
 """Shared helpers for provider-backed infrastructure factories."""
 
+import os
 from collections.abc import Callable, Iterable, Mapping
 from typing import TypeVar
 
@@ -59,6 +60,14 @@ def resolve_openai_api_key(
     resolved_key = api_key
     if not resolved_key and allow_settings_fallback:
         resolved_key = getattr(settings, "OPENAI_API_KEY", None)
+        # Fall back to the process environment. On Lambda the app secret is
+        # expanded into os.environ early during settings import, while the
+        # settings.OPENAI_API_KEY attribute is assigned near the end of
+        # settings.py and can be missing if a cold-start init times out and
+        # leaves the settings module partially loaded (DB/R2 still work because
+        # those read the secret dict directly). os.environ is the reliable source.
+        if not resolved_key:
+            resolved_key = os.environ.get("OPENAI_API_KEY")
 
     if not resolved_key:
         raise ProviderConfigError(

--- a/backend/app/infrastructure/common/tests/test_embeddings.py
+++ b/backend/app/infrastructure/common/tests/test_embeddings.py
@@ -46,7 +46,9 @@ class GetEmbeddingsTests(SimpleTestCase):
         EMBEDDING_MODEL="text-embedding-3-small",
         OPENAI_API_KEY="",
     )
+    @patch.dict("os.environ", {}, clear=True)
     def test_openai_embeddings_require_api_key(self):
+        # No key in settings and none in os.environ -> must raise.
         with self.assertRaises(ProviderConfigError) as context:
             get_embeddings()
 

--- a/backend/app/infrastructure/common/tests/test_provider_registry.py
+++ b/backend/app/infrastructure/common/tests/test_provider_registry.py
@@ -1,0 +1,42 @@
+"""Tests for shared provider-registry helpers."""
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from app.domain.shared.exceptions import ProviderConfigError
+from app.infrastructure.common.provider_registry import resolve_openai_api_key
+
+
+class ResolveOpenAIApiKeyTests(SimpleTestCase):
+    """resolve_openai_api_key key-resolution precedence and fallbacks."""
+
+    def test_explicit_key_takes_precedence(self):
+        with override_settings(OPENAI_API_KEY="settings-key"):
+            self.assertEqual(
+                resolve_openai_api_key("explicit-key"), "explicit-key"
+            )
+
+    @override_settings(OPENAI_API_KEY="settings-key")
+    def test_falls_back_to_django_settings(self):
+        self.assertEqual(resolve_openai_api_key(), "settings-key")
+
+    @override_settings(OPENAI_API_KEY="")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "env-key"}, clear=False)
+    def test_falls_back_to_os_environ_when_settings_empty(self):
+        # Regression: on Lambda the app secret is expanded into os.environ early,
+        # but settings.OPENAI_API_KEY (assigned late in settings.py) can be empty
+        # if a cold-start init times out. os.environ must be the reliable source.
+        self.assertEqual(resolve_openai_api_key(), "env-key")
+
+    @override_settings(OPENAI_API_KEY="")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "env-key"}, clear=False)
+    def test_no_env_fallback_when_settings_fallback_disabled(self):
+        with self.assertRaises(ProviderConfigError):
+            resolve_openai_api_key(allow_settings_fallback=False)
+
+    @override_settings(OPENAI_API_KEY="")
+    def test_raises_when_no_key_anywhere(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with self.assertRaises(ProviderConfigError):
+                resolve_openai_api_key(purpose="OpenAI embeddings")

--- a/backend/app/infrastructure/common/tests/test_whisper_client.py
+++ b/backend/app/infrastructure/common/tests/test_whisper_client.py
@@ -69,6 +69,7 @@ class CreateWhisperClientTests(SimpleTestCase):
 
 
     @override_settings(WHISPER_BACKEND="openai", OPENAI_API_KEY="")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": ""})
     def test_openai_client_requires_api_key(self):
         with self.assertRaises(ProviderConfigError) as context:
             create_whisper_client(api_key=None)

--- a/backend/app/infrastructure/external/tests/test_llm.py
+++ b/backend/app/infrastructure/external/tests/test_llm.py
@@ -41,12 +41,14 @@ class GetLangchainLLMTests(SimpleTestCase):
         )
 
     @override_settings(LLM_PROVIDER="openai", LLM_MODEL="gpt-4o-mini", OPENAI_API_KEY="")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": ""})
     def test_get_langchain_llm_without_api_key(self):
         """Test get_langchain_llm raises ProviderConfigError when no key provided"""
         with self.assertRaises(ProviderConfigError):
             get_langchain_llm()
 
     @override_settings(LLM_PROVIDER="openai", LLM_MODEL="gpt-4o-mini", OPENAI_API_KEY="")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": ""})
     def test_get_langchain_llm_with_none_api_key(self):
         """Test get_langchain_llm raises ProviderConfigError when API key is None"""
         with self.assertRaises(ProviderConfigError):

--- a/backend/app/infrastructure/scene_otsu/tests/test_embedders.py
+++ b/backend/app/infrastructure/scene_otsu/tests/test_embedders.py
@@ -139,6 +139,7 @@ class CreateEmbedderOpenAITests(SimpleTestCase):
             batch_size=16,
         )
 
+    @patch.dict("os.environ", {"OPENAI_API_KEY": ""})
     def test_raises_without_api_key(self):
         """Test that ProviderConfigError is raised without API key"""
         from app.infrastructure.scene_otsu.embedders import create_embedder

--- a/backend/app/infrastructure/transcription/tests/test_srt_processing.py
+++ b/backend/app/infrastructure/transcription/tests/test_srt_processing.py
@@ -234,6 +234,7 @@ class ApplySceneSplittingTests(SimpleTestCase):
         self.assertEqual(scene_count, 1)
 
     @override_settings(EMBEDDING_PROVIDER="openai")
+    @patch.dict("os.environ", {"OPENAI_API_KEY": ""})
     def test_requires_api_key_for_openai(self):
         """Test that missing API key for OpenAI falls back to original SRT"""
         srt_content = "1\n00:00:00,000 --> 00:00:05,000\nTest\n"


### PR DESCRIPTION
## 概要

worker Lambda で、app secret に有効な `OPENAI_API_KEY`（値あり）が入っているのに、セマンティック字幕分割等の OpenAI 機能が `OpenAI API key is required` で degrade していた問題を修正する。

## 根本原因

- Lambda では `settings.py` 冒頭で app secret を `os.environ` に展開するが、`settings.OPENAI_API_KEY` はモジュール**末尾**（636行）で代入される。
- worker のコールドスタート初期化が **INIT 10 秒を超過**（`INIT_REPORT ... Status: timeout`）すると、settings モジュールが**部分的にしか初期化されず末尾の `OPENAI_API_KEY` 属性が欠落**する場合がある。DB/R2 は `_app_secrets` を直接読むため動作する一方、`settings.OPENAI_API_KEY` 経由の OpenAI だけ空になる。
- 早期に設定される `os.environ` は信頼できる（`SECRET_KEY` が同経路で機能していることが証拠）。
- **移行前（2026-03/05）から発生**しており、CDK→Terraform 移行とは無関係。

## 修正

`resolve_openai_api_key` に **`os.environ["OPENAI_API_KEY"]` フォールバック**を追加（Django settings の後段）。これで embeddings（字幕分割）/whisper/llm など全 OpenAI 消費側が settings ロード状態に依存せずキーを解決できる。

> コールドスタート最適化（INIT タイムアウト自体の解消）は別対応。本修正は消費側での堅牢化。

## テスト

- 追加: `test_provider_registry.py`（明示キー > settings > env の優先順位、env フォールバック、キー皆無時の raise）
- 更新: 既存の「キー必須」テスト（whisper/llm/embeddings/scene_otsu/srt）は env フォールバックの影響で raise しなくなるため、`os.environ` の `OPENAI_API_KEY` も空にして「どこにもキー無し」を正しく検証するよう修正。
- 全 58 テスト green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)