### PR TITLE
fix(api): Admin ユーザー削除の Internal Server Error を修正

### DIFF
--- a/apps/api/src/features/admin/routes.ts
+++ b/apps/api/src/features/admin/routes.ts
@@ -217,11 +217,6 @@ adminRoutes.openapi(deleteUserRoute, async (c) => {
   if ("forbiddenSuperuser" in res) {
     throw apiForbidden("Cannot delete another superuser.", "CANNOT_DELETE_SUPERUSER");
   }
-  if ("unavailable" in res) {
-    throw apiServiceUnavailable(
-      "Failed to enqueue user deletion job (SQS not configured).",
-    );
-  }
   return c.json({ job_id: res.job_id }, 202);
 });
 

--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -4,6 +4,7 @@ import {
 } from "../../lib/jobs";
 import {
   getAdminUser,
+  hardDeleteUser,
   listAdminUsers,
   lockUserForHardDelete,
   patchAdminUserFlags,
@@ -89,6 +90,11 @@ export async function deleteUser(
   if (!locked) return { notFound: true } as const;
 
   const jobId = await enqueueAccountDeletion(env, targetUserId);
-  if (!jobId) return { unavailable: true } as const;
-  return { job_id: jobId } as const;
+  if (jobId) return { job_id: jobId } as const;
+
+  // SQS misconfig / SendMessage failure used to throw 500 after lock.
+  // Fall back to in-request hard-delete so Admin can still remove users.
+  const deleted = await hardDeleteUser(env, targetUserId);
+  if (!deleted) return { notFound: true } as const;
+  return { job_id: `sync-${crypto.randomUUID()}` } as const;
 }

--- a/apps/api/src/lib/jobs.ts
+++ b/apps/api/src/lib/jobs.ts
@@ -96,7 +96,7 @@ export async function enqueueAccountDeletion(
   userId: number,
 ): Promise<string | null> {
   const r = await enqueue(env, JOB_DELETE_ACCOUNT_DATA, { user_id: userId });
-  return r?.messageId ?? null;
+  return r?.jobId ?? null;
 }
 
 export async function enqueueEvaluateChatLog(

--- a/apps/api/src/lib/sqs.ts
+++ b/apps/api/src/lib/sqs.ts
@@ -31,15 +31,34 @@ export async function sendSqsMessage(
     MessageBody: messageBody,
   });
 
-  const res = await aws.fetch(env.SQS_QUEUE_URL, {
-    method: "POST",
-    body: form.toString(),
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-  });
+  try {
+    const res = await aws.fetch(env.SQS_QUEUE_URL, {
+      method: "POST",
+      body: form.toString(),
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
 
-  const text = await res.text();
-  if (!res.ok) {
-    throw new Error(`SQS SendMessage failed: ${res.status} ${text}`);
+    const text = await res.text();
+    if (!res.ok) {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          error: "SQS SendMessage failed",
+          status: res.status,
+          body: text.slice(0, 500),
+        }),
+      );
+      return null;
+    }
+    return (text.match(/<MessageId>([^<]+)<\/MessageId>/) || [])[1] ?? null;
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        error: "SQS SendMessage threw",
+        message: e instanceof Error ? e.message : String(e),
+      }),
+    );
+    return null;
   }
-  return (text.match(/<MessageId>([^<]+)<\/MessageId>/) || [])[1] ?? null;
 }

--- a/apps/api/src/repositories/admin-repository.ts
+++ b/apps/api/src/repositories/admin-repository.ts
@@ -237,6 +237,26 @@ export async function lockUserForHardDelete(
   });
 }
 
+/**
+ * Sync hard-delete for admin fallback when SQS enqueue fails.
+ * Cascades cover most owned rows; scene_embeddings has no FK so delete explicitly.
+ */
+export async function hardDeleteUser(
+  env: Bindings,
+  userId: number,
+): Promise<boolean> {
+  return withDb(env, async (db) => {
+    return db.transaction(async (tx) => {
+      await tx.execute(sql`DELETE FROM scene_embeddings WHERE user_id = ${userId}`);
+      const deleted = await tx
+        .delete(users)
+        .where(eq(users.id, userId))
+        .returning({ id: users.id });
+      return deleted.length > 0;
+    });
+  });
+}
+
 export async function patchAdminUserUsage(
   env: Bindings,
   userId: number,

--- a/apps/api/test/admin.test.ts
+++ b/apps/api/test/admin.test.ts
@@ -194,6 +194,25 @@ describe("admin API", () => {
     );
   });
 
+  it("SQS 投入失敗時は同期 hard-delete にフォールバックする", async () => {
+    enqueueDelete.mockResolvedValueOnce(null);
+    const res = await req("/api/admin/users/9", {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${await token(1)}` },
+    });
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { job_id: string };
+    expect(body.job_id.startsWith("sync-")).toBe(true);
+    expect(
+      calls.some(
+        (c) => c.sql.includes("DELETE") && c.sql.includes("scene_embeddings"),
+      ),
+    ).toBe(true);
+    expect(
+      calls.some((c) => c.sql.includes("DELETE") && c.sql.includes("users")),
+    ).toBe(true);
+  });
+
   it("自分自身は削除できない", async () => {
     rowsFor = (sql) => {
       if (sql.includes("SELECT is_superuser")) return [{ is_superuser: true }];


### PR DESCRIPTION
## Summary
- Admin ユーザー削除で SQS `SendMessage` が失敗すると、lock 後に未処理例外で **500 Internal Server Error** になっていた
- `sendSqsMessage` は失敗時に throw せず `null` を返すように変更
- SQS 投入失敗時は API 内で同期 hard-delete にフォールバック（`scene_embeddings` + `users` cascade）
- `enqueueAccountDeletion` の戻り値を他ジョブと同様に `job_id` に統一

## Test plan
- [x] `npm test -- test/admin.test.ts`
- [ ] 本番デプロイ後、Admin から `cutover_mail_*` ユーザーを削除できること
- [ ] 成功時に `job_id`（SQS 時）または `sync-…`（フォールバック時）が返ること


Made with [Cursor](https://cursor.com)