### PR TITLE
fix(infra/worker): R2 認証を R2_* secret キーに分離

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -50,8 +50,8 @@ worker は modern schema と native job type のみを使用します。
 | `EMBEDDING_PROVIDER` | `openai` または `ollama` |
 | `EMBEDDING_MODEL` / `EMBEDDING_VECTOR_SIZE` | `scene_embeddings` と一致するモデル・次元 |
 | `USE_S3_STORAGE` | S3 互換 object storage の利用 |
-| `AWS_STORAGE_BUCKET_NAME` / `AWS_S3_ENDPOINT_URL` | R2 / MinIO |
-| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 用クレデンシャル（Lambda では必須。実行ロールの `AWS_ACCESS_KEY_ID` を上書きしない） |
+| `R2_BUCKET_NAME` / `R2_S3_ENDPOINT` / `R2_S3_REGION` | R2 bucket / endpoint / region |
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 S3 API token（Lambda の `APP_SECRET_ARN` ではこの名前を使う。`AWS_ACCESS_KEY_ID` は実行ロール予約） |
 | `USER_SECRET_ENCRYPTION_KEY` | AES-256-GCM のユーザー秘密復号鍵 |
 | `ENABLE_HEAVY_PIPELINE` | 文字起こし等の重量処理を有効化 |
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -51,6 +51,7 @@ worker は modern schema と native job type のみを使用します。
 | `EMBEDDING_MODEL` / `EMBEDDING_VECTOR_SIZE` | `scene_embeddings` と一致するモデル・次元 |
 | `USE_S3_STORAGE` | S3 互換 object storage の利用 |
 | `AWS_STORAGE_BUCKET_NAME` / `AWS_S3_ENDPOINT_URL` | R2 / MinIO |
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 用クレデンシャル（Lambda では必須。実行ロールの `AWS_ACCESS_KEY_ID` を上書きしない） |
 | `USER_SECRET_ENCRYPTION_KEY` | AES-256-GCM のユーザー秘密復号鍵 |
 | `ENABLE_HEAVY_PIPELINE` | 文字起こし等の重量処理を有効化 |
 

--- a/apps/worker/scripts/run_worker.py
+++ b/apps/worker/scripts/run_worker.py
@@ -10,9 +10,10 @@ and deletes successful messages (failed ones become visible again / DLQ).
   export SQS_QUEUE_URL=http://127.0.0.1:9324/000000000000/videoq-jobs
   export AWS_REGION=us-east-1
   # ElasticMQ accepts any keys — reuse MinIO credentials for S3 + SQS locally.
