### PR TITLE
feat: OpenAI Terraform プロバイダ導入 + LLM モデル一本化

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -53,4 +53,7 @@ jobs:
           TF_VAR_pages_domain: ${{ secrets.PAGES_DOMAIN }}
           TF_VAR_custom_domain: ${{ secrets.CUSTOM_DOMAIN }}
           TF_VAR_certificate_arn: ${{ secrets.CERTIFICATE_ARN }}
+          # OpenAI プロジェクト管理 (openai/openai プロバイダ) 用
+          OPENAI_ADMIN_KEY: ${{ secrets.OPENAI_ADMIN_KEY }}
+          TF_VAR_openai_spend_alert_email: ${{ secrets.OPENAI_SPEND_ALERT_EMAIL }}
         run: terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -51,6 +51,9 @@ jobs:
           TF_VAR_pages_domain: ${{ secrets.PAGES_DOMAIN }}
           TF_VAR_custom_domain: ${{ secrets.CUSTOM_DOMAIN }}
           TF_VAR_certificate_arn: ${{ secrets.CERTIFICATE_ARN }}
+          # OpenAI プロジェクト管理 (openai/openai プロバイダ) 用
+          OPENAI_ADMIN_KEY: ${{ secrets.OPENAI_ADMIN_KEY }}
+          TF_VAR_openai_spend_alert_email: ${{ secrets.OPENAI_SPEND_ALERT_EMAIL }}
         run: |
           set +e
           PLAN_OUTPUT=$(terraform plan -no-color -input=false 2>&1)

--- a/backend/app/infrastructure/external/llm.py
+++ b/backend/app/infrastructure/external/llm.py
@@ -40,10 +40,8 @@ def get_langchain_grading_llm(api_key: str | None = None) -> BaseChatModel:
     """Small-model LLM for GradeReply (paper §3.2 / Algorithm 1 line 15)."""
     provider = get_provider_setting("LLM_PROVIDER", "openai")
     builders: dict[str, Callable[[], BaseChatModel]] = {
-        "openai": lambda: _create_openai_llm(
-            api_key, model_setting="LLM_GRADE_MODEL", max_tokens=256
-        ),
-        "ollama": lambda: _create_ollama_llm(model_setting="LLM_GRADE_MODEL"),
+        "openai": lambda: _create_openai_llm(api_key, max_tokens=256),
+        "ollama": _create_ollama_llm,
     }
     return create_from_provider_registry("LLM_PROVIDER", provider, builders)
 
@@ -66,19 +64,11 @@ def get_langchain_extraction_llm(api_key: str | None = None) -> BaseChatModel:
 def _create_openai_llm(
     api_key: str | None = None,
     *,
-    model_setting: str = "LLM_MODEL",
     max_tokens: int = 1024,
     prompt_cache_key: str | None = None,
 ) -> BaseChatModel:
     resolved_key = resolve_openai_api_key(api_key, purpose="OpenAI LLM")
