### PR TITLE
fix(backend): centralize OpenAI and database settings

### DIFF
--- a/backend/app/composition_root/_video_shared.py
+++ b/backend/app/composition_root/_video_shared.py
@@ -2,8 +2,6 @@
 
 from functools import lru_cache
 
-from django.conf import settings
-
 from app.domain.video.gateways import VideoTaskGateway
 from app.infrastructure.external.vector_gateway import DjangoVectorStoreGateway
 from app.infrastructure.repositories.django_user_repository import DjangoUserRepository
@@ -53,13 +51,10 @@ def get_vector_indexing_gateway():
 @lru_cache(maxsize=1)
 def get_file_upload_gateway():
     from app.infrastructure.external.file_upload_gateway import (
-        LocalFileUploadGateway,
-        R2FileUploadGateway,
+        create_file_upload_gateway,
     )
 
-    if settings.USE_S3_STORAGE:
-        return R2FileUploadGateway()
-    return LocalFileUploadGateway()
+    return create_file_upload_gateway()
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/composition_root/_video_shared.py
+++ b/backend/app/composition_root/_video_shared.py
@@ -2,6 +2,8 @@
 
 from functools import lru_cache
 
+from django.conf import settings
+
 from app.domain.video.gateways import VideoTaskGateway
 from app.infrastructure.external.vector_gateway import DjangoVectorStoreGateway
 from app.infrastructure.repositories.django_user_repository import DjangoUserRepository
@@ -50,14 +52,12 @@ def get_vector_indexing_gateway():
 
 @lru_cache(maxsize=1)
 def get_file_upload_gateway():
-    import os
-
     from app.infrastructure.external.file_upload_gateway import (
         LocalFileUploadGateway,
         R2FileUploadGateway,
     )
 
-    if os.environ.get("USE_S3_STORAGE", "").lower() in ("true", "1", "yes"):
+    if settings.USE_S3_STORAGE:
         return R2FileUploadGateway()
     return LocalFileUploadGateway()
 

