### PR TITLE
ci(cd): auto-deploy Cloudflare Workers API

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,8 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      worker: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' || steps.filter.outputs.worker == 'true' }}
-      migrate: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' || steps.filter.outputs.migrate == 'true' }}
+      api: ${{ steps.resolve.outputs.api }}
+      worker: ${{ steps.resolve.outputs.worker }}
+      migrate: ${{ steps.resolve.outputs.migrate }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,10 +32,13 @@ jobs:
           fetch-depth: 2
       - uses: dorny/paths-filter@v3
         id: filter
-        if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_run'
+        if: github.event_name != 'workflow_dispatch'
         with:
           base: HEAD~1
           filters: |
+            api:
+              - 'apps/api/**'
+              - '.github/workflows/cd.yml'
             worker:
               - 'apps/worker/**'
               - '.github/workflows/cd.yml'
@@ -45,10 +49,20 @@ jobs:
               - 'apps/api/scripts/db-migrate.sh'
               - 'apps/api/scripts/stamp-baseline.mjs'
               - '.github/workflows/cd.yml'
+      - name: Resolve deploy flags
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "api=true" >> "$GITHUB_OUTPUT"
+            echo "worker=true" >> "$GITHUB_OUTPUT"
+            echo "migrate=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "api=${{ steps.filter.outputs.api }}" >> "$GITHUB_OUTPUT"
+            echo "worker=${{ steps.filter.outputs.worker }}" >> "$GITHUB_OUTPUT"
+            echo "migrate=${{ steps.filter.outputs.migrate }}" >> "$GITHUB_OUTPUT"
+          fi
 
-  # Web API は Cloudflare Workers（apps/api）を別パイプラインでデプロイする。
   # DB スキーマは Drizzle（stamp + migrate）。manage.py migrate は廃止。
-
   db-migrate:
     name: Drizzle DB Migrate
     runs-on: ubuntu-latest
@@ -75,8 +89,36 @@ jobs:
           npm ci
           npm run db:migrate
 
+  api-deploy:
+    name: Deploy API (Cloudflare Workers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [changes, db-migrate]
+    if: |
+      always() &&
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.api == 'true' &&
+      (needs.db-migrate.result == 'success' || needs.db-migrate.result == 'skipped')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: apps/api/package-lock.json
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/api
+          packageManager: npm
+          command: deploy --minify --env production
+
   worker-deploy:
-    name: Deploy Worker (django-free)
+    name: Deploy Worker Lambda
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.worker == 'true'

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -56,6 +56,19 @@ npx wrangler secret put AWS_SECRET_ACCESS_KEY
 
 ## 3. API deploy
 
+`main` への CI 成功後、CD が `apps/api` の変更を検知すると
+`wrangler deploy --minify --env production` を実行します
+（[`.github/workflows/cd.yml`](../.github/workflows/cd.yml)）。
+
+必要な GitHub Actions secrets:
+
+| Secret | 用途 |
+|---|---|
+| `CLOUDFLARE_API_TOKEN` | Workers デプロイ用 API トークン（Edit Cloudflare Workers 相当） |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID |
+
+手動デプロイ:
+
 ```bash
 cd apps/api
 npm ci
@@ -67,9 +80,9 @@ npm run deploy
 確認:
 
 ```bash
-curl https://<api-host>/health
-curl https://<api-host>/ready
-curl https://<api-host>/api/openapi.json
+curl https://videoq.jp/health
+curl https://videoq.jp/ready
+curl https://videoq.jp/api/openapi.json
 ```
 
 ## 4. Worker infrastructure


### PR DESCRIPTION
## Summary
- Add `Deploy API (Cloudflare Workers)` job to CD (`wrangler deploy --minify --env production`)
- Run API deploy after Drizzle migrate succeeds or is skipped
- Fix path filters so `workflow_run` no longer always deploys everything
- Document required `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets

## Test plan
- [ ] Set GitHub secret `CLOUDFLARE_API_TOKEN` (Edit Cloudflare Workers template; include Workers Routes)
- [ ] Confirm `CLOUDFLARE_ACCOUNT_ID` is already set
- [ ] Merge to `main`, or run CD via `workflow_dispatch`
- [ ] Verify CD job deploys and `https://videoq.jp/ready` stays healthy


Made with [Cursor](https://cursor.com)