### PR TITLE
fix(infra): OpenAI スペンドアラートのしきい値はセント単位

### DIFF
--- a/infra/openai.tf
+++ b/infra/openai.tf
@@ -21,10 +21,12 @@ resource "openai_project_model_permissions" "videoq" {
 }
 
 # 月次スペンドがしきい値を超えたらメール通知する (予算ガードレール)。
+# 注意: threshold_amount は最小通貨単位 (USD=セント) で渡す。実測でも 50→$0.50 を確認。
+#       currency = "USD" 固定なので USD=100セント (定義) に従い var(USD)*100 を渡す。
 resource "openai_project_spend_alert" "videoq" {
   count                           = var.manage_openai_project && var.openai_spend_alert_email != "" ? 1 : 0
   project_id                      = openai_project.videoq[0].project_id
-  threshold_amount                = var.openai_spend_threshold_usd
+  threshold_amount                = var.openai_spend_threshold_usd * 100
   currency                        = "USD"
   interval                        = "month"
   notification_channel_type       = "email"


### PR DESCRIPTION
## 問題

`openai_project_spend_alert` の `threshold_amount` は**最小通貨単位（USD=セント）**で渡す必要があった。`var.openai_spend_threshold_usd = 50` をそのまま渡していたため、意図の $50 ではなく **$0.50** でアラートが作成されていた。

## 根拠（実測）

apply 済みのプロジェクト（`videoq-prod`）のダッシュボードで、我々のアラート（通知先が本人メール）が **「Alert when spend reaches 100% ($0.50)」** と表示。`50` を渡して `$0.50` = 表示は値÷100 → 単位はセント。公式ガイド/プロバイダ doc には単位の明記がなく、実挙動が唯一の確証。

## 修正

変数は USD のまま、HCL で ×100 してセントに変換（`currency = "USD"` 固定なので USD=100セントに従う）:

```hcl
threshold_amount = var.openai_spend_threshold_usd * 100
```

`openai_spend_threshold_usd = 50` → `5000` → ダッシュボードで **$50** 表示になる。

## 検証
- `terraform validate` OK
- マージ後の apply でダッシュ表示が **$50** になれば単位も同時に実証される（plan では `threshold_amount: 50 -> 5000` の in-place 差分になる想定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)