### PR TITLE
fix(api): 動画削除が消えない問題（Hyperdrive cache）

### DIFF
--- a/apps/api/src/features/videos/service.ts
+++ b/apps/api/src/features/videos/service.ts
@@ -272,7 +272,8 @@ export async function deleteUserVideo(
   }
   const fileSize = resolveStorageBytesForRelease(info.fileKey, r2Size);
 
-  await deleteVideoCascade(env, videoId, userId);
+  const deleted = await deleteVideoCascade(env, videoId, userId);
+  if (!deleted) return { notFound: true } as const;
 
   await deleteVideoVectors(env, videoId).catch((error) => {
     reportBestEffortFailure("delete_video_vectors", error);

--- a/apps/api/src/repositories/video-repository.ts
+++ b/apps/api/src/repositories/video-repository.ts
@@ -453,9 +453,9 @@ export async function deleteVideoCascade(
   env: Bindings,
   videoId: number,
   userId: number,
-): Promise<void> {
+): Promise<boolean> {
   return withDb(env, async (db) => {
-    await db.transaction(async (tx) => {
+    return db.transaction(async (tx) => {
       await tx.execute(sql`SELECT 1 FROM videos WHERE id = ${videoId} FOR UPDATE`);
 
       await tx.execute(sql`
@@ -473,10 +473,14 @@ export async function deleteVideoCascade(
       await tx.delete(plogBuildJobs).where(eq(plogBuildJobs.videoId, videoId));
       await tx.delete(videoTags).where(eq(videoTags.videoId, videoId));
       await tx.delete(videoGroupMembers).where(eq(videoGroupMembers.videoId, videoId));
+      // No FK; remove vector rows so orphan embeddings do not linger.
+      await tx.execute(sql`DELETE FROM scene_embeddings WHERE video_id = ${videoId}`);
 
-      await tx
+      const deleted = await tx
         .delete(videos)
-        .where(and(eq(videos.id, videoId), eq(videos.userId, userId)));
+        .where(and(eq(videos.id, videoId), eq(videos.userId, userId)))
+        .returning({ id: videos.id });
+      return deleted.length > 0;
     });
   });
 }

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -12,7 +12,7 @@
 ## 1. DB と R2
 
 1. Neon project と pooler connection を作成
-2. Cloudflare Hyperdrive を Neon に接続
+2. Cloudflare Hyperdrive を Neon に接続（**query caching は無効**にする。有効だと DELETE 後も古い SELECT が返り、動画削除などが消えたように見えない）
 3. R2 bucket と S3 API token を作成
 4. `apps/api/wrangler.jsonc` の binding ID / bucket を本番値に設定
 


### PR DESCRIPTION
## Summary
- 本番ログでは `DELETE /api/videos/102` が **204** なのに、直後の `GET` が **200** のまま（動画が残って見える）
- 原因: Hyperdrive query caching が有効で、書き込み後も古い SELECT を返していた（キャッシュ invalidate なし）
- 本番 Hyperdrive `videoq-neon-prod` の **caching を無効化済み**
- あわせて `deleteVideoCascade` が削除件数を検証し、`scene_embeddings` も明示削除するように変更
- `DEPLOY.md` に caching 無効の運用注意を追加

## Test plan
- [ ] `/ja/videos/102` で削除 → 一覧/詳細から消えること
- [ ] 削除直後にハードリロードしても復活しないこと
- [ ] 存在しない ID の削除は 404 になること


Made with [Cursor](https://cursor.com)