--- a/backend/app/infrastructure/common/provider_registry.py
+++ b/backend/app/infrastructure/common/provider_registry.py
@@ -49,13 +49,10 @@ def create_from_provider_registry[T](
 def resolve_openai_api_key(
     api_key: str | None = None,
     *,
-    allow_settings_fallback: bool = True,
     purpose: str = "OpenAI provider",
 ) -> str:
     """Resolve an OpenAI API key from an explicit value or Django settings."""
-    resolved_key = api_key
-    if not resolved_key and allow_settings_fallback:
-        resolved_key = getattr(settings, "OPENAI_API_KEY", None)
+    resolved_key = api_key or getattr(settings, "OPENAI_API_KEY", None)
 
     if not resolved_key:
         raise ProviderConfigError(

--- a/backend/app/infrastructure/external/file_upload_gateway.py
+++ b/backend/app/infrastructure/external/file_upload_gateway.py
@@ -14,6 +14,13 @@ from app.domain.video.gateways import FileUploadGateway
 logger = logging.getLogger(__name__)
 
 
+def create_file_upload_gateway() -> FileUploadGateway:
+    """Create the configured upload gateway at the infrastructure boundary."""
+    if settings.USE_S3_STORAGE:
+        return R2FileUploadGateway()
+    return LocalFileUploadGateway()
+
+
 class LocalFileUploadGateway(FileUploadGateway):
     """Local filesystem-backed file gateway for non-S3 environments."""
 

--- a/backend/app/infrastructure/external/tests/test_file_upload_gateway.py
+++ b/backend/app/infrastructure/external/tests/test_file_upload_gateway.py
@@ -1,0 +1,19 @@
+"""Tests for the configured file-upload gateway factory."""
+
+from django.test import SimpleTestCase, override_settings
+
+from app.infrastructure.external.file_upload_gateway import (
+    LocalFileUploadGateway,
+    R2FileUploadGateway,
+    create_file_upload_gateway,
+)
+
+
+class CreateFileUploadGatewayTests(SimpleTestCase):
+    @override_settings(USE_S3_STORAGE=False)
+    def test_creates_local_gateway_when_object_storage_is_disabled(self):
+        self.assertIsInstance(create_file_upload_gateway(), LocalFileUploadGateway)
+
+    @override_settings(USE_S3_STORAGE=True)
+    def test_creates_r2_gateway_when_object_storage_is_enabled(self):
+        self.assertIsInstance(create_file_upload_gateway(), R2FileUploadGateway)

--- a/backend/app/infrastructure/external/tests/test_vector_store.py
+++ b/backend/app/infrastructure/external/tests/test_vector_store.py
@@ -2,7 +2,6 @@
 Tests for vector_manager module
 """
 
-import os
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, override_settings
@@ -31,9 +30,7 @@ class PGVectorManagerTests(SimpleTestCase):
         PGVectorManager._table_initialized = False
 
     @patch("app.infrastructure.external.vector_store.PGEngine.from_connection_string")
-    @patch.dict(
-        os.environ, {"DATABASE_URL": "postgresql://test:test@localhost:5432/test"}
-    )
+    @override_settings(DATABASE_URL="postgresql://test:test@localhost:5432/test")
     def test_get_engine_creates_singleton(self, mock_from_conn):
         mock_engine = MagicMock()
         mock_from_conn.return_value = mock_engine
@@ -47,20 +44,20 @@ class PGVectorManagerTests(SimpleTestCase):
         )
 
     @patch("app.infrastructure.external.vector_store.PGEngine.from_connection_string")
-    @patch.dict(os.environ, {}, clear=True)
-    def test_get_engine_default_url(self, mock_from_conn):
+    @override_settings(
+        DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
+    )
+    def test_get_engine_uses_configured_url(self, mock_from_conn):
         mock_from_conn.return_value = MagicMock()
 
         PGVectorManager.get_engine()
 
         mock_from_conn.assert_called_once_with(
-            url="postgresql+psycopg://postgres:postgres@postgres:5432/postgres"
+            url="postgresql+psycopg://postgres:postgres@localhost:5432/postgres"
         )
 
     @patch("app.infrastructure.external.vector_store.PGEngine.from_connection_string")
-    @patch.dict(
-        os.environ, {"DATABASE_URL": "postgres://test:test@localhost:5432/test"}
-    )
+    @override_settings(DATABASE_URL="postgres://test:test@localhost:5432/test")
     def test_get_engine_normalizes_postgres_short_url(self, mock_from_conn):
         mock_from_conn.return_value = MagicMock()
 

--- a/backend/app/infrastructure/external/vector_store.py
+++ b/backend/app/infrastructure/external/vector_store.py
@@ -4,7 +4,6 @@ Moved from app/utils/vector_manager.py.
 """
 
 import logging
-import os
 import threading
 
 from django.conf import settings
@@ -62,10 +61,7 @@ class PGVectorManager:
         if cls._engine is None:
             with cls._engine_lock:
                 if cls._engine is None:
-                    db_url = os.getenv(
-                        "DATABASE_URL",
-                        "postgresql://postgres:postgres@postgres:5432/postgres",
-                    )
+                    db_url = settings.DATABASE_URL
                     # PGEngine requires postgresql+psycopg:// format
                     if db_url.startswith("postgresql://"):
                         db_url = db_url.replace(

--- a/backend/app/infrastructure/external/vector_store.py
+++ b/backend/app/infrastructure/external/vector_store.py
@@ -81,16 +81,12 @@ class PGVectorManager:
     @classmethod
     def get_table_name(cls):
         """Get the vectorstore table name (= collection name)."""
-        return getattr(
-            settings,
-            "PGVECTOR_COLLECTION_NAME",
-            os.getenv("PGVECTOR_COLLECTION_NAME", "videoq_scenes"),
-        )
+        return settings.PGVECTOR_COLLECTION_NAME
 
     @classmethod
     def get_vector_size(cls):
         """Get the embedding vector dimension size."""
-        return getattr(settings, "EMBEDDING_VECTOR_SIZE", 1536)
+        return settings.EMBEDDING_VECTOR_SIZE
 
     @classmethod
     def ensure_table(cls):

--- a/backend/app/infrastructure/scene_otsu/embedders.py
+++ b/backend/app/infrastructure/scene_otsu/embedders.py
@@ -92,7 +92,6 @@ def create_embedder(
 def _create_openai_embedder(api_key: str | None, batch_size: int) -> BaseEmbedder:
     resolved_key = resolve_openai_api_key(
         api_key,
-        allow_settings_fallback=False,
         purpose="OpenAI embeddings",
     )
     return OpenAIEmbedder(

--- a/backend/app/infrastructure/scene_otsu/tests/test_embedders.py
+++ b/backend/app/infrastructure/scene_otsu/tests/test_embedders.py
@@ -139,6 +139,23 @@ class CreateEmbedderOpenAITests(SimpleTestCase):
             batch_size=16,
         )
 
+    @override_settings(OPENAI_API_KEY="server-key")
+    @patch("app.infrastructure.scene_otsu.embedders.OpenAIEmbedder")
+    def test_uses_server_key_when_explicit_key_is_missing(
+        self, mock_openai_embedder
+    ):
+        """Use the server key after per-user OpenAI keys were removed."""
+        from app.infrastructure.scene_otsu.embedders import create_embedder
+
+        create_embedder(api_key=None)
+
+        mock_openai_embedder.assert_called_once_with(
+            api_key="server-key",
+            model="text-embedding-3-small",
+            batch_size=16,
+        )
+
+    @override_settings(OPENAI_API_KEY="")
     def test_raises_without_api_key(self):
         """Test that ProviderConfigError is raised without API key"""
         from app.infrastructure.scene_otsu.embedders import create_embedder

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -655,7 +655,7 @@ SEARCHAPI_TIMEOUT_SECONDS = int(
     os.environ.get("SEARCHAPI_TIMEOUT_SECONDS", DefaultSettings.SEARCHAPI_TIMEOUT_SECONDS)
 )
 
-# OpenAI API key (system-level fallback; users can override with their own key)
+# Server credential shared by OpenAI-backed providers.
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
 
 # Billing configuration

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -250,11 +250,8 @@ WSGI_APPLICATION = "videoq.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-DATABASES = {
-    "default": dj_database_url.parse(
-        os.environ.get("DATABASE_URL", DefaultSettings.DATABASE_URL)
-    )
-}
+DATABASE_URL = os.environ.get("DATABASE_URL", DefaultSettings.DATABASE_URL)
+DATABASES = {"default": dj_database_url.parse(DATABASE_URL)}
 
 # Cache configuration
 # USE_DATABASE_CACHE=true の場合は DatabaseCache (Aurora) を使用。


### PR DESCRIPTION
## 概要

PR #792 からOpenAIキー解決と環境設定の整理だけを分離しました。

- 字幕のscene splittingで呼び出し側の空キーではなくserver設定を利用
- provider、storage、vector storeの環境値参照をDjango settingsへ集約
- Django DBとPGVectorが同じ `DATABASE_URL` を使うよう統一
- file upload gatewayの選択をinfrastructure factoryへ集約
- OpenAIキー、vector store、file upload gatewayの回帰テストを追加・更新

## 検査

- `uv tool run ruff@latest check app videoq`
- `mypy --config-file mypy.ini app videoq`
- 対象39テスト

## 依存関係

- マージ順: #797 → #793 → このPR
- #793のマージ後、このPRのbaseを `main` へ変更します
- 分割元: #792