### PR TITLE
chore: translate comments to English

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -53,7 +53,7 @@ jobs:
           TF_VAR_pages_domain: ${{ secrets.PAGES_DOMAIN }}
           TF_VAR_custom_domain: ${{ secrets.CUSTOM_DOMAIN }}
           TF_VAR_certificate_arn: ${{ secrets.CERTIFICATE_ARN }}
-          # OpenAI プロジェクト管理 (openai/openai プロバイダ) 用
+          # Used to manage OpenAI projects with the openai/openai provider.
           OPENAI_ADMIN_KEY: ${{ secrets.OPENAI_ADMIN_KEY }}
           TF_VAR_openai_spend_alert_email: ${{ secrets.OPENAI_SPEND_ALERT_EMAIL }}
         run: terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -51,7 +51,7 @@ jobs:
           TF_VAR_pages_domain: ${{ secrets.PAGES_DOMAIN }}
           TF_VAR_custom_domain: ${{ secrets.CUSTOM_DOMAIN }}
           TF_VAR_certificate_arn: ${{ secrets.CERTIFICATE_ARN }}
-          # OpenAI プロジェクト管理 (openai/openai プロバイダ) 用
+          # Used to manage OpenAI projects with the openai/openai provider.
           OPENAI_ADMIN_KEY: ${{ secrets.OPENAI_ADMIN_KEY }}
           TF_VAR_openai_spend_alert_email: ${{ secrets.OPENAI_SPEND_ALERT_EMAIL }}
         run: |
@@ -84,10 +84,10 @@ jobs:
             <!-- terraform-plan -->
             ## Terraform Plan
 
-            `infra/**` に変更が検出されました。以下の差分を確認してからマージしてください。
+            Changes were detected in `infra/**`. Review the diff below before merging.
 
             <details>
