### PR TITLE
fix(api): 本番 R2 endpoint 設定不足で /api/videos が 500 になる問題を修正

### DIFF
--- a/apps/api/src/integrations/media.ts
+++ b/apps/api/src/integrations/media.ts
@@ -109,7 +109,18 @@ export async function resolveFileUrl(
   if (!isS3Storage(env)) {
     return `/api/media/${fileKey.replace(/^\/+/, "")}`;
   }
-  return presignR2Get(env, fileKey);
+  try {
+    return await presignR2Get(env, fileKey);
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        error: "resolveFileUrl failed",
+        message: e instanceof Error ? e.message : String(e),
+      }),
+    );
+    return null;
+  }
 }
 
 /** R2 / MinIO の `media/` 配下に置くオブジェクトキー。 */

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -93,7 +93,10 @@
         "PGVECTOR_COLLECTION_NAME": "scene_embeddings",
         "OAUTH_ISSUER_URL": "https://videoq.jp",
         "OIDC_ENABLED": "false",
-        "OIDC_LOGOUT_ENABLED": "false"
+        "OIDC_LOGOUT_ENABLED": "false",
+        "R2_BUCKET_NAME": "videoq-media-prod",
+        "R2_S3_ENDPOINT": "https://12daec56fdba43f677f2766ee26a5a39.r2.cloudflarestorage.com",
+        "R2_S3_REGION": "auto"
       },
       "routes": [
         { "pattern": "videoq.jp/api/*", "zone_name": "videoq.jp" },

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -45,12 +45,11 @@ npx wrangler secret put AWS_SECRET_ACCESS_KEY
 メール操作とOAuth HTML formのaction tokenはDBにSHA-256だけを保存するランダム値であり、
 追加の共有secretは不要です。
 
-非機密設定:
+非機密設定（`wrangler.jsonc` `env.production.vars`）:
 
 - `ENVIRONMENT=production`
-- `FRONTEND_URL=https://<public-host>`
-- `CORS_ALLOW_ORIGIN=https://<public-host>`
-- `OAUTH_ISSUER_URL=https://<public-host>`
+- `FRONTEND_URL` / `CORS_ALLOW_ORIGIN` / `OAUTH_ISSUER_URL`
+- `R2_BUCKET_NAME` / `R2_S3_ENDPOINT` / `R2_S3_REGION`（`USE_S3_STORAGE=true` 時必須。未設定だと `/api/videos` が 500）
 - embedding / LLM model
 - Hyperdrive、R2、KV、Durable Object binding
 


### PR DESCRIPTION
## Summary
- 本番 Worker に `R2_S3_ENDPOINT` / `R2_BUCKET_NAME` / `R2_S3_REGION` がなく、`GET /api/videos` が署名 URL 生成時に `S3/R2 credentials are not configured` で **500** になっていた
- `wrangler.jsonc` の `env.production.vars` に非機密の R2 設定を追加
- `resolveFileUrl` は設定ミス時に一覧全体を落とさず `null` を返すように防御
- `DEPLOY.md` に必須 vars を明記

## Test plan
- [x] 本番へ手動デプロイ済み（動画一覧が開けること）
- [ ] `/ja/videos` が 500 にならないこと
- [ ] 動画の `file` URL が R2 署名 URL で返ること（キーが設定されている場合）


Made with [Cursor](https://cursor.com)