### PR TITLE
fix(cd): workflow_run で path filter が落ちる問題を修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,12 +29,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          fetch-depth: 2
+          fetch-depth: 0
+      # workflow_run: omit base so paths-filter uses the GitHub API file list.
       - uses: dorny/paths-filter@v3
         id: filter
         if: github.event_name != 'workflow_dispatch'
         with:
-          base: HEAD~1
           filters: |
             api:
               - 'apps/api/**'


### PR DESCRIPTION
## Summary
- CD の `Detect Changes` が `workflow_run` 時に失敗していたのを修正
- 原因: `dorny/paths-filter` に `base: HEAD~1` を渡しており、GitHub Actions がこれを fetch refspec として解釈して `fatal: invalid refspec 'HEAD~1'` になっていた（例: [run 30802769745](https://github.com/yukiharada1228/videoq/actions/runs/30802769745)）
- 対応: `base` を外し、`workflow_run` では GitHub API の変更ファイル一覧で判定する

## Notes
- この PR は path filter 修正のみ。パスワード再設定（`0002_native_auth.sql`）とは無関係
- Drizzle マイグレーションは `__drizzle_migrations` に記録済みなら再実行されない（`password_reset_required = true` の UPDATE も一度きり）

## Test plan
- [ ] マージ後、CD の `Detect Changes` が success になること
- [ ] `apps/api` 変更時のみ API deploy、`apps/worker` 変更時のみ Lambda deploy、migrate 対象変更時のみ migrate が走ること
- [ ] frontend のみの変更では deploy / migrate がスキップされること