-            <summary>terraform plan の結果（クリックで展開）</summary>
+            <summary>Terraform plan result (click to expand)</summary>
 
             ```
             ${{ steps.plan.outputs.plan_output }}
@@ -95,10 +95,10 @@ jobs:
 
             </details>
 
-            > `main` マージ後、手動承認を経て `terraform apply` が自動実行されます。
+            > After merging into `main`, `terraform apply` runs automatically following manual approval.
 
       - name: Fail if plan errored
         if: steps.plan.outputs.exit_code != '0'
         run: |
-          echo "terraform plan がエラー終了しました (exit ${{ steps.plan.outputs.exit_code }})。上記コメントの内容を確認してください。"
+          echo "Terraform plan failed (exit ${{ steps.plan.outputs.exit_code }}). Review the comment above."
           exit 1

--- a/backend/Dockerfile.lambda
+++ b/backend/Dockerfile.lambda
@@ -1,14 +1,14 @@
 # ── Lambda Web Adapter + Django API ─────────────────────────────────────────
-# Lambda Web Adapter (LWA) は Lambda イベントを HTTP に変換して
-# Gunicorn へ転送するエクステンション。コード変更不要。
+# Lambda Web Adapter (LWA) is an extension that converts Lambda events to HTTP
+# and forwards them to Gunicorn. No application code changes are required.
 # https://github.com/awslabs/aws-lambda-web-adapter
 #
-# 重要: LWA はカスタムランタイムとして動作するため、Lambda ベースイメージ
-# (public.ecr.aws/lambda/python) ではなく通常の Python イメージを使う。
-# Lambda ベースイメージの entrypoint は handler 名を要求し、gunicorn CMD と競合する。
+# Important: LWA runs as a custom runtime, so use a standard Python image
+# instead of the Lambda base image (public.ecr.aws/lambda/python).
+# The Lambda base image entrypoint expects a handler name and conflicts with the Gunicorn CMD.
 FROM public.ecr.aws/docker/library/python:3.12-slim
 
-# Lambda Web Adapter バイナリをコピー
+# Copy the Lambda Web Adapter binary.
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.0-rc1 /lambda-adapter /opt/extensions/lambda-adapter 
 ENV NLTK_DATA=/usr/local/nltk_data
 WORKDIR /var/task
@@ -37,13 +37,13 @@ COPY . .
 # Django gettext message catalogs (.po → .mo) for OAuth consent screen i18n
 RUN python manage.py compilemessages
 
-# Django static files を収集
+# Collect Django static files.
 RUN python manage.py collectstatic --noinput || true
 
-# LWA が PORT=8000 を監視し、Gunicorn が起動したら
-# AWS_LWA_READINESS_CHECK_PATH へポーリングして準備完了を確認する。
-# --workers 1: Lambda は単一プロセス (LWA がスケールを管理)
-# --timeout 0: タイムアウトは Lambda/LWA に委ねる
+# LWA monitors PORT=8000 and polls AWS_LWA_READINESS_CHECK_PATH after Gunicorn
+# starts to confirm that the application is ready.
+# --workers 1: Lambda uses one process; LWA manages scaling.
+# --timeout 0: Delegate timeout handling to Lambda/LWA.
 CMD ["gunicorn", "videoq.asgi:application", \
     "--worker-class", "uvicorn_worker.UvicornWorker", \
     "--bind", "0.0.0.0:8000", \

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,15 +1,15 @@
-# ── Worker Lambda (SQS トリガー) ─────────────────────────────────────────────
-# Lambda Runtime Interface Client (awslambdaric) が標準搭載されている
-# public.ecr.aws/lambda/python:3.12 ベースイメージを使用。
-# Celery ワーカーは起動せず、lambda_handler.py が SQS メッセージを
-# 直接タスク関数にディスパッチする。
+# ── Worker Lambda (SQS trigger) ──────────────────────────────────────────────
+# Use the public.ecr.aws/lambda/python:3.12 base image, which includes the
+# Lambda Runtime Interface Client (awslambdaric).
+# Instead of starting a Celery worker, lambda_handler.py dispatches SQS messages
+# directly to task functions.
 FROM public.ecr.aws/lambda/python:3.12
 
 ARG APP_HOME=/var/task
 ENV NLTK_DATA=/usr/local/nltk_data
 WORKDIR ${APP_HOME}
 
-# ffmpeg: AL2023 最小イメージには tar/xz が未インストールのため先にインストール
+# ffmpeg: Install tar/xz first because the minimal AL2023 image omits them.
 RUN dnf install -y tar xz && dnf clean all
 
 RUN curl -fsSL \
@@ -29,5 +29,5 @@ RUN python -m nltk.downloader -e -d "${NLTK_DATA}" \
 
 COPY . .
 
-# Lambda ハンドラー: lambda_handler.py の handler 関数
+# Lambda handler: the handler function in lambda_handler.py.
 CMD ["lambda_handler.handler"]

--- a/backend/app/infrastructure/chat/tests/test_keyword_extractor.py
+++ b/backend/app/infrastructure/chat/tests/test_keyword_extractor.py
@@ -10,7 +10,7 @@ class JanomeNltkKeywordExtractorJapaneseTests(TestCase):
         self.extractor = JanomeNltkKeywordExtractor()
 
     def test_extracts_japanese_nouns_from_single_question(self):
-        # janome splits "機械学習" into "機械" + "学習"
+        # Janome splits the compound phrase into separate noun tokens.
         results = self.extractor.extract(["機械学習の特徴は何ですか"])
         words = [r.word for r in results]
         self.assertIn("機械", words)
@@ -24,13 +24,13 @@ class JanomeNltkKeywordExtractorJapaneseTests(TestCase):
             self.assertGreaterEqual(len(word), 2)
 
     def test_counts_are_aggregated_across_questions(self):
-        # janome splits "機械学習" into "機械" + "学習"; each appears in both questions
+        # Janome splits the compound phrase; each token appears in both questions.
         results = self.extractor.extract(["機械学習の特徴", "機械学習の課題"])
         count_map = {r.word: r.count for r in results}
         self.assertEqual(count_map.get("学習"), 2)
 
     def test_results_are_sorted_by_frequency_descending(self):
-        # "学習" appears 3 times, "特徴" 2 times
+        # The learning token appears three times and the feature token twice.
         results = self.extractor.extract(["機械学習の特徴", "機械学習の課題", "深層学習の特徴"])
         if len(results) >= 2:
             for i in range(len(results) - 1):

--- a/backend/app/infrastructure/repositories/tests/test_django_video_repository.py
+++ b/backend/app/infrastructure/repositories/tests/test_django_video_repository.py
@@ -45,7 +45,7 @@ class DjangoVideoRepositoryTagFilterTests(TestCase):
         self.assertNotIn("Video B", titles)
 
     def test_multiple_tag_filter_returns_videos_with_any_tag_or_logic(self):
-        """複数タグ選択時はORロジック（いずれかのタグを持つ動画）で返すこと"""
+        """Multiple selected tags use OR logic and return videos with any tag."""
         criteria = VideoSearchCriteria(tag_ids=[self.tag_a.id, self.tag_b.id])
         results = self.repo.list_for_user(self.user.id, criteria)
         titles = {v.title for v in results}
@@ -54,7 +54,7 @@ class DjangoVideoRepositoryTagFilterTests(TestCase):
         self.assertIn("Video AB", titles)
 
     def test_multiple_tag_filter_no_duplicates(self):
-        """ORロジックでも重複動画が返らないこと（distinct）"""
+        """OR logic does not return duplicate videos because it uses distinct."""
         criteria = VideoSearchCriteria(tag_ids=[self.tag_a.id, self.tag_b.id])
         results = self.repo.list_for_user(self.user.id, criteria)
         ids = [v.id for v in results]

--- a/backend/app/infrastructure/storage/tests/test_local_media_storage.py
+++ b/backend/app/infrastructure/storage/tests/test_local_media_storage.py
@@ -10,7 +10,7 @@ from app.infrastructure.storage.local_media_storage import LocalMediaStorage
 
 
 class LocalMediaStoragePathValidationTests(TestCase):
-    """LocalMediaStorage が危険なパスを拒否することを確認する。"""
+    """Verify that LocalMediaStorage rejects unsafe paths."""
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -53,29 +53,30 @@ class LocalMediaStoragePathValidationTests(TestCase):
 
     @override_settings(MEDIA_ROOT="/tmp/media_root")
     def test_path_with_escaped_traversal_raises(self):
-        """解決後に MEDIA_ROOT 外に出るパスは拒否する。"""
+        """Reject paths that resolve outside MEDIA_ROOT."""
         with self.assertRaises(ValueError):
             self.storage.exists("videos/../../../../etc/passwd")
 
     def test_startswith_false_positive_is_rejected(self):
         """
-        MEDIA_ROOT が /tmp/media の場合、/tmp/media_evil/file は
-        str.startswith("/tmp/media") が True になるが、正しく拒否されなければならない。
-        Path.is_relative_to() を使っていれば False になる。
+        When MEDIA_ROOT is /tmp/media, str.startswith("/tmp/media") returns True
+        for /tmp/media_evil/file. The path must still be rejected;
+        Path.is_relative_to() correctly returns False.
         """
         import os
         import tempfile
 
-        # /tmp/media_<suffix> と /tmp/media_<suffix>_evil のような2つのディレクトリを作る
+        # Create sibling directories such as /tmp/media_<suffix> and
+        # /tmp/media_<suffix>_evil.
         base = tempfile.mkdtemp()
         sibling = base + "_evil"
         os.makedirs(sibling, exist_ok=True)
-        # sibling 内にファイルを作る
+        # Create a file inside the sibling directory.
         evil_file = os.path.join(sibling, "secret.txt")
         with open(evil_file, "w") as f:
             f.write("secret")
         # MEDIA_ROOT = base, path = ../base_evil/secret.txt
-        # .. は拒否されるので、symlink で試みる
+        # Because ``..`` is rejected, attempt traversal through a symlink.
         link_path = os.path.join(base, "evil_link")
         os.symlink(sibling, link_path)
         try:

--- a/backend/app/migrations/0020_enable_pgvector_and_cache_table.py
+++ b/backend/app/migrations/0020_enable_pgvector_and_cache_table.py
@@ -1,14 +1,14 @@
 """
-Aurora PostgreSQL 上で pgvector 拡張を有効化し、
-Django DatabaseCache 用テーブルを作成するマイグレーション。
+Enable the pgvector extension on Aurora PostgreSQL and create the table used by
+Django's DatabaseCache backend.
 
-- pgvector: Aurora PostgreSQL 15.4+ に標準搭載。
-  既存の ChatLog モデルのベクトル埋め込みに使用済みだが、
-  CREATE EXTENSION を明示的に実行することで Lambda 環境でも確実に有効化する。
+- pgvector: Included with Aurora PostgreSQL 15.4 and later. ChatLog already uses
+  it for vector embeddings, but explicitly running CREATE EXTENSION ensures it
+  is available in the Lambda environment.
 
-- django_cache: USE_DATABASE_CACHE=true 時に DRF スロットリング等が使用する
-  DatabaseCache バックエンドのテーブル。
-  manage.py createcachetable の代わりにマイグレーションで管理する。
+- django_cache: The DatabaseCache backend table used by DRF throttling and
+  related features when USE_DATABASE_CACHE=true. Manage it through this
+  migration instead of manage.py createcachetable.
 """
 from django.db import migrations
 
@@ -20,12 +20,12 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # pgvector 拡張の有効化 (冪等)
+        # Enable the pgvector extension (idempotent).
         migrations.RunSQL(
             sql="CREATE EXTENSION IF NOT EXISTS vector;",
-            reverse_sql="-- pgvector を削除するとデータが失われるため逆適用しない",
+            reverse_sql="-- No reverse operation: removing pgvector would lose data.",
         ),
-        # Django DatabaseCache テーブルの作成 (冪等)
+        # Create the Django DatabaseCache table (idempotent).
         migrations.RunSQL(
             sql="""
             CREATE TABLE IF NOT EXISTS django_cache (

--- a/backend/app/presentation/common/health.py
+++ b/backend/app/presentation/common/health.py
@@ -1,10 +1,11 @@
 """
-Lambda Web Adapter 用ヘルスチェックエンドポイント。
+Health-check endpoint for Lambda Web Adapter.
 
-AWS_LWA_READINESS_CHECK_PATH=/api/health/ として設定することで、
-LWA は Gunicorn の起動完了を確認してからリクエストの転送を開始する。
+Setting AWS_LWA_READINESS_CHECK_PATH=/api/health/ makes LWA wait for Gunicorn to
+finish starting before it begins forwarding requests.
 
-認証不要・DB アクセスなし。WSGI アプリが応答できるかのみ確認。
+No authentication or database access is required. This endpoint only verifies
+that the WSGI application can respond.
 """
 from typing import Any, ClassVar
 

--- a/backend/app/presentation/media/tests/test_views.py
+++ b/backend/app/presentation/media/tests/test_views.py
@@ -176,20 +176,20 @@ class ProtectedMediaViewTests(APITestCase):
         self.assertEqual(response["Content-Type"], "video/mp4")
 
     def test_path_traversal_dotdot_returns_404(self):
-        """../secret のようなパストラバーサルは 404 を返す。"""
+        """Path traversal such as ../secret returns 404."""
         self.client.force_authenticate(user=self.user)
-        # Django の URLconf が <path:path> を受け取るため直接 get を使う
+        # Use get directly because Django's URLconf accepts <path:path>.
         response = self.client.get("/api/media/../secret")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_path_traversal_double_dotdot_returns_404(self):
-        """../../etc/passwd のようなパスは 404 を返す。"""
+        """A path such as ../../etc/passwd returns 404."""
         self.client.force_authenticate(user=self.user)
         response = self.client.get("/api/media/../../etc/passwd")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_path_traversal_embedded_dotdot_returns_404(self):
-        """videos/../../../etc/passwd のようなパスは 404 を返す。"""
+        """A path such as videos/../../../etc/passwd returns 404."""
         self.client.force_authenticate(user=self.user)
         response = self.client.get("/api/media/videos/../../../etc/passwd")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/app/presentation/video/tests/test_views.py
+++ b/backend/app/presentation/video/tests/test_views.py
@@ -239,7 +239,7 @@ class VideoGroupMemberAPITestCase(APITestCase):
         self.assertEqual(VideoGroupMember.objects.count(), 0)
 
     def test_remove_video_from_group_function_does_not_exist(self):
-        """remove_video_from_group 関数ベースビューはデッドコードのため存在しないこと"""
+        """The dead remove_video_from_group function-based view is absent."""
         import app.presentation.video.views as views_module
 
         self.assertFalse(
@@ -955,7 +955,7 @@ class ShareLinkTests(APITestCase):
         self.group.share_slug = "my-group"
         self.group.save(update_fields=["share_slug"])
 
-        # 有効なトークンで旧URLを叩いてもルーティングレベルで404になるべき
+        # Even with a valid token, the legacy URL should return 404 at routing.
         response = self.client.get("/api/videos/groups/shared/my-group/")
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/app/tests/test_chat_history_format_csv.py
+++ b/backend/app/tests/test_chat_history_format_csv.py
@@ -1,6 +1,6 @@
 """TDD tests for GET /chat/history/?download=csv endpoint.
 
-Issue #459: /export/ エンドポイントをクエリパラメータに変更する
+Issue #459: Replace the /export/ endpoint with a query parameter.
 - GET /api/chat/history/?download=csv&group_id=1 → CSV response
 - GET /api/chat/history/?group_id=1              → JSON response (unchanged)
 """

--- a/backend/app/use_cases/media/resolve_protected_media.py
+++ b/backend/app/use_cases/media/resolve_protected_media.py
@@ -26,7 +26,7 @@ class ResolveProtectedMediaOutput:
 
 
 def _is_safe_path(path: str) -> bool:
-    """絶対パスや .. を含むパスを拒否する。"""
+    """Reject absolute paths and paths containing ``..`` components."""
     if os.path.isabs(path):
         return False
     return ".." not in Path(path).parts
@@ -60,7 +60,7 @@ class ResolveProtectedMediaUseCase:
         self.media_storage = media_storage
 
     def execute(self, input: ResolveProtectedMediaInput) -> ResolveProtectedMediaOutput:
-        # 1. パス検証 — ファイルシステムアクセスより前に実行する
+        # 1. Validate the path before accessing the file system.
         if not _is_safe_path(input.path):
             raise ResourceNotFound("Media")
 
@@ -69,7 +69,7 @@ class ResolveProtectedMediaUseCase:
         if video_id is None:
             raise ResourceNotFound("Media")
 
-        # 3. 認可チェック
+        # 3. Check authorization.
         if input.group_id is not None:
             if not self.media_repo.is_video_in_group(video_id, input.group_id):
                 raise ResourceNotFound("Media")
@@ -79,7 +79,7 @@ class ResolveProtectedMediaUseCase:
         else:
             raise ResourceNotFound("Media")
 
-        # 4. ファイル存在確認 — 認可後に実行
+        # 4. Check file existence only after authorization.
         if not self.media_storage.exists(input.path):
             raise ResourceNotFound("Media")
 

--- a/backend/app/use_cases/media/tests/test_resolve_protected_media.py
+++ b/backend/app/use_cases/media/tests/test_resolve_protected_media.py
@@ -38,7 +38,7 @@ class _FakeStorage:
 
 
 class _TrackingStorage:
-    """ファイルシステムアクセスの呼び出しを追跡するストレージ。"""
+    """Storage test double that tracks file-system access calls."""
 
     def __init__(self):
         self.exists_called = False
@@ -90,7 +90,7 @@ class ResolveProtectedMediaUseCaseTests(unittest.TestCase):
             )
 
     def test_dotdot_path_raises_not_found_without_filesystem_access(self):
-        """../secret のようなパスはストレージを呼び出す前に拒否する。"""
+        """Reject a path such as ../secret before calling storage."""
         storage = _TrackingStorage()
         use_case = ResolveProtectedMediaUseCase(
             media_repo=_FakeMediaRepo(),
@@ -106,7 +106,7 @@ class ResolveProtectedMediaUseCaseTests(unittest.TestCase):
         self.assertFalse(storage.open_called, "open() must not be called for traversal paths")
 
     def test_double_dotdot_to_etc_passwd_raises_not_found_without_filesystem_access(self):
-        """../../etc/passwd のようなパスはストレージを呼び出す前に拒否する。"""
+        """Reject a path such as ../../etc/passwd before calling storage."""
         storage = _TrackingStorage()
         use_case = ResolveProtectedMediaUseCase(
             media_repo=_FakeMediaRepo(),
@@ -122,7 +122,7 @@ class ResolveProtectedMediaUseCaseTests(unittest.TestCase):
         self.assertFalse(storage.open_called)
 
     def test_absolute_path_raises_not_found_without_filesystem_access(self):
-        """/etc/passwd のような絶対パスはストレージを呼び出す前に拒否する。"""
+        """Reject an absolute path such as /etc/passwd before calling storage."""
         storage = _TrackingStorage()
         use_case = ResolveProtectedMediaUseCase(
             media_repo=_FakeMediaRepo(),
@@ -138,7 +138,7 @@ class ResolveProtectedMediaUseCaseTests(unittest.TestCase):
         self.assertFalse(storage.open_called)
 
     def test_embedded_dotdot_raises_not_found_without_filesystem_access(self):
-        """videos/../../../etc/passwd のようなパスも拒否する。"""
+        """Also reject a path such as videos/../../../etc/passwd."""
         storage = _TrackingStorage()
         use_case = ResolveProtectedMediaUseCase(
             media_repo=_FakeMediaRepo(),

--- a/backend/lambda_handler.py
+++ b/backend/lambda_handler.py
@@ -1,9 +1,9 @@
 """
-AWS Lambda ハンドラー: SQS トリガーによる Celery タスク実行
+AWS Lambda handler for executing Celery tasks triggered by SQS.
 
-kombu SQS transport はメッセージ本体全体を base64 エンコードして SQS body に格納する。
-Lambda SQS トリガーが渡す record["body"] は base64 文字列であり、
-デコードすると以下の JSON になる:
+The kombu SQS transport base64-encodes the entire message and stores it in the
+SQS body. The record["body"] value supplied by the Lambda SQS trigger is a
+base64 string that decodes to the following JSON:
 
 {
   "body": "<base64(json([args, kwargs, options]))>",
@@ -16,8 +16,9 @@ Lambda SQS トリガーが渡す record["body"] は base64 文字列であり、
   "content-encoding": "utf-8"
 }
 
-Celery ワーカープロセスを起動せず、タスク関数を直接 apply() で同期実行する。
-失敗したメッセージは batchItemFailures で返し SQS DLQ へ転送する。
+Rather than starting a Celery worker process, this handler invokes the task
+function directly and synchronously with apply(). Failed messages are returned
+in batchItemFailures so that SQS can route them to the DLQ.
 """
 import base64
 import json
@@ -30,21 +31,21 @@ import django
 
 django.setup()
 
-# すべてのタスクを Celery レジストリに登録
+# Register every task with the Celery registry.
 from app.celery_config import app as celery_app  # noqa: E402
-celery_app.loader.import_default_modules()  # 遅延 autodiscover を強制実行
-import app.entrypoints.tasks  # noqa: E402, F401 — タスク登録を確実にする
+celery_app.loader.import_default_modules()  # Force deferred autodiscovery.
+import app.entrypoints.tasks  # noqa: E402, F401 — Ensure task registration.
 
 logger = logging.getLogger(__name__)
 
 
 def handler(event: dict, context: object) -> dict:
     """
-    SQS バッチメッセージを処理するエントリポイント。
+    Process a batch of SQS messages.
 
     Returns:
-        batchItemFailures 形式のレスポンス。
-        失敗したメッセージのみ DLQ へ転送され、成功分は削除される。
+        A response in batchItemFailures format. Only failed messages are sent
+        to the DLQ; successful messages are deleted.
     """
     batch_item_failures = []
 
@@ -62,16 +63,17 @@ def handler(event: dict, context: object) -> dict:
 
 def _execute_task(raw_body: str) -> None:
     """
-    SQS メッセージ本体をデコードして Celery タスクを同期実行する。
+    Decode an SQS message body and execute the Celery task synchronously.
 
-    kombu SQS transport はメッセージ全体を base64 エンコードして送信する。
-    raw_body が JSON として直接パースできない場合、base64 デコードを試みる。
+    The kombu SQS transport base64-encodes the entire message before sending it.
+    If raw_body cannot be parsed directly as JSON, attempt base64 decoding.
 
     Raises:
-        KeyError: 未登録のタスク名
-        Exception: タスク実行中の例外 (batchItemFailures 経由で DLQ へ)
+        KeyError: The task name is not registered.
+        Exception: Task execution failed. The message is sent to the DLQ via
+            batchItemFailures.
     """
-    # kombu SQS transport は base64 エンコードする
+    # The kombu SQS transport uses base64 encoding.
     try:
         sqs_payload = json.loads(raw_body)
     except (json.JSONDecodeError, ValueError):
@@ -80,7 +82,7 @@ def _execute_task(raw_body: str) -> None:
     task_name: str = sqs_payload["headers"]["task"]
     task_id: str = sqs_payload["headers"].get("id", "unknown")
 
-    # base64 デコード → JSON パース → [args, kwargs, embed]
+    # Decode base64, parse JSON, and unpack [args, kwargs, embed].
     decoded = base64.b64decode(sqs_payload["body"]).decode("utf-8")
     args, kwargs, _ = json.loads(decoded)
 
@@ -90,7 +92,7 @@ def _execute_task(raw_body: str) -> None:
     )
 
     task = celery_app.tasks[task_name]
-    # apply() は同期実行。Lambda 内では Celery ワーカーループ不要。
-    # throw=True にすることで例外が呼び出し元に伝播し DLQ 転送が機能する。
+    # apply() runs synchronously, so Lambda does not need a Celery worker loop.
+    # throw=True propagates exceptions to the caller, enabling DLQ routing.
     result = task.apply(args=args, kwargs=kwargs, task_id=task_id, throw=True)
     result.get(propagate=True)

--- a/backend/videoq/settings.py
+++ b/backend/videoq/settings.py
@@ -19,10 +19,10 @@ from typing import ClassVar
 import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 
-# ── AWS Secrets Manager サポート ─────────────────────────────────────────────
-# Lambda 環境では DB_SECRET_ARN / APP_SECRET_ARN を環境変数で渡す。
-# settings モジュール読み込み時に 1 度だけ取得し、環境変数に展開する。
-# (Lambda コンテナは再利用されるため実質的にキャッシュされる)
+# ── AWS Secrets Manager support ──────────────────────────────────────────────
+# Pass DB_SECRET_ARN / APP_SECRET_ARN as environment variables in Lambda.
+# Fetch each secret once when the settings module loads and expose its values as
+# environment variables. Lambda container reuse effectively caches the result.
 
 def _load_aws_secret(secret_arn: str) -> dict:
     import boto3
@@ -36,10 +36,11 @@ _db_secret_arn = os.environ.get("DB_SECRET_ARN")
 if _db_secret_arn:
     _db = _load_aws_secret(_db_secret_arn)
     if "DATABASE_URL" in _db:
-        # Neon 形式: {"DATABASE_URL": "postgresql://...@neon.tech/...?sslmode=require"}
+        # Neon format: {"DATABASE_URL": "postgresql://...@neon.tech/...?sslmode=require"}
         os.environ.setdefault("DATABASE_URL", _db["DATABASE_URL"])
     else:
-        # RDS 管理シークレット形式 (後方互換): username / password / host / port / dbname
+        # RDS managed-secret format (backward compatible):
+        # username / password / host / port / dbname
         os.environ.setdefault(
             "DATABASE_URL",
             "postgresql://{username}:{password}@{host}:{port}/{dbname}".format(
@@ -57,7 +58,7 @@ if _app_secret_arn:
     _app_secrets = _load_aws_secret(_app_secret_arn)
     for _k, _v in _app_secrets.items():
         os.environ.setdefault(_k, str(_v))
-# ── END: AWS Secrets Manager サポート ────────────────────────────────────────
+# ── End AWS Secrets Manager support ──────────────────────────────────────────
 
 
 class DefaultSettings:
@@ -111,7 +112,7 @@ class DefaultSettings:
 
     # LLM configuration
     LLM_PROVIDER = "openai"  # openai or ollama
-    LLM_MODEL = "gpt-4o-mini"  # QA / PLOG study nudge / GradeReply すべて共通
+    LLM_MODEL = "gpt-4o-mini"  # Shared by QA, PLOG study nudges, and GradeReply.
 
     # Whisper configuration
     WHISPER_BACKEND = "openai"  # openai or whisper.cpp
@@ -252,8 +253,8 @@ DATABASE_URL = os.environ.get("DATABASE_URL", DefaultSettings.DATABASE_URL)
 DATABASES = {"default": dj_database_url.parse(DATABASE_URL)}
 
 # Cache configuration
-# USE_DATABASE_CACHE=true の場合は DatabaseCache (Aurora) を使用。
-# Redis が不要になるため Lambda 環境でのコスト削減に有効。
+# Use DatabaseCache (Aurora) when USE_DATABASE_CACHE=true.
+# This removes the Redis dependency and reduces costs in Lambda environments.
 _use_database_cache = (
     os.environ.get("USE_DATABASE_CACHE", "false").lower() == "true"
 )
@@ -450,8 +451,8 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = "America/Chicago"
 CELERY_TASK_TRACK_STARTED = True
-# Lambda 環境では CELERY_TASK_TIME_LIMIT を 840s (14 分) に設定する。
-# (Lambda 最大タイムアウト 900s より短くしないとタスクが強制終了される)
+# Set CELERY_TASK_TIME_LIMIT to 840 seconds (14 minutes) in Lambda environments.
+# Keep it below Lambda's 900-second maximum to avoid forced termination.
 CELERY_TASK_TIME_LIMIT = int(
     os.environ.get("CELERY_TASK_TIME_LIMIT", str(30 * 60))
 )
@@ -459,7 +460,7 @@ CELERY_TASK_SOFT_TIME_LIMIT = int(
     os.environ.get("CELERY_TASK_SOFT_TIME_LIMIT", str(25 * 60))
 )
 
-# SQS ブローカー固有設定 (CELERY_BROKER_URL=sqs:// のときのみ有効)
+# SQS-specific broker settings (active only when CELERY_BROKER_URL=sqs://).
 if CELERY_BROKER_URL.startswith("sqs://"):
     _sqs_queue_name = os.environ.get("SQS_QUEUE_NAME", "videoq-worker")
     CELERY_TASK_DEFAULT_QUEUE = _sqs_queue_name
@@ -470,12 +471,12 @@ if CELERY_BROKER_URL.startswith("sqs://"):
                 "url": os.environ.get("SQS_QUEUE_URL", ""),
             }
         },
-        # visibility_timeout は Lambda タイムアウト以上に設定すること
+        # Keep visibility_timeout greater than or equal to the Lambda timeout.
         "visibility_timeout": int(
             os.environ.get("CELERY_TASK_TIME_LIMIT", "840")
         ) + 60,
     }
-    # SQS 環境ではリザルトバックエンド不要 (タスクは DB の状態を直接更新)
+    # SQS needs no result backend because tasks update database state directly.
     CELERY_RESULT_BACKEND = None
 
 # Feature flags
@@ -484,8 +485,8 @@ ENABLE_SIGNUP = os.environ.get("ENABLE_SIGNUP", "true").lower() == "true"
 # Security profile: enforce secure defaults for production deployments.
 
 SECURE_COOKIES = IS_PRODUCTION
-# Lambda + API Gateway 環境では API Gateway が TLS 終端するため、
-# ヘルスチェック (LWA 内部 HTTP) がリダイレクトされないよう除外する。
+# API Gateway terminates TLS in Lambda deployments. Exempt the LWA internal
+# HTTP health check from redirects.
 SECURE_SSL_REDIRECT = IS_PRODUCTION
 SECURE_REDIRECT_EXEMPT = [r"^api/health/$"]
 SECURE_PROXY_SSL_HEADER = (

--- a/frontend/src/components/ui/chip-label.tsx
+++ b/frontend/src/components/ui/chip-label.tsx
@@ -16,7 +16,7 @@ type ChipLabelColor =
   | "magenta"
   | "purple"
 
-// 色に関するスタイルのみ定義（共通スタイルは chipLabelVariants で適用）
+// Define only color-specific styles; chipLabelVariants applies shared styles.
 const colorClasses: Record<
   NonNullable<VariantProps<typeof chipLabelVariants>["variant"]>,
   Record<ChipLabelColor, string>

--- a/frontend/src/components/ui/progress-indicator.tsx
+++ b/frontend/src/components/ui/progress-indicator.tsx
@@ -370,8 +370,8 @@ const format = (template: string, variables: Record<string, string | number>) =>
   )
 
 /**
- * スクリーンリーダーへの通知テキストを管理する hook。
- * 戻り値を `role="status"` のビジュアル上隠した要素に差し込んで使用する。
+ * Hook that manages announcement text for screen readers.
+ * Render the returned value in a visually hidden element with `role="status"`.
  */
 const useProgressIndicatorAnnouncer = (
   props: UseProgressIndicatorAnnouncerProps

--- a/infra/backend.hcl.example
+++ b/infra/backend.hcl.example
@@ -1,6 +1,6 @@
-# backend.hcl (このファイルをコピーして作成。backend.hcl は .gitignore 済み)
+# backend.hcl (copy this file to create it; backend.hcl is in .gitignore)
 #   cp backend.hcl.example backend.hcl
 #   terraform init -backend-config=backend.hcl
 #
-# bucket は infra/bootstrap が作成した state バケット名 (アカウント ID を含む)。
+# bucket is the state bucket created by infra/bootstrap (includes the account ID).
 bucket = "videoq-terraform-state-<AWS_ACCOUNT_ID>"

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,14 +1,15 @@
-# Terraform state backend (S3 + ネイティブロック)。
+# Terraform state backend (S3 with native locking).
 #
-# bucket は infra/bootstrap を一度 apply して作成する。ロックは S3 の
-# 条件付き書き込みを使う use_lockfile 方式 (Terraform 1.11+)。DynamoDB は不要。
+# Create the bucket by applying infra/bootstrap once. Locking uses use_lockfile
+# with S3 conditional writes (Terraform 1.11+), so DynamoDB is unnecessary.
 #
-# bucket 名にはアカウント ID が含まれるため、public リポジトリに含めないよう
-# backend ブロックには書かず、init 時に -backend-config で注入する。
-#   - ローカル: cp backend.hcl.example backend.hcl で bucket を記入し
+# The bucket name contains the account ID. To keep it out of the public
+# repository, omit it from the backend block and inject it at init time with
+# -backend-config.
+#   - Local: run cp backend.hcl.example backend.hcl, enter the bucket, and then
 #               terraform init -backend-config=backend.hcl
 #   - CI:       terraform init -backend-config="bucket=$TF_STATE_BUCKET"
-# (backend.hcl は .gitignore 済み。region は非機密なのでここに残す。)
+# backend.hcl is in .gitignore. The non-sensitive region remains here.
 
 terraform {
   backend "s3" {
@@ -16,6 +17,6 @@ terraform {
     region       = "ap-northeast-1"
     use_lockfile = true
     encrypt      = true
-    # bucket は -backend-config で注入
+    # Inject bucket with -backend-config.
   }
 }

--- a/infra/bootstrap/.gitignore
+++ b/infra/bootstrap/.gitignore
@@ -5,5 +5,5 @@
 crash.log
 crash.*.log
 
-# backend config (アカウント ID 入り bucket 名。example のみコミット)
+# Backend config (bucket includes the account ID; commit only the example).
 backend.hcl

--- a/infra/bootstrap/backend.hcl.example
+++ b/infra/bootstrap/backend.hcl.example
@@ -1,6 +1,6 @@
-# backend.hcl (このファイルをコピーして作成。backend.hcl は .gitignore 済み)
+# backend.hcl (copy this file to create it; backend.hcl is in .gitignore)
 #   cp backend.hcl.example backend.hcl
 #   terraform init -backend-config=backend.hcl
 #
-# bootstrap が作成する state バケット名 (アカウント ID を含む)。本体構成と同じ値。
+# State bucket created by bootstrap (includes the account ID); use the same value in the main configuration.
 bucket = "videoq-terraform-state-<AWS_ACCOUNT_ID>"

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -1,19 +1,20 @@
 # Terraform state backend bootstrap.
 #
-# state 保存先の S3 バケットそのものを作る構成。bootstrap 自身の state は、作った
-# バケットへ置く (自己参照バックエンド)。これで state は S3 上で永続・共有され、
-# public リポジトリに tfstate を置かずに済む。ロックは S3 ネイティブ (use_lockfile)
-# を使うため DynamoDB は不要。bucket 名はアカウント ID を含むため backend には
-# 書かず、init 時に -backend-config で注入する (cp backend.hcl.example backend.hcl)。
+# This configuration creates the S3 bucket that stores state. Bootstrap's own
+# state is placed in that bucket through a self-referential backend. This keeps
+# state persistent and shared in S3 without committing tfstate to the public
+# repository. Native S3 locking (use_lockfile) removes the need for DynamoDB.
+# Because the bucket name includes the account ID, omit it from the backend and
+# inject it at init time with -backend-config (copy backend.hcl.example to backend.hcl).
 #
-# バケット作成済み・backend 有効なので、通常は:
+# Once the bucket exists and the backend is enabled, normally run:
 #   terraform init -backend-config=backend.hcl && terraform plan/apply
 #
-# 【新規アカウントで一から作る場合のみ】バケットがまだ無いので:
-#   1. 下の backend "s3" ブロックを一時的にコメントアウトする
-#   2. terraform init && terraform apply            # ローカル state でバケット作成
-#   3. backend "s3" ブロックのコメントを戻す + backend.hcl に bucket 名を記入
-#   4. terraform init -migrate-state -backend-config=backend.hcl  # state をバケットへ移動
+# Only when bootstrapping a new account from scratch, before the bucket exists:
+#   1. Temporarily comment out the backend "s3" block below.
+#   2. Run terraform init && terraform apply to create the bucket with local state.
+#   3. Restore the backend "s3" block and enter the bucket name in backend.hcl.
+#   4. Run terraform init -migrate-state -backend-config=backend.hcl to move the state.
 
 terraform {
   required_version = ">= 1.11"
@@ -29,7 +30,7 @@ terraform {
     region       = "ap-northeast-1"
     use_lockfile = true
     encrypt      = true
-    # bucket は -backend-config で注入
+    # Inject bucket with -backend-config.
   }
 }
 
@@ -40,15 +41,15 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 locals {
-  # S3 バケット名はグローバル一意が必要なのでアカウント ID を付与。
+  # Add the account ID because S3 bucket names must be globally unique.
   state_bucket_name = "videoq-terraform-state-${data.aws_caller_identity.current.account_id}"
 }
 
-# ── state 保存バケット ────────────────────────────────────────────────────────
+# ── State storage bucket ──────────────────────────────────────────────────────
 resource "aws_s3_bucket" "state" {
   bucket = local.state_bucket_name
 
-  # 誤削除防止。state が入るバケットなので破棄されると全リソースの追跡を失う。
+  # Prevent accidental deletion; destroying this bucket loses resource tracking.
   lifecycle {
     prevent_destroy = true
   }

--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -4,8 +4,8 @@
 # single domain so cookies are first-party.
 
 # ── AWS managed policies ─────────────────────────────────────────────────────
-# 名前でマネージドポリシーを解決する (List で名前→ID、Get で詳細取得の 2 段階)。
-# CI ユーザーには以下 4 つの読み取り権限が必要:
+# Resolve managed policies by name in two stages: List maps names to IDs, then
+# Get retrieves the details. The CI user needs these four read permissions:
 #   cloudfront:ListCachePolicies / GetCachePolicy
 #   cloudfront:ListOriginRequestPolicies / GetOriginRequestPolicy
 data "aws_cloudfront_cache_policy" "caching_optimized" {

--- a/infra/openai.tf
+++ b/infra/openai.tf
@@ -1,18 +1,21 @@
-# OpenAI プロジェクトのガバナンスを Terraform で管理する (openai/openai プロバイダ)。
-# 埋め込み / LLM / 文字起こしに使う OpenAI 組織プロジェクトの設定を IaC 化する。
+# Manage OpenAI project governance with Terraform (openai/openai provider).
+# Define the OpenAI organization project used for embeddings, LLMs, and
+# transcription as infrastructure as code.
 #
-# 注意: このプロバイダは API キーを管理できない。ランタイムの OPENAI_API_KEY は
-# 従来どおりダッシュボードで手動発行し、app シークレット (secrets.tf) に手動保存する。
+# Note: This provider cannot manage API keys. Continue issuing the runtime
+# OPENAI_API_KEY manually from the dashboard and saving it in the app secret
+# (secrets.tf).
 #
-# var.manage_openai_project = false (デフォルト) の間は全リソース count=0 なので
-# OPENAI_ADMIN_KEY 無しで plan/apply できる。true にして Admin キーを export すると有効化。
+# While var.manage_openai_project is false (the default), every resource has
+# count=0, so plan/apply works without OPENAI_ADMIN_KEY. Set the variable to true
+# and export the admin key to enable management.
 
 resource "openai_project" "videoq" {
   count = var.manage_openai_project ? 1 : 0
   name  = "${local.name_prefix}-${var.env_name}"
 }
 
-# videoq が実際に呼ぶモデルだけに制限する (コストガードレール)。
+# Limit access to models that VideoQ actually calls as a cost guardrail.
 resource "openai_project_model_permissions" "videoq" {
   count      = var.manage_openai_project ? 1 : 0
   project_id = openai_project.videoq[0].project_id
@@ -20,9 +23,10 @@ resource "openai_project_model_permissions" "videoq" {
   model_ids  = var.openai_allowed_models
 }
 
-# 月次スペンドがしきい値を超えたらメール通知する (予算ガードレール)。
-# 注意: threshold_amount は最小通貨単位 (USD=セント) で渡す。実測でも 50→$0.50 を確認。
-#       currency = "USD" 固定なので USD=100セント (定義) に従い var(USD)*100 を渡す。
+# Send an email when monthly spend exceeds the threshold as a budget guardrail.
+# Note: threshold_amount uses the smallest currency unit (cents for USD); testing
+# confirmed that 50 means $0.50. Because currency is fixed to USD, pass
+# var (in dollars) * 100 according to the definition of 100 cents per dollar.
 resource "openai_project_spend_alert" "videoq" {
   count                           = var.manage_openai_project && var.openai_spend_alert_email != "" ? 1 : 0
   project_id                      = openai_project.videoq[0].project_id

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -2,6 +2,6 @@ provider "aws" {
   region = var.aws_region
 }
 
-# OpenAI Administration API プロバイダ。OPENAI_ADMIN_KEY を環境変数から読む。
-# var.manage_openai_project = false のときは全リソース count=0 なので Admin キー不要。
+# OpenAI Administration API provider. Reads OPENAI_ADMIN_KEY from the environment.
+# No admin key is needed when var.manage_openai_project=false because all resources have count=0.
 provider "openai" {}

--- a/infra/sqs.tf
+++ b/infra/sqs.tf
@@ -1,15 +1,15 @@
 # ── Dead Letter Queue ─────────────────────────────────────────────────
-# 最大受信数を超えたメッセージ (失敗タスク) が転送される
+# Messages that exceed the maximum receive count (failed tasks) are forwarded here.
 resource "aws_sqs_queue" "dlq" {
   name                      = local.names.worker_dlq
   message_retention_seconds = 1209600 # 14 days
   sqs_managed_sse_enabled   = true
 }
 
-# ── メインキュー (Celery ブローカー) ──────────────────────────────────
-# visibility_timeout は Worker Lambda のタイムアウト以上に設定すること。
-# Lambda が処理中にメッセージが再度見えてしまうのを防ぐため。
-# receive_wait_time=20s: ロングポーリングで空のポーリングを削減。
+# ── Main queue (Celery broker) ─────────────────────────────────────────
+# Keep visibility_timeout greater than or equal to the Worker Lambda timeout so
+# messages do not become visible again while Lambda is processing them.
+# receive_wait_time=20s enables long polling to reduce empty polls.
 resource "aws_sqs_queue" "main" {
   name                       = local.names.worker
   visibility_timeout_seconds = var.sqs_visibility_timeout_seconds

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,74 +1,76 @@
-# VideoQ Terraform 変数サンプル
+# Sample VideoQ Terraform variables
 #
-# 使い方:
+# Usage:
 #   cp terraform.tfvars.example terraform.tfvars
-#   # 値を環境に合わせて編集してから `terraform plan` / `terraform apply` を実行
+#   # Adjust values for the environment, then run `terraform plan` / `terraform apply`.
 #
-# terraform.tfvars は .gitignore で除外されている (このサンプルのみコミットされる)。
-# 値は TF_VAR_<name> 環境変数でも指定可能 (CI ではこちらを使用)。
+# terraform.tfvars is excluded by .gitignore; only this example is committed.
+# Values can also be supplied through TF_VAR_<name> environment variables, as in CI.
 #
-# 注意: シークレット (DB 接続文字列・SECRET_KEY・R2 認証情報など) は
-#       Terraform では管理しない。apply 後に AWS CLI で Secrets Manager へ登録する
-#       (DEPLOY.md の「シークレットを登録」を参照)。
+# Note: Do not manage secrets such as the DB connection string, SECRET_KEY, or R2
+#       credentials with Terraform. After applying, register them in Secrets
+#       Manager with the AWS CLI (see "Register secrets" in DEPLOY.md).
 
-# --- 基本設定 -------------------------------------------------------------
+# --- Basic settings ----------------------------------------------------------
 
-# リソースをデプロイする AWS リージョン
+# AWS region in which to deploy resources.
 aws_region = "ap-northeast-1"
 
-# 環境名 (全リソースの命名に使用: videoq-*-<env_name>)
+# Environment name used to name every resource: videoq-*-<env_name>.
 env_name = "prod"
 
-# Lambda が参照する ECR コンテナイメージのタグ
-# (通常はイメージを push した後に latest のまま運用)
+# ECR container image tag referenced by Lambda.
+# It normally remains "latest" after the image is pushed.
 image_tag = "latest"
 
-# --- ドメイン / CDN 設定 --------------------------------------------------
-# custom_domain と certificate_arn の両方を設定した場合のみ CloudFront が有効化される。
-# 空文字のままだとローカル開発用の CORS 設定 (localhost) になる。
+# --- Domain / CDN settings ---------------------------------------------------
+# CloudFront is enabled only when both custom_domain and certificate_arn are set.
+# Leaving them empty retains the localhost CORS settings used for local development.
 
-# Cloudflare Pages ドメイン (CORS 許可リストに追加。未使用なら "")
+# Cloudflare Pages domain added to the CORS allowlist. Use "" when unused.
 pages_domain = "videoq.pages.dev"
 
-# CloudFront カスタムドメイン (例: videoq.jp。未使用なら "")
+# CloudFront custom domain, for example videoq.jp. Use "" when unused.
 custom_domain = "videoq.jp"
 
-# ACM 証明書 ARN (CloudFront 用のため us-east-1 で作成必須。未使用なら "")
+# ACM certificate ARN. It must be created in us-east-1 for CloudFront. Use "" when unused.
 certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/00000000-0000-0000-0000-000000000000"
 
-# --- Lambda チューニング --------------------------------------------------
+# --- Lambda tuning -----------------------------------------------------------
 
-# API Lambda のメモリサイズ (MB)
+# API Lambda memory size in MB.
 api_lambda_memory_mb = 1024
 
-# API Lambda のタイムアウト (秒)
+# API Lambda timeout in seconds.
 api_lambda_timeout_seconds = 30
 
-# Worker Lambda のメモリサイズ (MB) (ffmpeg + AI 推論でメモリを多く使う)
+# Worker Lambda memory size in MB; ffmpeg and AI inference are memory intensive.
 worker_lambda_memory_mb = 5120
 
-# Worker Lambda のタイムアウト (秒) (Lambda 最大 15 分 = 900)
+# Worker Lambda timeout in seconds. Lambda's 15-minute maximum is 900 seconds.
 worker_lambda_timeout_seconds = 900
 
-# --- SQS 設定 -------------------------------------------------------------
+# --- SQS settings ------------------------------------------------------------
 
-# SQS の visibility timeout (秒)
-# worker_lambda_timeout_seconds 以上に設定すること (推奨: timeout + 60)
+# SQS visibility timeout in seconds.
+# Keep this at or above worker_lambda_timeout_seconds; timeout + 60 is recommended.
 sqs_visibility_timeout_seconds = 960
 
-# メッセージ最大受信回数 (超過で DLQ へ送信)
+# Maximum message receive count before routing to the DLQ.
 sqs_max_receive_count = 3
 
-# --- OpenAI プロジェクト管理 ----------------------------------------------
-# OpenAI 組織プロジェクトのガバナンス (許可モデル / スペンドアラート) を Terraform で管理する。
-# デフォルトで有効 (manage_openai_project = true)。apply の前に Admin API キーを
-# 環境変数 OPENAI_ADMIN_KEY (必要なら OPENAI_ORG_ID) に export しておくこと。
-# CI では GitHub Secret OPENAI_ADMIN_KEY / OPENAI_SPEND_ALERT_EMAIL から渡す (DEPLOY.md 参照)。
-# 注意: このプロバイダはランタイムの OPENAI_API_KEY を管理しない。実行用キーは
-#       従来どおりダッシュボードで手動発行し、Secrets Manager の app シークレットへ手動保存する。
+# --- OpenAI project management -----------------------------------------------
+# Manage OpenAI organization project governance, including allowed models and
+# spend alerts, with Terraform. Management is enabled by default through
+# manage_openai_project=true. Before applying, export the admin API key as
+# OPENAI_ADMIN_KEY and, if needed, OPENAI_ORG_ID. CI reads OPENAI_ADMIN_KEY and
+# OPENAI_SPEND_ALERT_EMAIL from GitHub Secrets; see DEPLOY.md.
+# Note: The provider does not manage the runtime OPENAI_API_KEY. Continue issuing
+#       that key manually from the dashboard and saving it in the Secrets Manager
+#       app secret.
 #
-# ローカル apply 時に上書きする場合の例:
+# Example overrides for a local apply:
 # openai_spend_alert_email   = "ops@example.com"
 # openai_spend_threshold_usd = 50
 # openai_allowed_models = ["text-embedding-3-small", "gpt-4o-mini", "whisper-1"]
-# manage_openai_project = false  # 一時的に無効化したいときのみ
+# manage_openai_project = false  # Use only to disable management temporarily.

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -9,7 +9,7 @@
 #
 # Note: Do not manage secrets such as the DB connection string, SECRET_KEY, or R2
 #       credentials with Terraform. After applying, register them in Secrets
-#       Manager with the AWS CLI (see "Register secrets" in DEPLOY.md).
+#       Manager with the AWS CLI (see Step 4 in DEPLOY.md).
 
 # --- Basic settings ----------------------------------------------------------
 

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  # 1.11+: S3 backend の use_lockfile (ネイティブロック) を使用。
+  # 1.11+: Use native locking through use_lockfile in the S3 backend.
   required_version = ">= 1.11"
 
   required_providers {


### PR DESCRIPTION
## 概要

コードベース全体のコメント・ドキュメントを日本語から英語へ統一する軽微な整理です。挙動を変える変更はありません。

## 変更内容

- backend / frontend / infra のソースコメント、テストコメント、Terraform の説明文などを英語に統一
- コメント・ドキュメント文字列のみの変更（ロジック変更なし）

## テスト

- コメント／ドキュメント中心の変更のため挙動への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