-    # Paper §3.3: large study nudge / small grading; QA stays on LLM_MODEL.
-    if model_setting == "LLM_GRADE_MODEL":
-        default = "gpt-4o-mini"
-    elif model_setting == "LLM_STUDY_MODEL":
-        default = "gpt-4o"
-    else:
-        default = "gpt-4o-mini"
-    model = getattr(settings, model_setting, getattr(settings, "LLM_MODEL", default))
+    model = getattr(settings, "LLM_MODEL", "gpt-4o-mini")
 
     del prompt_cache_key  # reserved; automatic prefix caching uses identical system bytes
     llm = ChatOpenAI(
@@ -93,28 +83,20 @@ def _create_openai_llm(
 def get_langchain_study_llm(
     api_key: str | None = None, *, prompt_cache_key: str | None = None
 ) -> BaseChatModel:
-    """Large-model LLM for the single generative nudge (paper §3.3)."""
+    """LLM for the single generative nudge (paper §3.3)."""
     provider = get_provider_setting("LLM_PROVIDER", "openai")
     builders: dict[str, Callable[[], BaseChatModel]] = {
         "openai": lambda: _create_openai_llm(
-            api_key,
-            model_setting="LLM_STUDY_MODEL",
-            prompt_cache_key=prompt_cache_key,
+            api_key, prompt_cache_key=prompt_cache_key
         ),
-        "ollama": lambda: _create_ollama_llm(model_setting="LLM_STUDY_MODEL"),
+        "ollama": _create_ollama_llm,
     }
     return create_from_provider_registry("LLM_PROVIDER", provider, builders)
 
 
-def _create_ollama_llm(*, model_setting: str = "LLM_MODEL") -> BaseChatModel:
+def _create_ollama_llm() -> BaseChatModel:
     base_url = getattr(settings, "OLLAMA_BASE_URL", "http://host.docker.internal:11434")
-    if model_setting == "LLM_GRADE_MODEL":
-        default = "qwen3:0.6b"
-    elif model_setting == "LLM_STUDY_MODEL":
-        default = "qwen3:8b"
-    else:
-        default = "qwen3:0.6b"
-    model = getattr(settings, model_setting, getattr(settings, "LLM_MODEL", default))
+    model = getattr(settings, "LLM_MODEL", "qwen3:0.6b")
 
     return ChatOllama(
         model=model,

--- a/backend/app/infrastructure/external/tests/test_llm.py
+++ b/backend/app/infrastructure/external/tests/test_llm.py
@@ -28,14 +28,14 @@ class GetLangchainLLMTests(SimpleTestCase):
         )
 
     @patch("app.infrastructure.external.llm.ChatOpenAI")
-    @override_settings(LLM_PROVIDER="openai", LLM_MODEL="gpt-4o")
+    @override_settings(LLM_PROVIDER="openai", LLM_MODEL="gpt-4o-mini")
     def test_get_langchain_llm_with_custom_model(self, mock_chat_openai):
         """Test get_langchain_llm with custom LLM model from environment"""
         llm = get_langchain_llm(api_key="test-api-key")
 
         self.assertIsNotNone(llm)
         mock_chat_openai.assert_called_once_with(
-            model="gpt-4o",
+            model="gpt-4o-mini",
             api_key=SecretStr("test-api-key"),
             temperature=0.0,
         )

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -109,11 +109,9 @@ class DefaultSettings:
     )
     OLLAMA_BASE_URL = "http://host.docker.internal:11434"  # Ollama server URL
 
-    # LLM configuration (paper §3.3 model-tier: large study nudge / small grade)
+    # LLM configuration
     LLM_PROVIDER = "openai"  # openai or ollama
-    LLM_MODEL = "gpt-4o-mini"  # Default generative LLM (QA and general)
-    LLM_STUDY_MODEL = "gpt-4o"  # Large model for PLOG study nudge (§3.3)
-    LLM_GRADE_MODEL = "gpt-4o-mini"  # Small model for PLOG GradeReply
+    LLM_MODEL = "gpt-4o-mini"  # QA / PLOG study nudge / GradeReply すべて共通
 
     # Whisper configuration
     WHISPER_BACKEND = "openai"  # openai or whisper.cpp
@@ -641,8 +639,6 @@ EMBEDDING_VECTOR_SIZE = int(os.environ.get("EMBEDDING_VECTOR_SIZE", "1536"))
 # LLM configuration
 LLM_PROVIDER = os.environ.get("LLM_PROVIDER", DefaultSettings.LLM_PROVIDER).lower()
 LLM_MODEL = os.environ.get("LLM_MODEL", DefaultSettings.LLM_MODEL)
-LLM_STUDY_MODEL = os.environ.get("LLM_STUDY_MODEL", DefaultSettings.LLM_STUDY_MODEL)
-LLM_GRADE_MODEL = os.environ.get("LLM_GRADE_MODEL", DefaultSettings.LLM_GRADE_MODEL)
 
 # Whisper configuration
 WHISPER_BACKEND = os.environ.get(

--- a/docs/plog/README.md
+++ b/docs/plog/README.md
@@ -45,8 +45,8 @@ Per turn:
 2. Prerequisite frontier / unmet redirect
 3. `Retrieve(L0, L1, t)` + learning object + withhold(Ahead)
 4. Opening turn served **statically** (no LLM)
-5. Else one generative nudge on the **large** model (`LLM_STUDY_MODEL`, default `gpt-4o`)
-6. Next turn: `GradeReply` on the **small** model (`LLM_GRADE_MODEL`, default `gpt-4o-mini`); advance hint ladder or next topo concept
+5. Else one generative nudge on `LLM_MODEL` (default `gpt-4o-mini`)
+6. Next turn: `GradeReply` on `LLM_MODEL` (short output budget); advance hint ladder or next topo concept
 
 ### Near-cost-neutral (§3.3)
 

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -23,3 +23,25 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
+
+provider "registry.terraform.io/openai/openai" {
+  version     = "1.0.0"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:mCXQTqY2GZXj0fa/IooZfgycEzZcBQQLJxa13TgkGJQ=",
+    "zh:11800721ec408b7f986553c9bcad5425262b231e6b2b35f1bd846b738f9ae330",
+    "zh:4cecff140c02f97aadcd9c1361f127d105293e2baff86e626f0543f965305ec7",
+    "zh:4d532550ef3c22699cce231dd49f21c7133b6bda15c5ed339aaf2bc752c9bcde",
+    "zh:4f1f7bc0a895a48b9b6389b1f4241fadf76bdc8027c2a22f7b6ce7c6c96cf652",
+    "zh:4f71ce31d3736a4b6e313cf185c13a6a266523a5d30c713425e4d103512e0e29",
+    "zh:6b7c9cdb05c7f5ee4965dac1af01685d1b5252da648e7af9a5705297df7ab111",
+    "zh:827fa0bd7bf7cebc9a6a4ab2936b399e4fe5816e5562b905a1f2f42c775ee557",
+    "zh:95c9ce0fe81ef020c65ebd3a2c89f53e19d29e44cb6faead858e714ca8c90786",
+    "zh:9c14b62d93e457b8cb356f862a3000067e9e7e5d00fdff1d74be354fbdfcb1e1",
+    "zh:b01a9fbdd7caa68fe76bc6522bda445f11cb703b832fe95828791b8ab0571c02",
+    "zh:b72d4be99862f328bd8b497fd18ea8b2dbef48e5573b2ba6acaeb9ba80315159",
+    "zh:ca5eccd62cd9eb117ec31bab1ea836430c31a56c1483288713a5ce86b3198ec2",
+    "zh:ee3c4ed78c271f397f28f5942e50db7d5b103217790035b5c748f02cc85cb38b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -218,6 +218,45 @@ aws secretsmanager put-secret-value \
 
 ---
 
+## (任意) OpenAI プロジェクト管理
+
+埋め込み / LLM / 文字起こしに使う OpenAI 組織プロジェクトのガバナンス
+(許可モデルの制限・月次スペンドアラート) を Terraform で管理できる
+(`infra/openai.tf`、`openai/openai` プロバイダ使用)。
+
+デフォルト (`manage_openai_project = false`) では全リソースが `count = 0` なので、
+Admin キー無しで `terraform plan` / `apply` が通る。有効化する場合のみ設定する。
+
+> **重要:** このプロバイダは **ランタイムの `OPENAI_API_KEY` を管理しない**。
+> アプリが実行時に使う API キーは従来どおりダッシュボードで手動発行し、
+> Secrets Manager の app シークレットへ手動保存する (Step 4 参照)。
+> Terraform が管理するのはプロジェクト設定 (許可モデル・スペンドアラート) のみ。
+
+有効化手順:
+
+1. OpenAI ダッシュボードで **Admin API キー** を発行する。
+2. apply の前に環境変数へ export する:
+
+   ```bash
+   export OPENAI_ADMIN_KEY=sk-admin-...
+   # 組織が複数ある場合は OPENAI_ORG_ID も指定
+   export OPENAI_ORG_ID=org-...
+   ```
+
+3. `terraform.tfvars` (または `TF_VAR_*`) で有効化する:
+
+   ```hcl
+   manage_openai_project      = true
+   openai_spend_alert_email   = "ops@example.com"
+   openai_spend_threshold_usd = 50
+   # openai_allowed_models は videoq が使うモデルで既定値済み
+   ```
+
+4. `terraform apply` を実行する。作成された OpenAI プロジェクト ID は
+   `terraform output openai_project_id` で確認できる。
+
+---
+
 ## Step 5: コンテナイメージをビルド & プッシュ
 
 ```bash

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -218,42 +218,45 @@ aws secretsmanager put-secret-value \
 
 ---
 
-## (任意) OpenAI プロジェクト管理
+## OpenAI プロジェクト管理
 
 埋め込み / LLM / 文字起こしに使う OpenAI 組織プロジェクトのガバナンス
-(許可モデルの制限・月次スペンドアラート) を Terraform で管理できる
+(許可モデルの制限・月次スペンドアラート) を Terraform で管理する
 (`infra/openai.tf`、`openai/openai` プロバイダ使用)。
 
-デフォルト (`manage_openai_project = false`) では全リソースが `count = 0` なので、
-Admin キー無しで `terraform plan` / `apply` が通る。有効化する場合のみ設定する。
+**デフォルトで有効** (`manage_openai_project = true`)。CI (terraform-plan /
+terraform-apply) から実行するため、プロバイダが Admin API へ認証できるよう
+GitHub Secrets の設定が必須。
 
 > **重要:** このプロバイダは **ランタイムの `OPENAI_API_KEY` を管理しない**。
 > アプリが実行時に使う API キーは従来どおりダッシュボードで手動発行し、
 > Secrets Manager の app シークレットへ手動保存する (Step 4 参照)。
 > Terraform が管理するのはプロジェクト設定 (許可モデル・スペンドアラート) のみ。
 
-有効化手順:
+### 前提: GitHub Secrets (未設定だと terraform-plan / apply が失敗する)
 
 1. OpenAI ダッシュボードで **Admin API キー** を発行する。
-2. apply の前に環境変数へ export する:
+2. リポジトリ (Environment `production`) に以下を登録する:
 
-   ```bash
-   export OPENAI_ADMIN_KEY=sk-admin-...
-   # 組織が複数ある場合は OPENAI_ORG_ID も指定
-   export OPENAI_ORG_ID=org-...
-   ```
+   | Secret | 値 |
+   | --- | --- |
+   | `OPENAI_ADMIN_KEY` | `sk-admin-...` (Admin API キー) |
+   | `OPENAI_SPEND_ALERT_EMAIL` | スペンドアラートの通知先メール |
 
-3. `terraform.tfvars` (または `TF_VAR_*`) で有効化する:
+   しきい値は `openai_spend_threshold_usd` (既定 50 USD/月)、許可モデルは
+   `openai_allowed_models` で videoq が使うモデルに既定済み。
 
-   ```hcl
-   manage_openai_project      = true
-   openai_spend_alert_email   = "ops@example.com"
-   openai_spend_threshold_usd = 50
-   # openai_allowed_models は videoq が使うモデルで既定値済み
-   ```
+### apply 後
 
-4. `terraform apply` を実行する。作成された OpenAI プロジェクト ID は
-   `terraform output openai_project_id` で確認できる。
+作成された OpenAI プロジェクト ID は `terraform output openai_project_id`
+で確認できる。**そのプロジェクトでランタイム用 `OPENAI_API_KEY` を手動発行し**、
+Secrets Manager の app シークレットへ保存する (Step 4)。
+
+### ローカルで実行する場合
+
+`export OPENAI_ADMIN_KEY=sk-admin-...` してから
+`terraform.tfvars` に `openai_spend_alert_email` を記入して `terraform apply`。
+一時的に無効化したい場合のみ `manage_openai_project = false` を設定する。
 
 ---
 

--- a/infra/openai.tf
+++ b/infra/openai.tf
@@ -1,0 +1,32 @@
+# OpenAI プロジェクトのガバナンスを Terraform で管理する (openai/openai プロバイダ)。
+# 埋め込み / LLM / 文字起こしに使う OpenAI 組織プロジェクトの設定を IaC 化する。
+#
+# 注意: このプロバイダは API キーを管理できない。ランタイムの OPENAI_API_KEY は
+# 従来どおりダッシュボードで手動発行し、app シークレット (secrets.tf) に手動保存する。
+#
+# var.manage_openai_project = false (デフォルト) の間は全リソース count=0 なので
+# OPENAI_ADMIN_KEY 無しで plan/apply できる。true にして Admin キーを export すると有効化。
+
+resource "openai_project" "videoq" {
+  count = var.manage_openai_project ? 1 : 0
+  name  = "${local.name_prefix}-${var.env_name}"
+}
+
+# videoq が実際に呼ぶモデルだけに制限する (コストガードレール)。
+resource "openai_project_model_permissions" "videoq" {
+  count      = var.manage_openai_project ? 1 : 0
+  project_id = openai_project.videoq[0].project_id
+  mode       = "allow_list"
+  model_ids  = var.openai_allowed_models
+}
+
+# 月次スペンドがしきい値を超えたらメール通知する (予算ガードレール)。
+resource "openai_project_spend_alert" "videoq" {
+  count                           = var.manage_openai_project && var.openai_spend_alert_email != "" ? 1 : 0
+  project_id                      = openai_project.videoq[0].project_id
+  threshold_amount                = var.openai_spend_threshold_usd
+  currency                        = "USD"
+  interval                        = "month"
+  notification_channel_type       = "email"
+  notification_channel_recipients = [var.openai_spend_alert_email]
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -32,3 +32,8 @@ output "distribution_id" {
   description = "CloudFront ディストリビューション ID"
   value       = try(aws_cloudfront_distribution.this[0].id, null)
 }
+
+output "openai_project_id" {
+  description = "Terraform 管理下の OpenAI プロジェクト ID (未管理なら null)"
+  value       = try(openai_project.videoq[0].project_id, null)
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,3 +1,7 @@
 provider "aws" {
   region = var.aws_region
 }
+
+# OpenAI Administration API プロバイダ。OPENAI_ADMIN_KEY を環境変数から読む。
+# var.manage_openai_project = false のときは全リソース count=0 なので Admin キー不要。
+provider "openai" {}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -61,12 +61,14 @@ sqs_max_receive_count = 3
 
 # --- OpenAI プロジェクト管理 ----------------------------------------------
 # OpenAI 組織プロジェクトのガバナンス (許可モデル / スペンドアラート) を Terraform で管理する。
-# manage_openai_project = true にする場合は、apply の前に Admin API キーを
+# デフォルトで有効 (manage_openai_project = true)。apply の前に Admin API キーを
 # 環境変数 OPENAI_ADMIN_KEY (必要なら OPENAI_ORG_ID) に export しておくこと。
+# CI では GitHub Secret OPENAI_ADMIN_KEY / OPENAI_SPEND_ALERT_EMAIL から渡す (DEPLOY.md 参照)。
 # 注意: このプロバイダはランタイムの OPENAI_API_KEY を管理しない。実行用キーは
 #       従来どおりダッシュボードで手動発行し、Secrets Manager の app シークレットへ手動保存する。
 #
-# manage_openai_project = true
+# ローカル apply 時に上書きする場合の例:
 # openai_spend_alert_email   = "ops@example.com"
 # openai_spend_threshold_usd = 50
 # openai_allowed_models = ["text-embedding-3-small", "gpt-4o-mini", "whisper-1"]
+# manage_openai_project = false  # 一時的に無効化したいときのみ

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -58,3 +58,15 @@ sqs_visibility_timeout_seconds = 960
 
 # メッセージ最大受信回数 (超過で DLQ へ送信)
 sqs_max_receive_count = 3
+
+# --- OpenAI プロジェクト管理 ----------------------------------------------
+# OpenAI 組織プロジェクトのガバナンス (許可モデル / スペンドアラート) を Terraform で管理する。
+# manage_openai_project = true にする場合は、apply の前に Admin API キーを
+# 環境変数 OPENAI_ADMIN_KEY (必要なら OPENAI_ORG_ID) に export しておくこと。
+# 注意: このプロバイダはランタイムの OPENAI_API_KEY を管理しない。実行用キーは
+#       従来どおりダッシュボードで手動発行し、Secrets Manager の app シークレットへ手動保存する。
+#
+# manage_openai_project = true
+# openai_spend_alert_email   = "ops@example.com"
+# openai_spend_threshold_usd = 50
+# openai_allowed_models = ["text-embedding-3-small", "gpt-4o-mini", "whisper-1"]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -73,7 +73,7 @@ variable "image_tag" {
 variable "manage_openai_project" {
   description = "OpenAI プロジェクトのガバナンスを Terraform で管理するか (true で有効化。要 OPENAI_ADMIN_KEY)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "openai_allowed_models" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -69,3 +69,27 @@ variable "image_tag" {
   type        = string
   default     = "latest"
 }
+
+variable "manage_openai_project" {
+  description = "OpenAI プロジェクトのガバナンスを Terraform で管理するか (true で有効化。要 OPENAI_ADMIN_KEY)"
+  type        = bool
+  default     = false
+}
+
+variable "openai_allowed_models" {
+  description = "OpenAI プロジェクトで許可するモデル ID の一覧 (videoq が実際に使うモデルのみ)"
+  type        = list(string)
+  default     = ["text-embedding-3-small", "gpt-4o-mini", "whisper-1"]
+}
+
+variable "openai_spend_alert_email" {
+  description = "月次スペンドアラートの通知先メールアドレス (空文字でアラート無効)"
+  type        = string
+  default     = ""
+}
+
+variable "openai_spend_threshold_usd" {
+  description = "月次スペンドアラートのしきい値 (USD)"
+  type        = number
+  default     = 50
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -7,5 +7,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    openai = {
+      source  = "openai/openai"
+      version = ">= 1.0.0"
+    }
   }
 }


### PR DESCRIPTION
## 概要

OpenAI 公式 Terraform プロバイダ (`openai/openai`) を `infra/` に導入し、videoq が使う OpenAI 組織プロジェクトのガバナンスを IaC 化する。あわせて LLM のモデル階層を `LLM_MODEL` に一本化した。

## 変更内容

### 1. OpenAI プロジェクト管理 (infra)
- `infra/openai.tf` を新規追加。`openai/openai` プロバイダ経由で以下を管理:
  - `openai_project` — videoq 専用プロジェクト
  - `openai_project_model_permissions` — 許可モデルを allow-list で制限（コストガードレール）
  - `openai_project_spend_alert` — 月次 50 USD でメール通知（予算ガードレール）
- `manage_openai_project = true` で**デフォルト有効**。
- `terraform-plan` / `terraform-apply` ワークフローに `OPENAI_ADMIN_KEY` と `TF_VAR_openai_spend_alert_email` を配線。

> ⚠️ このプロバイダは **ランタイムの `OPENAI_API_KEY` を管理しない**。実行用キーは従来どおりダッシュボードで手動発行し、Secrets Manager の app シークレットに保存する。

### 2. LLM モデル一本化 (backend)
- `LLM_STUDY_MODEL` / `LLM_GRADE_MODEL` を廃止し、PLOG の study nudge・GradeReply も含めて `LLM_MODEL`（`gpt-4o-mini`）に統一。
- backend から `gpt-4o` を一掃。ヘルパー関数はモデル差ではなく用途/トークン予算差（grading は `max_tokens=256`）のみを表現。

## マージ前の必須作業 ⚠️

Environment `production`（または repo secrets）に以下を登録しないと、`infra/**` を触った PR の terraform-plan が OpenAI Admin API 認証で失敗する:

| Secret | 値 |
| --- | --- |
| `OPENAI_ADMIN_KEY` | OpenAI Admin API キー (`sk-admin-...`) |
| `OPENAI_SPEND_ALERT_EMAIL` | スペンドアラート通知先メール |

## apply 後

`terraform output openai_project_id` で作成されたプロジェクトを確認 → そのプロジェクトでランタイム用 `OPENAI_API_KEY` を手動発行 → Secrets Manager の app シークレットへ保存。

## テスト
- `terraform fmt -check` / `terraform validate` OK（`openai/openai` v1.0.0 解決・lock 更新済み）
- backend `test_llm` + PLOG + prompts 全 52 テスト OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)