-  export AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin
-  export USE_S3_STORAGE=true AWS_STORAGE_BUCKET_NAME=videoq-media
-  export AWS_S3_ENDPOINT_URL=http://127.0.0.1:9000 AWS_S3_REGION_NAME=us-east-1
+  export USE_S3_STORAGE=true
+  export R2_ACCESS_KEY_ID=minioadmin R2_SECRET_ACCESS_KEY=minioadmin
+  export R2_BUCKET_NAME=videoq-media
+  export R2_S3_ENDPOINT=http://127.0.0.1:9000 R2_S3_REGION=us-east-1
   python scripts/run_worker.py
 """
 

--- a/apps/worker/tests/test_secrets_bootstrap.py
+++ b/apps/worker/tests/test_secrets_bootstrap.py
@@ -1,29 +1,39 @@
-"""R2 credentials must not be swallowed by Lambda execution-role env vars."""
+"""R2 credentials must use R2_* names, never Lambda reserved AWS_ACCESS_KEY_ID."""
 
 from __future__ import annotations
+
+import os
 
 import worker_python.secrets_bootstrap as bootstrap
 
 
-def test_app_secret_maps_aws_keys_to_r2(monkeypatch):
+def test_canonical_r2_keys_from_app_secret(monkeypatch):
     bootstrap._LOADED = False
     monkeypatch.setenv("APP_SECRET_ARN", "arn:aws:secretsmanager:ap-northeast-1:1:secret:app")
-    # Lambda always injects role credentials under these reserved names.
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ASIA_ROLE_EXAMPLE")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "role-secret")
-    monkeypatch.delenv("R2_ACCESS_KEY_ID", raising=False)
-    monkeypatch.delenv("R2_SECRET_ACCESS_KEY", raising=False)
-    monkeypatch.delenv("DB_SECRET_ARN", raising=False)
+    for key in (
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+        "R2_BUCKET_NAME",
+        "R2_S3_ENDPOINT",
+        "R2_S3_REGION",
+        "AWS_STORAGE_BUCKET_NAME",
+        "AWS_S3_ENDPOINT_URL",
+        "AWS_S3_REGION_NAME",
+        "DB_SECRET_ARN",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
     class FakeClient:
         def get_secret_value(self, SecretId):  # noqa: N803
             assert SecretId.endswith("secret:app")
             return {
                 "SecretString": (
-                    '{"AWS_ACCESS_KEY_ID":"AKIA_R2","AWS_SECRET_ACCESS_KEY":"r2-secret",'
-                    '"AWS_STORAGE_BUCKET_NAME":"videoq-media-prod",'
-                    '"AWS_S3_ENDPOINT_URL":"https://example.r2.cloudflarestorage.com",'
-                    '"AWS_S3_REGION_NAME":"auto"}'
+                    '{"R2_ACCESS_KEY_ID":"AKIA_R2","R2_SECRET_ACCESS_KEY":"r2-secret",'
+                    '"R2_BUCKET_NAME":"videoq-media-prod",'
+                    '"R2_S3_ENDPOINT":"https://example.r2.cloudflarestorage.com",'
+                    '"R2_S3_REGION":"auto"}'
                 )
             }
 
@@ -34,7 +44,45 @@ def test_app_secret_maps_aws_keys_to_r2(monkeypatch):
     monkeypatch.setitem(__import__("sys").modules, "boto3", FakeBoto3())
     bootstrap.ensure_secrets_loaded()
 
-    assert __import__("os").environ["AWS_ACCESS_KEY_ID"] == "ASIA_ROLE_EXAMPLE"
-    assert __import__("os").environ["R2_ACCESS_KEY_ID"] == "AKIA_R2"
-    assert __import__("os").environ["R2_SECRET_ACCESS_KEY"] == "r2-secret"
-    assert __import__("os").environ["AWS_STORAGE_BUCKET_NAME"] == "videoq-media-prod"
+    assert os.environ["AWS_ACCESS_KEY_ID"] == "ASIA_ROLE_EXAMPLE"
+    assert os.environ["R2_ACCESS_KEY_ID"] == "AKIA_R2"
+    assert os.environ["R2_SECRET_ACCESS_KEY"] == "r2-secret"
+    assert os.environ["R2_BUCKET_NAME"] == "videoq-media-prod"
+    assert os.environ["R2_S3_ENDPOINT"] == "https://example.r2.cloudflarestorage.com"
+    # Legacy mirrors for older call sites.
+    assert os.environ["AWS_STORAGE_BUCKET_NAME"] == "videoq-media-prod"
+    assert os.environ["AWS_S3_ENDPOINT_URL"] == "https://example.r2.cloudflarestorage.com"
+
+
+def test_legacy_aws_secret_keys_map_to_r2(monkeypatch):
+    bootstrap._LOADED = False
+    monkeypatch.setenv("APP_SECRET_ARN", "arn:aws:secretsmanager:ap-northeast-1:1:secret:app")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ASIA_ROLE_EXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "role-secret")
+    for key in (
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+        "R2_BUCKET_NAME",
+        "DB_SECRET_ARN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    class FakeClient:
+        def get_secret_value(self, SecretId):  # noqa: N803
+            return {
+                "SecretString": (
+                    '{"AWS_ACCESS_KEY_ID":"AKIA_LEGACY","AWS_SECRET_ACCESS_KEY":"legacy",'
+                    '"AWS_STORAGE_BUCKET_NAME":"videoq-media-prod"}'
+                )
+            }
+
+    class FakeBoto3:
+        def client(self, _name):
+            return FakeClient()
+
+    monkeypatch.setitem(__import__("sys").modules, "boto3", FakeBoto3())
+    bootstrap.ensure_secrets_loaded()
+
+    assert os.environ["AWS_ACCESS_KEY_ID"] == "ASIA_ROLE_EXAMPLE"
+    assert os.environ["R2_ACCESS_KEY_ID"] == "AKIA_LEGACY"
+    assert os.environ["R2_BUCKET_NAME"] == "videoq-media-prod"

--- a/apps/worker/tests/test_secrets_bootstrap.py
+++ b/apps/worker/tests/test_secrets_bootstrap.py
@@ -1,0 +1,40 @@
+"""R2 credentials must not be swallowed by Lambda execution-role env vars."""
+
+from __future__ import annotations
+
+import worker_python.secrets_bootstrap as bootstrap
+
+
+def test_app_secret_maps_aws_keys_to_r2(monkeypatch):
+    bootstrap._LOADED = False
+    monkeypatch.setenv("APP_SECRET_ARN", "arn:aws:secretsmanager:ap-northeast-1:1:secret:app")
+    # Lambda always injects role credentials under these reserved names.
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ASIA_ROLE_EXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "role-secret")
+    monkeypatch.delenv("R2_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("R2_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("DB_SECRET_ARN", raising=False)
+
+    class FakeClient:
+        def get_secret_value(self, SecretId):  # noqa: N803
+            assert SecretId.endswith("secret:app")
+            return {
+                "SecretString": (
+                    '{"AWS_ACCESS_KEY_ID":"AKIA_R2","AWS_SECRET_ACCESS_KEY":"r2-secret",'
+                    '"AWS_STORAGE_BUCKET_NAME":"videoq-media-prod",'
+                    '"AWS_S3_ENDPOINT_URL":"https://example.r2.cloudflarestorage.com",'
+                    '"AWS_S3_REGION_NAME":"auto"}'
+                )
+            }
+
+    class FakeBoto3:
+        def client(self, _name):
+            return FakeClient()
+
+    monkeypatch.setitem(__import__("sys").modules, "boto3", FakeBoto3())
+    bootstrap.ensure_secrets_loaded()
+
+    assert __import__("os").environ["AWS_ACCESS_KEY_ID"] == "ASIA_ROLE_EXAMPLE"
+    assert __import__("os").environ["R2_ACCESS_KEY_ID"] == "AKIA_R2"
+    assert __import__("os").environ["R2_SECRET_ACCESS_KEY"] == "r2-secret"
+    assert __import__("os").environ["AWS_STORAGE_BUCKET_NAME"] == "videoq-media-prod"

--- a/apps/worker/worker_python/pipeline/storage.py
+++ b/apps/worker/worker_python/pipeline/storage.py
@@ -24,12 +24,30 @@ def object_storage_key(file_key: str) -> str:
 
 def _s3_client():
     import boto3
+    from botocore.config import Config
 
     endpoint = env_str("AWS_S3_ENDPOINT_URL") or env_str("AWS_S3_ENDPOINT") or None
     region = env_str("AWS_S3_REGION_NAME") or env_str("AWS_REGION") or "auto"
-    kwargs: dict = {"region_name": region}
+    # Prefer R2_* so Lambda execution-role AWS_ACCESS_KEY_ID is not used against R2.
+    access_key = (
+        env_str("R2_ACCESS_KEY_ID")
+        or env_str("AWS_S3_ACCESS_KEY_ID")
+        or env_str("AWS_ACCESS_KEY_ID")
+    )
+    secret_key = (
+        env_str("R2_SECRET_ACCESS_KEY")
+        or env_str("AWS_S3_SECRET_ACCESS_KEY")
+        or env_str("AWS_SECRET_ACCESS_KEY")
+    )
+    kwargs: dict = {
+        "region_name": region,
+        "config": Config(signature_version="s3v4"),
+    }
     if endpoint:
         kwargs["endpoint_url"] = endpoint
+    if access_key and secret_key:
+        kwargs["aws_access_key_id"] = access_key
+        kwargs["aws_secret_access_key"] = secret_key
     return boto3.client("s3", **kwargs)
 
 

--- a/apps/worker/worker_python/pipeline/storage.py
+++ b/apps/worker/worker_python/pipeline/storage.py
@@ -26,9 +26,19 @@ def _s3_client():
     import boto3
     from botocore.config import Config
 
-    endpoint = env_str("AWS_S3_ENDPOINT_URL") or env_str("AWS_S3_ENDPOINT") or None
-    region = env_str("AWS_S3_REGION_NAME") or env_str("AWS_REGION") or "auto"
-    # Prefer R2_* so Lambda execution-role AWS_ACCESS_KEY_ID is not used against R2.
+    endpoint = (
+        env_str("R2_S3_ENDPOINT")
+        or env_str("AWS_S3_ENDPOINT_URL")
+        or env_str("AWS_S3_ENDPOINT")
+        or None
+    )
+    region = (
+        env_str("R2_S3_REGION")
+        or env_str("AWS_S3_REGION_NAME")
+        or env_str("AWS_REGION")
+        or "auto"
+    )
+    # Prefer R2_* so Lambda execution-role AWS_ACCESS_KEY_ID is never used against R2.
     access_key = (
         env_str("R2_ACCESS_KEY_ID")
         or env_str("AWS_S3_ACCESS_KEY_ID")
@@ -52,9 +62,9 @@ def _s3_client():
 
 
 def _bucket() -> str:
-    name = env_str("AWS_STORAGE_BUCKET_NAME") or env_str("R2_BUCKET_NAME")
+    name = env_str("R2_BUCKET_NAME") or env_str("AWS_STORAGE_BUCKET_NAME")
     if not name:
-        raise RuntimeError("AWS_STORAGE_BUCKET_NAME (or R2_BUCKET_NAME) is required")
+        raise RuntimeError("R2_BUCKET_NAME (or AWS_STORAGE_BUCKET_NAME) is required")
     return name
 
 

--- a/apps/worker/worker_python/secrets_bootstrap.py
+++ b/apps/worker/worker_python/secrets_bootstrap.py
@@ -1,8 +1,8 @@
 """Load Secrets Manager payloads into process env for Lambda.
 
