### PR TITLE
fix(auth): harden same-origin login for mobile Safari

### DIFF
--- a/apps/api/src/features/auth/routes.ts
+++ b/apps/api/src/features/auth/routes.ts
@@ -57,10 +57,12 @@ function refreshCookieName(c: Context<AppEnv>): string {
 
 function setRefreshCookie(c: Context<AppEnv>, refresh: string): void {
   const secure = c.env.ENVIRONMENT === "production";
+  // Same-origin SPA (/api on videoq.jp): Lax is correct. SameSite=None is for
+  // cross-site cookies and is stricter on mobile Safari / ITP.
   setCookie(c, refreshCookieName(c), refresh, {
     httpOnly: true,
     secure,
-    sameSite: secure ? "None" : "Lax",
+    sameSite: "Lax",
     maxAge: REFRESH_TOKEN_TTL_SECONDS,
     path: "/",
   });
@@ -70,7 +72,7 @@ function clearRefreshCookie(c: Context<AppEnv>): void {
   const secure = c.env.ENVIRONMENT === "production";
   deleteCookie(c, refreshCookieName(c), {
     path: "/",
-    sameSite: secure ? "None" : "Lax",
+    sameSite: "Lax",
     secure,
   });
 }

--- a/apps/api/src/features/oauth/oidc.ts
+++ b/apps/api/src/features/oauth/oidc.ts
@@ -141,7 +141,7 @@ function clearSessionCookies(c: Context<AppEnv>) {
   setCookie(c, name, "", {
     path: "/",
     httpOnly: true,
-    sameSite: secure ? "None" : "Lax",
+    sameSite: "Lax",
     secure,
     maxAge: 0,
   });

--- a/apps/api/test/auth-login-contract.test.ts
+++ b/apps/api/test/auth-login-contract.test.ts
@@ -44,6 +44,7 @@ describe("POST /api/auth/sessions response contract", () => {
     const cookie = res.headers.get("set-cookie") ?? "";
     expect(cookie).toContain("vq_refresh=opaque-refresh-token");
     expect(cookie).toContain("HttpOnly");
+    expect(cookie.toLowerCase()).toContain("samesite=lax");
     expect(cookie).not.toContain("access_token=");
   });
 });

--- a/frontend/src/hooks/useAuthForm.ts
+++ b/frontend/src/hooks/useAuthForm.ts
@@ -13,7 +13,7 @@ interface UseAuthFormReturn<T> {
   isLoading: boolean;
   setError: (error: string | null) => void;
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleSubmit: (e: React.FormEvent) => Promise<void>;
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => Promise<void>;
 }
 
 export function useAuthForm<T extends Record<string, unknown>>({
@@ -45,10 +45,22 @@ export function useAuthForm<T extends Record<string, unknown>>({
     updateField(e.target.name as keyof T, e.target.value as T[keyof T]);
   }, [updateField]);
 
-  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+  const handleSubmit = useCallback(async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
-    await submitMutation.mutateAsync(formData);
+    // Prefer DOM values so iOS/Android autofill (which may skip React onChange) still submits.
+    let data = { ...formData };
+    if (e.currentTarget instanceof HTMLFormElement) {
+      const fd = new FormData(e.currentTarget);
+      for (const key of Object.keys(formData) as Array<keyof T>) {
+        const value = fd.get(String(key));
+        if (typeof value === 'string') {
+          data[key] = value as T[keyof T];
+        }
+      }
+      setFormData(data);
+    }
+    await submitMutation.mutateAsync(data);
   }, [submitMutation, formData]);
 
   return {

--- a/frontend/src/hooks/useAuthForm.ts
+++ b/frontend/src/hooks/useAuthForm.ts
@@ -49,7 +49,7 @@ export function useAuthForm<T extends Record<string, unknown>>({
     e.preventDefault();
     setError(null);
     // Prefer DOM values so iOS/Android autofill (which may skip React onChange) still submits.
-    let data = { ...formData };
+    const data = { ...formData };
     if (e.currentTarget instanceof HTMLFormElement) {
       const fd = new FormData(e.currentTarget);
       for (const key of Object.keys(formData) as Array<keyof T>) {

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -102,8 +102,8 @@ describe('ApiClient', () => {
       expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/sessions', expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ username: 'user', password: 'pw' }),
+        credentials: 'include',
       }));
-      expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('credentials');
     });
 
     it('login should retain access token in memory for subsequent API requests', async () => {
@@ -301,8 +301,8 @@ describe('ApiClient', () => {
       expect(result).toEqual(mockKeys);
       expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/api-keys', expect.objectContaining({
         headers: expect.any(Object),
+        credentials: 'include',
       }));
-      expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('credentials');
     });
 
     it('createIntegrationApiKey should create an api key', async () => {
@@ -353,8 +353,8 @@ describe('ApiClient', () => {
       expect(result).toEqual(mockStatus);
       expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/api/auth/searchapi-key', expect.objectContaining({
         headers: expect.any(Object),
+        credentials: 'include',
       }));
-      expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('credentials');
     });
 
     it('saveSearchApiKey should save a key', async () => {
@@ -537,9 +537,11 @@ describe('ApiClient', () => {
       expect(result).toEqual({ id: 1, username: 'custom' });
       expect(customFetch).toHaveBeenCalledWith(
         'https://api.example.test/v1/auth/me',
-        expect.objectContaining({ headers: expect.any(Object) }),
+        expect.objectContaining({
+          headers: expect.any(Object),
+          credentials: 'include',
+        }),
       );
-      expect(customFetch.mock.calls[0][1]).not.toHaveProperty('credentials');
     });
 
     it('setUnauthorizedHandler should update the handler used by later auth failures', async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -633,6 +633,7 @@ export class ApiClient {
     const body = this.stringifyBody(options.body);
 
     const config: RequestInit = {
+      credentials: 'include',
       ...options,
       body,
       headers,
@@ -749,7 +750,7 @@ export class ApiClient {
   private fetchMe(): Promise<Response> {
     const url = this.buildUrl('/auth/me');
     const headers = this.buildHeaders();
-    return this.fetchFn(url, { headers });
+    return this.fetchFn(url, { headers, credentials: 'include' });
   }
 
   async getMeOrNull(): Promise<User | null> {


### PR DESCRIPTION
## Summary
- Use `SameSite=Lax` for refresh cookies (same-origin `/api` on `videoq.jp`; `None` is unnecessarily strict on mobile Safari / ITP).
- Always send `credentials: 'include'` on API fetches so refresh cookies are reliably stored and sent.
- Read DOM `FormData` on auth form submit so iOS/Android autofill still works when React `onChange` is skipped.

## Test plan
- [ ] `cd apps/api && npm test -- test/auth-login-contract.test.ts test/auth-login.test.ts test/auth-refresh.test.ts`
- [ ] `cd frontend && npm test -- src/lib/__tests__/api.test.ts src/hooks/__tests__/useAuthForm.test.ts src/pages/__tests__/LoginPage.test.tsx`
- [ ] Desktop: log in at https://videoq.jp and confirm session persists across refresh
- [ ] Mobile Safari: log in (including with password autofill) and confirm you stay signed in after reload
- [ ] Confirm logout still clears the session cookie


Made with [Cursor](https://cursor.com)