-Lambda forbids configuring reserved keys like AWS_ACCESS_KEY_ID on the
-function configuration, so R2 credentials are injected at runtime from
-APP_SECRET_ARN instead.
+Lambda injects reserved AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for the
+execution role. R2 credentials must therefore live under R2_* names in
+APP_SECRET_ARN and are loaded into R2_* process env vars.
 """
 
 from __future__ import annotations
@@ -15,19 +15,21 @@ logger = logging.getLogger(__name__)
 
 _LOADED = False
 
-# app secret key → process env (skip if already set).
-# R2 keys must NOT overwrite Lambda's reserved AWS_ACCESS_KEY_ID /
-# AWS_SECRET_ACCESS_KEY (execution-role creds). Map them to R2_* instead.
+# Canonical app-secret key → process env (skip if already set).
 _APP_ENV_MAP = {
     "OPENAI_API_KEY": "OPENAI_API_KEY",
     "USER_SECRET_ENCRYPTION_KEY": "USER_SECRET_ENCRYPTION_KEY",
-    "AWS_ACCESS_KEY_ID": "R2_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY": "R2_SECRET_ACCESS_KEY",
     "R2_ACCESS_KEY_ID": "R2_ACCESS_KEY_ID",
     "R2_SECRET_ACCESS_KEY": "R2_SECRET_ACCESS_KEY",
-    "AWS_STORAGE_BUCKET_NAME": "AWS_STORAGE_BUCKET_NAME",
-    "AWS_S3_ENDPOINT_URL": "AWS_S3_ENDPOINT_URL",
-    "AWS_S3_REGION_NAME": "AWS_S3_REGION_NAME",
+    "R2_BUCKET_NAME": "R2_BUCKET_NAME",
+    "R2_S3_ENDPOINT": "R2_S3_ENDPOINT",
+    "R2_S3_REGION": "R2_S3_REGION",
+    # Legacy aliases (pre-R2_* rename). Prefer canonical keys above.
+    "AWS_STORAGE_BUCKET_NAME": "R2_BUCKET_NAME",
+    "AWS_S3_ENDPOINT_URL": "R2_S3_ENDPOINT",
+    "AWS_S3_REGION_NAME": "R2_S3_REGION",
+    "AWS_ACCESS_KEY_ID": "R2_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY": "R2_SECRET_ACCESS_KEY",
 }
 
 
@@ -59,13 +61,26 @@ def ensure_secrets_loaded() -> None:
 
     if app_arn:
         payload = _get_json_secret(client, app_arn)
+        # Prefer canonical R2_* secret keys over legacy AWS_* aliases when both exist.
         for src, dest in _APP_ENV_MAP.items():
             if os.environ.get(dest):
                 continue
             value = payload.get(src)
             if isinstance(value, str) and value.strip():
                 os.environ[dest] = value.strip()
+        # Keep legacy env names some callers still read.
+        _mirror_if_missing("R2_BUCKET_NAME", "AWS_STORAGE_BUCKET_NAME")
+        _mirror_if_missing("R2_S3_ENDPOINT", "AWS_S3_ENDPOINT_URL")
+        _mirror_if_missing("R2_S3_REGION", "AWS_S3_REGION_NAME")
         logger.info("Loaded app secrets from APP_SECRET_ARN")
+
+
+def _mirror_if_missing(src: str, dest: str) -> None:
+    if os.environ.get(dest):
+        return
+    value = os.environ.get(src, "").strip()
+    if value:
+        os.environ[dest] = value
 
 
 def _get_json_secret(client: object, arn: str) -> dict:

--- a/apps/worker/worker_python/secrets_bootstrap.py
+++ b/apps/worker/worker_python/secrets_bootstrap.py
@@ -15,12 +15,16 @@ logger = logging.getLogger(__name__)
 
 _LOADED = False
 
-# app secret key → process env (skip if already set)
+# app secret key → process env (skip if already set).
+# R2 keys must NOT overwrite Lambda's reserved AWS_ACCESS_KEY_ID /
+# AWS_SECRET_ACCESS_KEY (execution-role creds). Map them to R2_* instead.
 _APP_ENV_MAP = {
     "OPENAI_API_KEY": "OPENAI_API_KEY",
     "USER_SECRET_ENCRYPTION_KEY": "USER_SECRET_ENCRYPTION_KEY",
-    "AWS_ACCESS_KEY_ID": "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY": "AWS_SECRET_ACCESS_KEY",
+    "AWS_ACCESS_KEY_ID": "R2_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY": "R2_SECRET_ACCESS_KEY",
+    "R2_ACCESS_KEY_ID": "R2_ACCESS_KEY_ID",
+    "R2_SECRET_ACCESS_KEY": "R2_SECRET_ACCESS_KEY",
     "AWS_STORAGE_BUCKET_NAME": "AWS_STORAGE_BUCKET_NAME",
     "AWS_S3_ENDPOINT_URL": "AWS_S3_ENDPOINT_URL",
     "AWS_S3_REGION_NAME": "AWS_S3_REGION_NAME",

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -116,7 +116,28 @@ aws lambda update-function-code \
   --region "$REGION"
 ```
 
-Lambda には少なくとも DB、SQS、R2、AI、`USER_SECRET_ENCRYPTION_KEY` を設定します。
+### App secret (`videoq/<env>/app`) JSON schema
+
+Secrets Manager の app secret は **R2 用キー名を `R2_*` にする**（Terraform は secret 器のみ管理）。
+
+```json
+{
+  "OPENAI_API_KEY": "...",
+  "USER_SECRET_ENCRYPTION_KEY": "...",
+  "R2_ACCESS_KEY_ID": "...",
+  "R2_SECRET_ACCESS_KEY": "...",
+  "R2_BUCKET_NAME": "videoq-media-prod",
+  "R2_S3_ENDPOINT": "https://<accountid>.r2.cloudflarestorage.com",
+  "R2_S3_REGION": "auto"
+}
+```
+
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` をここに入れないこと。
+Lambda 実行ロールが同名を予約しており、R2 キーが無視されて文字起こしが 400 になります。
+
+API Worker（Cloudflare）の SQS 送信用クレデンシャルは別 IAM ユーザー
+（例: `videoq-workers-api`）を `wrangler secret` の `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY` / `AWS_REGION` / `SQS_QUEUE_URL` に設定します。
 
 ## 5. Frontend
 

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -14,12 +14,24 @@ resource "aws_secretsmanager_secret" "db" {
   }
 }
 
-# App secrets + R2 credentials.
-# Worker runtime and R2 credentials are stored together;
-# every key is expanded into the environment by the app secret handler.
+# App secrets + R2 credentials for the SQS Lambda worker.
+#
+# Expected JSON keys (set via CLI / Console — not Terraform-managed versions):
+#
+#   OPENAI_API_KEY
+#   USER_SECRET_ENCRYPTION_KEY
+#   R2_ACCESS_KEY_ID          # Cloudflare R2 S3 API token (NOT Lambda role keys)
+#   R2_SECRET_ACCESS_KEY
+#   R2_BUCKET_NAME            # e.g. videoq-media-prod
+#   R2_S3_ENDPOINT            # https://<accountid>.r2.cloudflarestorage.com
+#   R2_S3_REGION              # usually "auto"
+#
+# Do NOT store R2 credentials as AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
+# Lambda injects those names for the execution role; colliding names are skipped
+# or break AWS API calls (SQS / Secrets Manager).
 resource "aws_secretsmanager_secret" "app" {
   name        = "${local.name_prefix}/${var.env_name}/app"
-  description = "App secrets + R2 credentials"
+  description = "App secrets + R2 credentials (use R2_* key names, never AWS_ACCESS_KEY_ID)"
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
## Summary
- Lambda 実行ロールが予約する `AWS_ACCESS_KEY_ID` と、R2 API トークンが同名で衝突していた
- **インフラ方針**: Secrets Manager app secret は `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_BUCKET_NAME` / `R2_S3_ENDPOINT` / `R2_S3_REGION` を正本にする（`infra/secrets.tf` / `DEPLOY.md`）
- **本番 secret 移行済み**: `videoq/prod/app` から `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` を除去し `R2_*` を追加
- worker は `R2_*` を明示利用（legacy 別名は読み取り互換のみ）

## Test plan
- [x] `pytest tests/test_secrets_bootstrap.py`
- [x] 本番 Secrets Manager を R2_* へ更新
- [ ] Lambda イメージ再デプロイ後、video 103 を再キューして完了すること
- [ ] 新規アップロードが自動で文字起こし開始すること