### PR TITLE
fix(auth): stale login cache and session/OAuth hardening

### DIFF
--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -15,6 +15,7 @@ import {
   type QuotaPatch,
   type UsagePatch,
 } from "../../repositories/admin-repository";
+import { revokeAllOAuthTokensForUser } from "../../repositories/oauth-repository";
 import type { Bindings } from "../../types/bindings";
 
 export function isSuperuser(env: Bindings, userId: number) {
@@ -65,6 +66,10 @@ export async function patchFlags(
 
   const user = await patchAdminUserFlags(env, targetUserId, patch);
   if (!user) return { notFound: true as const };
+  // Sessions are deleted in the repository; drop OAuth/MCP tokens too.
+  if (patch.is_active === false) {
+    await revokeAllOAuthTokensForUser(env, targetUserId);
+  }
   return { user } as const;
 }
 
@@ -88,6 +93,7 @@ export async function deleteUser(
 
   const locked = await lockUserForHardDelete(env, targetUserId);
   if (!locked) return { notFound: true } as const;
+  await revokeAllOAuthTokensForUser(env, targetUserId);
 
   const jobId = await enqueueAccountDeletion(env, targetUserId);
   if (jobId) return { job_id: jobId } as const;

--- a/apps/api/src/features/auth/routes.ts
+++ b/apps/api/src/features/auth/routes.ts
@@ -7,7 +7,6 @@ import {
 } from "../../shared/openapi";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
-import { getCookie, setCookie, deleteCookie } from "hono/cookie";
 import { requireAuth, apiKeyMethod, jwtMethod } from "../../middleware/auth";
 import { apiError, toErrorBody, validationError } from "../../shared/errors";
 import { hasTrustedOrigin } from "../../shared/origin";
@@ -18,6 +17,11 @@ import {
   throttledResponse,
   type ThrottleScope,
 } from "../../lib/rate-limit";
+import {
+  clearRefreshCookie,
+  refreshTokenFromCookie,
+  setRefreshCookie,
+} from "../../lib/refresh-cookie";
 import type { AppEnv } from "../../types/bindings";
 import {
   apiKeyCreateSchema,
@@ -40,7 +44,6 @@ import * as authService from "./service";
 export const authRoutes = createFeatureRouter();
 
 const jwtOnly = requireAuth(jwtMethod);
-const jwtWriteGuards = [requireAuth(jwtMethod)] as const;
 const meAuth = requireAuth(apiKeyMethod, jwtMethod);
 
 function isJsonRequest(c: Context<AppEnv>): boolean {
@@ -49,37 +52,6 @@ function isJsonRequest(c: Context<AppEnv>): boolean {
 }
 
 const ACCESS_TOKEN_TTL_SECONDS = 10 * 60;
-const REFRESH_TOKEN_TTL_SECONDS = 14 * 24 * 60 * 60;
-
-function refreshCookieName(c: Context<AppEnv>): string {
-  return c.env.ENVIRONMENT === "production" ? "__Host-vq_refresh" : "vq_refresh";
-}
-
-function setRefreshCookie(c: Context<AppEnv>, refresh: string): void {
-  const secure = c.env.ENVIRONMENT === "production";
-  // Same-origin SPA (/api on videoq.jp): Lax is correct. SameSite=None is for
-  // cross-site cookies and is stricter on mobile Safari / ITP.
-  setCookie(c, refreshCookieName(c), refresh, {
-    httpOnly: true,
-    secure,
-    sameSite: "Lax",
-    maxAge: REFRESH_TOKEN_TTL_SECONDS,
-    path: "/",
-  });
-}
-
-function clearRefreshCookie(c: Context<AppEnv>): void {
-  const secure = c.env.ENVIRONMENT === "production";
-  deleteCookie(c, refreshCookieName(c), {
-    path: "/",
-    sameSite: "Lax",
-    secure,
-  });
-}
-
-function refreshTokenFromCookie(c: Context<AppEnv>): string | undefined {
-  return getCookie(c, refreshCookieName(c));
-}
 
 const requireTrustedOrigin = createMiddleware<AppEnv>(async (c, next) => {
   if (!hasTrustedOrigin(c)) {
@@ -212,6 +184,8 @@ const refreshRoute = createRoute({
 authRoutes.openapi(refreshRoute, async (c) => {
   const res = await authService.refreshSession(c.env, refreshTokenFromCookie(c));
   if (!res.ok) {
+    // Drop a dead / reused cookie so the browser stops replaying it.
+    clearRefreshCookie(c);
     return apiError(c, 401, "Invalid refresh token", "AUTHENTICATION_FAILED");
   }
   setRefreshCookie(c, res.refreshToken);
@@ -453,7 +427,7 @@ const createApiKeyRoute = createRoute({
   path: "/api/auth/api-keys",
   tags: ["Auth"],
   summary: "Create API key",
-  middleware: [...jwtWriteGuards] as const,
+  middleware: [jwtOnly] as const,
   request: {
     body: {
       content: { "application/json": { schema: apiKeyCreateSchema } },
@@ -483,7 +457,7 @@ const revokeApiKeyRoute = createRoute({
   path: "/api/auth/api-keys/{id}",
   tags: ["Auth"],
   summary: "Revoke API key",
-  middleware: [...jwtWriteGuards] as const,
+  middleware: [jwtOnly] as const,
   request: { params: apiKeyIdParamSchema },
   responses: {
     204: { description: "No content" },
@@ -522,7 +496,7 @@ const saveSearchApiKeyRoute = createRoute({
   path: "/api/auth/searchapi-key",
   tags: ["Auth"],
   summary: "Save SearchAPI key",
-  middleware: [...jwtWriteGuards] as const,
+  middleware: [jwtOnly] as const,
   request: {
     body: {
       content: { "application/json": { schema: searchApiKeyBodySchema } },
@@ -556,7 +530,7 @@ const removeSearchApiKeyRoute = createRoute({
   path: "/api/auth/searchapi-key",
   tags: ["Auth"],
   summary: "Delete SearchAPI key",
-  middleware: [...jwtWriteGuards] as const,
+  middleware: [jwtOnly] as const,
   responses: {
     200: jsonResponse(messageResponseSchema),
     404: errorResponse("Not found"),

--- a/apps/api/src/features/auth/service.ts
+++ b/apps/api/src/features/auth/service.ts
@@ -34,10 +34,21 @@ import {
   consumeActionToken,
   createActionToken,
   createAuthSession,
+  revokeAllUserSessions,
   revokeAuthSession,
   rotateAuthSession,
 } from "../../repositories/auth-repository";
+import { revokeAllOAuthTokensForUser } from "../../repositories/oauth-repository";
 import type { Bindings } from "../../types/bindings";
+
+/** App sessions + OAuth 委譲をまとめて無効化（資格情報 / identity 変更時）。 */
+async function revokeAllUserDelegations(
+  env: Bindings,
+  userId: number,
+): Promise<void> {
+  await revokeAllUserSessions(env, userId);
+  await revokeAllOAuthTokensForUser(env, userId);
+}
 
 export const SIGNUP_OK_MESSAGE =
   "Verification email sent. Please check your email.";
@@ -135,6 +146,8 @@ export async function confirmPasswordReset(
   const action = await consumeActionToken(env, token, "reset_password");
   if (!action) return { ok: false, message: INVALID };
   await setUserPassword(env, action.userId, newPassword);
+  // Invalidate app sessions and OAuth/MCP tokens after credential change.
+  await revokeAllUserDelegations(env, action.userId);
   return { ok: true };
 }
 
@@ -183,6 +196,8 @@ export async function confirmEmailChange(
   if (!(await confirmPendingEmail(env, action.userId, pendingEmail))) {
     return { ok: false, message: INVALID };
   }
+  // Identity change: force re-login and drop third-party delegations.
+  await revokeAllUserDelegations(env, action.userId);
   return { ok: true };
 }
 

--- a/apps/api/src/features/oauth/html-helpers.ts
+++ b/apps/api/src/features/oauth/html-helpers.ts
@@ -1,17 +1,15 @@
 import type { Context } from "hono";
-import { getCookie } from "hono/cookie";
 import {
   consumeActionToken,
   createActionToken,
   resolveAuthSession,
 } from "../../repositories/auth-repository";
+import { refreshTokenFromCookie } from "../../lib/refresh-cookie";
 import { hasTrustedOrigin } from "../../shared/origin";
 import type { AppEnv } from "../../types/bindings";
 
 export async function cookieUserId(c: Context<AppEnv>): Promise<number | null> {
-  const cookieName =
-    c.env.ENVIRONMENT === "production" ? "__Host-vq_refresh" : "vq_refresh";
-  const session = await resolveAuthSession(c.env, getCookie(c, cookieName));
+  const session = await resolveAuthSession(c.env, refreshTokenFromCookie(c));
   return session?.userId ?? null;
 }
 

--- a/apps/api/src/features/oauth/oidc.ts
+++ b/apps/api/src/features/oauth/oidc.ts
@@ -1,7 +1,11 @@
 import type { Context } from "hono";
-import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { getCookie } from "hono/cookie";
 import { isOidcEnabled, isOidcRpLogoutEnabled } from "../../lib/oidc";
 import { escapeHtml, issuerFromEnv } from "../../lib/oauth";
+import {
+  clearRefreshCookie,
+  refreshCookieName,
+} from "../../lib/refresh-cookie";
 import { revokeAuthSession } from "../../repositories/auth-repository";
 import {
   createFeatureRouter,
@@ -134,19 +138,6 @@ oauthOidcRoutes.openapi(userinfoPostRoute, (c) =>
   userinfo(c, c.req.valid("form").access_token),
 );
 
-function clearSessionCookies(c: Context<AppEnv>) {
-  const secure = c.env.ENVIRONMENT === "production";
-  const name = secure ? "__Host-vq_refresh" : "vq_refresh";
-  deleteCookie(c, name, { path: "/" });
-  setCookie(c, name, "", {
-    path: "/",
-    httpOnly: true,
-    sameSite: "Lax",
-    secure,
-    maxAge: 0,
-  });
-}
-
 async function doLogout(
   c: Context<AppEnv>,
   opts: {
@@ -156,10 +147,8 @@ async function doLogout(
   },
 ): Promise<Response> {
   await oidcService.revokeTokensForOidcLogoutIfConfigured(c.env, opts.userId);
-  const cookieName =
-    c.env.ENVIRONMENT === "production" ? "__Host-vq_refresh" : "vq_refresh";
-  await revokeAuthSession(c.env, getCookie(c, cookieName));
-  clearSessionCookies(c);
+  await revokeAuthSession(c.env, getCookie(c, refreshCookieName(c)));
+  clearRefreshCookie(c);
 
   if (opts.postLogoutRedirectUri) {
     const u = new URL(opts.postLogoutRedirectUri);

--- a/apps/api/src/lib/refresh-cookie.ts
+++ b/apps/api/src/lib/refresh-cookie.ts
@@ -1,0 +1,36 @@
+import type { Context } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import type { AppEnv } from "../types/bindings";
+
+/** Opaque refresh session cookie. Production uses `__Host-` (Secure, Path=/, no Domain). */
+export const REFRESH_COOKIE_TTL_SECONDS = 14 * 24 * 60 * 60;
+
+export function refreshCookieName(c: Context<AppEnv>): string {
+  return c.env.ENVIRONMENT === "production" ? "__Host-vq_refresh" : "vq_refresh";
+}
+
+export function refreshTokenFromCookie(c: Context<AppEnv>): string | undefined {
+  return getCookie(c, refreshCookieName(c));
+}
+
+export function setRefreshCookie(c: Context<AppEnv>, refresh: string): void {
+  const secure = c.env.ENVIRONMENT === "production";
+  // Same-origin SPA (`/api` on videoq.jp): Lax is correct. SameSite=None is for
+  // cross-site cookies and is stricter on mobile Safari / ITP.
+  setCookie(c, refreshCookieName(c), refresh, {
+    httpOnly: true,
+    secure,
+    sameSite: "Lax",
+    maxAge: REFRESH_COOKIE_TTL_SECONDS,
+    path: "/",
+  });
+}
+
+export function clearRefreshCookie(c: Context<AppEnv>): void {
+  const secure = c.env.ENVIRONMENT === "production";
+  deleteCookie(c, refreshCookieName(c), {
+    path: "/",
+    sameSite: "Lax",
+    secure,
+  });
+}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import type { AppEnv } from "../types/bindings";
 import { toErrorBody } from "../shared/errors";
 import { sha256Hex } from "../shared/crypto";
 import { verifyAccessToken } from "../lib/jwt";
+import { isAuthSessionActive } from "../repositories/auth-repository";
 import { resolveActiveApiKey } from "../repositories/api-key-repository";
 import { resolveOAuthAccessToken } from "../repositories/oauth-repository";
 
@@ -80,7 +81,14 @@ export const jwtMethod: AuthMethod = async (c) => {
   const bearer = authz?.keyword === "Bearer" ? authz.value : undefined;
   if (!bearer || bearer.startsWith("vq_")) return { kind: "absent" };
   const verified = await verifyAccessToken(c.env, bearer);
-  return verified
+  if (!verified) return { kind: "invalid", message: "Invalid access token" };
+  // Refresh cookie 失効・パスワード変更後も access JWT を TTL 満了前に拒否する。
+  const active = await isAuthSessionActive(
+    c.env,
+    verified.sessionId,
+    verified.userId,
+  );
+  return active
     ? { kind: "ok", userId: verified.userId, via: "bearer" }
     : { kind: "invalid", message: "Invalid access token" };
 };

--- a/apps/api/src/middleware/cors.ts
+++ b/apps/api/src/middleware/cors.ts
@@ -13,7 +13,8 @@ export const corsMiddleware = createMiddleware<AppEnv>(async (c, next) => {
     .filter(Boolean);
   const handler = cors({
     // Comma-separated list in env (e.g. localhost + 127.0.0.1 for Vite).
-    origin: (origin) => (origin && allowed.includes(origin) ? origin : allowed[0] ?? ""),
+    // Return the request origin only when allowlisted; otherwise omit ACAO.
+    origin: (origin) => (origin && allowed.includes(origin) ? origin : null),
     credentials: true,
     allowHeaders: ["Content-Type", "Authorization", "X-API-Key"],
     allowMethods: ["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"],

--- a/apps/api/src/repositories/auth-repository.ts
+++ b/apps/api/src/repositories/auth-repository.ts
@@ -126,6 +126,47 @@ export async function revokeAuthSession(
   });
 }
 
+/** Revoke every refresh session for a user (e.g. after password reset). */
+export async function revokeAllUserSessions(
+  env: Bindings,
+  userId: number,
+): Promise<void> {
+  await withClient(env, async (client) => {
+    await client.query(
+      `UPDATE auth_sessions
+          SET revoked_at = COALESCE(revoked_at, now())
+        WHERE user_id = $1
+          AND revoked_at IS NULL`,
+      [userId],
+    );
+  });
+}
+
+/**
+ * Access JWT `sid` がまだ有効なセッションか（ログアウト / パスワード変更後の即時無効化用）。
+ */
+export async function isAuthSessionActive(
+  env: Bindings,
+  sessionId: string,
+  userId: number,
+): Promise<boolean> {
+  return withClient(env, async (client) => {
+    const result = await client.query<{ ok: number }>(
+      `SELECT 1 AS ok
+         FROM auth_sessions s
+         JOIN users u ON u.id = s.user_id
+        WHERE s.id = $1
+          AND s.user_id = $2
+          AND s.revoked_at IS NULL
+          AND s.expires_at > now()
+          AND u.is_active = true
+        LIMIT 1`,
+      [sessionId, userId],
+    );
+    return result.rows.length > 0;
+  });
+}
+
 export async function resolveAuthSession(
   env: Bindings,
   refreshToken: string | undefined,

--- a/apps/api/src/repositories/oauth-repository.ts
+++ b/apps/api/src/repositories/oauth-repository.ts
@@ -184,23 +184,113 @@ export async function listAuthorizedTokens(
   });
 }
 
-/** 所有者のトークンを削除（`revoke_for_user`）。成功=true。 */
+/**
+ * Connected Apps 切断: 対象 access token と同じ application の
+ * access / refresh をまとめて削除する（refresh だけ残して再発行されるのを防ぐ）。
+ */
 export async function revokeAuthorizedToken(
   env: Bindings,
   userId: number,
   tokenId: number,
 ): Promise<boolean> {
-  return withDb(env, async (db) => {
-    const rows = await db
-      .delete(oauthAccessTokens)
-      .where(
-        and(
-          eq(oauthAccessTokens.id, tokenId),
-          eq(oauthAccessTokens.userId, userId),
-        ),
-      )
-      .returning({ id: oauthAccessTokens.id });
-    return rows.length > 0;
+  return withDb(env, async (db, client) => {
+    await client.query("BEGIN");
+    try {
+      const existing = await db
+        .select({
+          id: oauthAccessTokens.id,
+          applicationId: oauthAccessTokens.applicationId,
+        })
+        .from(oauthAccessTokens)
+        .where(
+          and(
+            eq(oauthAccessTokens.id, tokenId),
+            eq(oauthAccessTokens.userId, userId),
+          ),
+        )
+        .limit(1);
+      const row = existing[0];
+      if (!row) {
+        await client.query("ROLLBACK");
+        return false;
+      }
+
+      if (row.applicationId != null) {
+        await db
+          .delete(oauthRefreshTokens)
+          .where(
+            and(
+              eq(oauthRefreshTokens.userId, userId),
+              eq(oauthRefreshTokens.applicationId, row.applicationId),
+            ),
+          );
+        await db
+          .update(oauthAccessTokens)
+          .set({ idTokenId: null })
+          .where(
+            and(
+              eq(oauthAccessTokens.userId, userId),
+              eq(oauthAccessTokens.applicationId, row.applicationId),
+            ),
+          );
+        await db
+          .delete(oauthAccessTokens)
+          .where(
+            and(
+              eq(oauthAccessTokens.userId, userId),
+              eq(oauthAccessTokens.applicationId, row.applicationId),
+            ),
+          );
+      } else {
+        await db
+          .delete(oauthAccessTokens)
+          .where(
+            and(
+              eq(oauthAccessTokens.id, tokenId),
+              eq(oauthAccessTokens.userId, userId),
+            ),
+          );
+      }
+      await client.query("COMMIT");
+      return true;
+    } catch (e) {
+      await client.query("ROLLBACK");
+      throw e;
+    }
+  });
+}
+
+/**
+ * 資格情報変更・アカウント無効化時: ユーザーの OAuth 委譲をすべて消す。
+ * (access / refresh / id token / auth code / device grant)
+ */
+export async function revokeAllOAuthTokensForUser(
+  env: Bindings,
+  userId: number,
+): Promise<void> {
+  await withDb(env, async (db, client) => {
+    await client.query("BEGIN");
+    try {
+      await db
+        .delete(oauthRefreshTokens)
+        .where(eq(oauthRefreshTokens.userId, userId));
+      await db.delete(oauthGrants).where(eq(oauthGrants.userId, userId));
+      await db
+        .delete(oauthDeviceGrants)
+        .where(eq(oauthDeviceGrants.userId, userId));
+      await db
+        .update(oauthAccessTokens)
+        .set({ idTokenId: null })
+        .where(eq(oauthAccessTokens.userId, userId));
+      await db.delete(oauthIdTokens).where(eq(oauthIdTokens.userId, userId));
+      await db
+        .delete(oauthAccessTokens)
+        .where(eq(oauthAccessTokens.userId, userId));
+      await client.query("COMMIT");
+    } catch (e) {
+      await client.query("ROLLBACK");
+      throw e;
+    }
   });
 }
 
@@ -221,11 +311,13 @@ export async function resolveOAuthAccessToken(
         scope: oauthAccessTokens.scope,
       })
       .from(oauthAccessTokens)
+      .innerJoin(users, eq(users.id, oauthAccessTokens.userId))
       .where(
         and(
           eq(oauthAccessTokens.tokenChecksum, tokenChecksumHex),
           gt(oauthAccessTokens.expires, sql`now()`),
           isNotNull(oauthAccessTokens.userId),
+          eq(users.isActive, true),
         ),
       )
       .limit(1);
@@ -613,9 +705,11 @@ export async function findActiveRefreshToken(
              r.created, coalesce(a.scope, '') AS scope
         FROM oauth_refresh_tokens r
          LEFT JOIN oauth_access_tokens a ON a.id = r.access_token_id
+         JOIN users u ON u.id = r.user_id
        WHERE r.token = ${rawRefresh}
          AND r.revoked IS NULL
          AND r.application_id = ${applicationId}
+         AND u.is_active = true
        ORDER BY r.id DESC
        LIMIT 1
     `);
@@ -1182,11 +1276,12 @@ export async function findAccessTokenForUserinfo(
         email: users.email,
       })
       .from(oauthAccessTokens)
-      .leftJoin(users, eq(users.id, oauthAccessTokens.userId))
+      .innerJoin(users, eq(users.id, oauthAccessTokens.userId))
       .where(
         and(
           eq(oauthAccessTokens.tokenChecksum, checksum),
           gt(oauthAccessTokens.expires, sql`now()`),
+          eq(users.isActive, true),
         ),
       )
       .limit(1);

--- a/apps/api/test/admin.test.ts
+++ b/apps/api/test/admin.test.ts
@@ -192,6 +192,30 @@ describe("admin API", () => {
     expect(calls.some((c) => c.sql.includes("DELETE") && c.sql.includes("auth_sessions"))).toBe(
       true,
     );
+    expect(
+      calls.some((c) => c.sql.includes("DELETE") && c.sql.includes("oauth_access_tokens")),
+    ).toBe(true);
+    expect(
+      calls.some((c) => c.sql.includes("DELETE") && c.sql.includes("oauth_refresh_tokens")),
+    ).toBe(true);
+  });
+
+  it("is_active=false で OAuth トークンも消す", async () => {
+    const res = await req("/api/admin/users/9/flags", {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${await token()}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ is_active: false }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls.some((c) => c.sql.includes("DELETE") && c.sql.includes("auth_sessions"))).toBe(
+      true,
+    );
+    expect(
+      calls.some((c) => c.sql.includes("DELETE") && c.sql.includes("oauth_access_tokens")),
+    ).toBe(true);
   });
 
   it("SQS 投入失敗時は同期 hard-delete にフォールバックする", async () => {

--- a/apps/api/test/apikeys.test.ts
+++ b/apps/api/test/apikeys.test.ts
@@ -1,11 +1,28 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { authRoutes } from "../src/features/auth/routes";
 import { signAccessToken } from "./helpers/auth";
+import { executeFakePgQuery, type PgQueryInput } from "./helpers/pg-fake";
+
+vi.mock("pg", () => {
+  class FakeClient {
+    async connect() {}
+    async end() {}
+    async query(sqlOrConfig: unknown, args: unknown[] = []) {
+      return executeFakePgQuery({
+        sqlOrConfig: sqlOrConfig as PgQueryInput,
+        args,
+        rowsFor: () => [],
+      });
+    }
+  }
+  return { default: { Client: FakeClient } };
+});
 
 const SECRET = "test-jwt-secret-apikeys";
 const ENV = {
   ENVIRONMENT: "development",
   AUTH_JWT_SECRET: SECRET,
+  HYPERDRIVE: { connectionString: "postgres://fake/db" },
 } as unknown as Record<string, unknown>;
 
 async function accessToken(userId = 5) {

--- a/apps/api/test/auth-email-change.test.ts
+++ b/apps/api/test/auth-email-change.test.ts
@@ -2,13 +2,18 @@ import { describe, it, expect, vi } from "vitest";
 import { authRoutes } from "../src/features/auth/routes";
 import { buildPasswordResetLink, buildEmailChangeLink } from "../src/lib/auth-email";
 import { signAccessToken } from "./helpers/auth";
+import { executeFakePgQuery, type PgQueryInput } from "./helpers/pg-fake";
 
 vi.mock("pg", () => {
   class FakeClient {
     async connect() {}
     async end() {}
-    async query() {
-      return { rows: [], rowCount: 0 };
+    async query(sqlOrConfig: unknown, args: unknown[] = []) {
+      return executeFakePgQuery({
+        sqlOrConfig: sqlOrConfig as PgQueryInput,
+        args,
+        rowsFor: () => [],
+      });
     }
   }
   return { default: { Client: FakeClient } };

--- a/apps/api/test/auth-refresh.test.ts
+++ b/apps/api/test/auth-refresh.test.ts
@@ -57,6 +57,8 @@ describe("POST /tokens refresh", () => {
     const j = await res.json();
     expect(j.error.code).toBe("AUTHENTICATION_FAILED");
     expect(j.error.message).toBe("Invalid refresh token");
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie.toLowerCase()).toMatch(/vq_refresh=.*max-age=0|vq_refresh=;/);
   });
 
   it("旧 refresh_token cookie は廃止", async () => {
@@ -131,5 +133,7 @@ describe("POST /tokens refresh", () => {
           call.sql.includes("family_id"),
       ),
     ).toBe(true);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie.toLowerCase()).toContain("vq_refresh=");
   });
 });

--- a/apps/api/test/auth-session-hardening.test.ts
+++ b/apps/api/test/auth-session-hardening.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { authRoutes } from "../src/features/auth/routes";
+import { signAccessToken } from "./helpers/auth";
+import {
+  executeFakePgQuery,
+  type MatchableSql,
+  type PgQueryInput,
+  type QueryCall,
+} from "./helpers/pg-fake";
+
+const calls: QueryCall[] = [];
+let rowsFor: (sql: MatchableSql, args: unknown[]) => Record<string, unknown>[];
+
+vi.mock("pg", () => {
+  class FakeClient {
+    async connect() {}
+    async end() {}
+    async query(sqlOrConfig: unknown, args: unknown[] = []) {
+      return executeFakePgQuery({
+        calls,
+        sqlOrConfig: sqlOrConfig as PgQueryInput,
+        args,
+        rowsFor,
+        defaultActiveTestSession: false,
+      });
+    }
+  }
+  return { default: { Client: FakeClient } };
+});
+
+const SECRET = "test-session-hardening";
+const ENV = {
+  ENVIRONMENT: "development",
+  AUTH_JWT_SECRET: SECRET,
+  HYPERDRIVE: { connectionString: "postgres://fake/db" },
+} as unknown as Record<string, unknown>;
+
+beforeEach(() => {
+  calls.length = 0;
+  rowsFor = () => [];
+});
+
+describe("JWT sid session binding", () => {
+  it("失効済み sid の access JWT は 401", async () => {
+    const token = await signAccessToken(SECRET, 5, "videoq", "revoked-session");
+    const res = await authRoutes.request("/api/auth/me", {
+      headers: { authorization: `Bearer ${token}` },
+    }, ENV);
+    expect(res.status).toBe(401);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes("FROM auth_sessions") &&
+          c.sql.includes("s.id = $1") &&
+          c.args[0] === "revoked-session",
+      ),
+    ).toBe(true);
+  });
+
+  it("有効な sid なら認証を通過する", async () => {
+    rowsFor = (sql, args) => {
+      if (
+        sql.includes("FROM auth_sessions") &&
+        sql.includes("s.id = $1") &&
+        args[0] === "live-session"
+      ) {
+        return [{ ok: 1 }];
+      }
+      return [];
+    };
+    const token = await signAccessToken(SECRET, 5, "videoq", "live-session");
+    // 認証後のバリデーションまで到達すれば sid チェックは成功している。
+    const res = await authRoutes.request("/api/auth/me/email", {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ email: "not-an-email" }),
+    }, ENV);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("credential change revokes sessions and OAuth", () => {
+  it("password reset 成功後にセッションと OAuth を revoke する", async () => {
+    rowsFor = (sql) => {
+      if (sql.includes("UPDATE auth_action_tokens") && sql.includes("RETURNING")) {
+        return [{ user_id: 9, payload: {} }];
+      }
+      if (sql.includes("UPDATE users") && sql.includes("password")) {
+        return [{ id: 9 }];
+      }
+      return [];
+    };
+    const res = await authRoutes.request("/api/auth/password-resets/opaque-token", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ new_password: "CorrectHorseBattery1!" }),
+    }, ENV);
+    expect(res.status).toBe(200);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes("UPDATE auth_sessions") &&
+          c.sql.includes("user_id = $1") &&
+          c.args[0] === 9,
+      ),
+    ).toBe(true);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes("delete") &&
+          c.sql.includes("oauth_access_tokens") &&
+          c.args.includes(9),
+      ),
+    ).toBe(true);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes("delete") &&
+          c.sql.includes("oauth_refresh_tokens") &&
+          c.args.includes(9),
+      ),
+    ).toBe(true);
+  });
+
+  it("email change 成功後にセッションと OAuth を revoke する", async () => {
+    rowsFor = (sql) => {
+      if (sql.includes("UPDATE auth_action_tokens") && sql.includes("RETURNING")) {
+        return [{ user_id: 11, payload: { email: "new@example.com" } }];
+      }
+      if (sql.includes("pending_email") || sql.includes("UPDATE users")) {
+        return [{ id: 11 }];
+      }
+      return [];
+    };
+    const res = await authRoutes.request("/api/auth/email-change/opaque-token", {
+      method: "PATCH",
+    }, ENV);
+    expect(res.status).toBe(200);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes("UPDATE auth_sessions") &&
+          c.sql.includes("user_id = $1") &&
+          c.args[0] === 11,
+      ),
+    ).toBe(true);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes("delete") &&
+          c.sql.includes("oauth_access_tokens") &&
+          c.args.includes(11),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/api/test/chat-history.test.ts
+++ b/apps/api/test/chat-history.test.ts
@@ -185,13 +185,14 @@ describe("DELETE /api/chat/groups/:id/history/", () => {
     expect(res.status).toBe(204);
     expect(await res.text()).toBe("");
 
-    const sqls = calls.map((c) => c.sql.replace(/\s+/g, " ").trim());
+    const txnCalls = calls.filter((c) => !c.sql.includes("FROM auth_sessions"));
+    const sqls = txnCalls.map((c) => c.sql.replace(/\s+/g, " ").trim());
     expect(sqls[0]).toBe("begin");
     expect(sqls[1]).toContain("video_groups");
     expect(sqls[2]).toContain("chat_log_evaluations");
     expect(sqls[3]).toContain("chat_logs");
     expect(sqls[4]).toBe("commit");
-    expect(calls[1].args.slice(0, 2)).toEqual([3, 5]);
+    expect(txnCalls[1].args.slice(0, 2)).toEqual([3, 5]);
   });
 
   it("グループが無ければ ROLLBACK して 404", async () => {

--- a/apps/api/test/helpers/auth.ts
+++ b/apps/api/test/helpers/auth.ts
@@ -1,12 +1,16 @@
 import { SignJWT } from "jose";
+import { TEST_AUTH_SESSION_ID } from "./pg-fake";
+
+export { TEST_AUTH_SESSION_ID };
 
 export async function signAccessToken(
   secret: string,
   userId = 5,
   issuer = "videoq",
+  sessionId = TEST_AUTH_SESSION_ID,
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
-  return new SignJWT({ sid: "test-session" })
+  return new SignJWT({ sid: sessionId })
     .setProtectedHeader({ alg: "HS256", typ: "JWT" })
     .setSubject(String(userId))
     .setIssuer(issuer)

--- a/apps/api/test/helpers/pg-fake.ts
+++ b/apps/api/test/helpers/pg-fake.ts
@@ -52,6 +52,19 @@ function toPgRows(
   return rawRows.map((r) => (Array.isArray(r) ? r : Object.values(r as Record<string, unknown>)));
 }
 
+/** JWT test helper (`helpers/auth.ts`) が埋め込む既定 sid。 */
+export const TEST_AUTH_SESSION_ID = "test-session";
+
+/** Access JWT の sid 有効性チェック SQL か。 */
+export function isAuthSessionActiveSql(sql: MatchableSql): boolean {
+  return (
+    sql.includes("FROM auth_sessions") &&
+    sql.includes("s.id = $1") &&
+    sql.includes("s.user_id = $2") &&
+    sql.includes("revoked_at IS NULL")
+  );
+}
+
 /**
  * Shared FakeClient.query implementation. Call from inside `vi.mock("pg")` factories.
  */
@@ -65,6 +78,8 @@ export function executeFakePgQuery(opts: {
     args: unknown[],
     rows: Record<string, unknown>[],
   ) => number;
+  /** When true (default), empty rows for `test-session` sid probes count as active. */
+  defaultActiveTestSession?: boolean;
 }) {
   const { sql, args: a, rowMode } = normalizePgQuery(opts.sqlOrConfig, opts.args ?? []);
   const matchSql = matchableSql(sql);
@@ -72,7 +87,15 @@ export function executeFakePgQuery(opts: {
   if (/^\s*(BEGIN|COMMIT|ROLLBACK)\s*$/i.test(sql)) {
     return { rows: [], rowCount: 0 };
   }
-  const rawRows = opts.rowsFor(matchSql, a);
+  let rawRows = opts.rowsFor(matchSql, a);
+  if (
+    opts.defaultActiveTestSession !== false &&
+    rawRows.length === 0 &&
+    isAuthSessionActiveSql(matchSql) &&
+    a[0] === TEST_AUTH_SESSION_ID
+  ) {
+    rawRows = [{ ok: 1 }];
+  }
   const objectRows = rawRows.every(Array.isArray)
     ? []
     : (rawRows as Record<string, unknown>[]);

--- a/apps/api/test/oauth-active-user.test.ts
+++ b/apps/api/test/oauth-active-user.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { requireAuth, oauthBearerMethod } from "../src/middleware/auth";
+import {
+  executeFakePgQuery,
+  type MatchableSql,
+  type PgQueryInput,
+  type QueryCall,
+} from "./helpers/pg-fake";
+import { sha256Hex } from "../src/shared/crypto";
+
+const calls: QueryCall[] = [];
+let rowsFor: (sql: MatchableSql, args: unknown[]) => Record<string, unknown>[];
+
+vi.mock("pg", () => {
+  class FakeClient {
+    async connect() {}
+    async end() {}
+    async query(sqlOrConfig: unknown, args: unknown[] = []) {
+      return executeFakePgQuery({
+        calls,
+        sqlOrConfig: sqlOrConfig as PgQueryInput,
+        args,
+        rowsFor,
+      });
+    }
+  }
+  return { default: { Client: FakeClient } };
+});
+
+const ENV = {
+  ENVIRONMENT: "development",
+  AUTH_JWT_SECRET: "unused",
+  HYPERDRIVE: { connectionString: "postgres://fake/db" },
+} as unknown as Record<string, unknown>;
+
+const app = new Hono();
+app.get("/probe", requireAuth(oauthBearerMethod), (c) => c.json({ ok: true }));
+
+beforeEach(() => {
+  calls.length = 0;
+  rowsFor = () => [];
+});
+
+describe("OAuth bearer requires active user", () => {
+  it("is_active を JOIN した解決に失敗すると 401", async () => {
+    const raw = "oauth-inactive-user-token";
+    const checksum = await sha256Hex(raw);
+    // 行を返さない = inactive / missing
+    rowsFor = (sql, args) => {
+      if (sql.includes("oauth_access_tokens") && args[0] === checksum) return [];
+      return [];
+    };
+    const res = await app.request(
+      "/probe",
+      { headers: { Authorization: `Bearer ${raw}` } },
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes("oauth_access_tokens") &&
+          c.sql.includes("is_active"),
+      ),
+    ).toBe(true);
+  });
+
+  it("active user なら 200", async () => {
+    const raw = "oauth-active-user-token";
+    const checksum = await sha256Hex(raw);
+    rowsFor = (sql, args) => {
+      if (sql.includes("oauth_access_tokens") && args.includes(checksum)) {
+        return [{ user_id: 4, scope: "mcp" }];
+      }
+      return [];
+    };
+    const res = await app.request(
+      "/probe",
+      { headers: { Authorization: `Bearer ${raw}` } },
+      ENV,
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/test/oauth-tokens.test.ts
+++ b/apps/api/test/oauth-tokens.test.ts
@@ -96,11 +96,17 @@ describe("GET /api/oauth/tokens/", () => {
 });
 
 describe("DELETE /api/oauth/tokens/:id/", () => {
-  it("returns 204 when the owner revokes a token", async () => {
-    rowsFor = (sql) =>
-      sql.includes("oauth_access_tokens") && sql.includes("delete")
-        ? [{ id: 11 }]
-        : [];
+  it("returns 204 and revokes refresh tokens for the same app", async () => {
+    rowsFor = (sql) => {
+      if (
+        sql.includes("oauth_access_tokens") &&
+        sql.includes("select") &&
+        !sql.includes("delete")
+      ) {
+        return [{ id: 11, application_id: 3 }];
+      }
+      return [];
+    };
     const res = await oauthRoutes.request(
       "/api/oauth/tokens/11",
       {
@@ -110,10 +116,18 @@ describe("DELETE /api/oauth/tokens/:id/", () => {
       ENV,
     );
     expect(res.status).toBe(204);
-    const del = calls.find((c) =>
-      c.sql.includes("oauth_access_tokens") && c.sql.includes("delete"),
-    );
-    expect(del?.args).toEqual([11, 7]);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes("oauth_refresh_tokens") && c.sql.includes("delete"),
+      ),
+    ).toBe(true);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes("oauth_access_tokens") && c.sql.includes("delete"),
+      ),
+    ).toBe(true);
   });
 
   it("returns 404 when token is missing", async () => {

--- a/apps/api/test/searchapi-key.test.ts
+++ b/apps/api/test/searchapi-key.test.ts
@@ -1,12 +1,29 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { authRoutes } from "../src/features/auth/routes";
 import { signAccessToken } from "./helpers/auth";
+import { executeFakePgQuery, type PgQueryInput } from "./helpers/pg-fake";
+
+vi.mock("pg", () => {
+  class FakeClient {
+    async connect() {}
+    async end() {}
+    async query(sqlOrConfig: unknown, args: unknown[] = []) {
+      return executeFakePgQuery({
+        sqlOrConfig: sqlOrConfig as PgQueryInput,
+        args,
+        rowsFor: () => [],
+      });
+    }
+  }
+  return { default: { Client: FakeClient } };
+});
 
 const SECRET = "test-searchapi-secret";
-const ENV = { ENVIRONMENT: "development", AUTH_JWT_SECRET: SECRET } as unknown as Record<
-  string,
-  unknown
->;
+const ENV = {
+  ENVIRONMENT: "development",
+  AUTH_JWT_SECRET: SECRET,
+  HYPERDRIVE: { connectionString: "postgres://fake/db" },
+} as unknown as Record<string, unknown>;
 
 async function accessToken() {
   return signAccessToken(SECRET);

--- a/apps/api/test/videos-multipart.test.ts
+++ b/apps/api/test/videos-multipart.test.ts
@@ -3,8 +3,10 @@ import { videoRoutes } from "../src/features/videos/routes";
 import { signAccessToken } from "./helpers/auth";
 
 import {
+  isAuthSessionActiveSql,
   matchableSql,
   normalizePgQuery,
+  TEST_AUTH_SESSION_ID,
   type MatchableSql,
   type PgQueryInput,
 } from "./helpers/pg-fake";
@@ -61,7 +63,10 @@ async function accessToken(userId = 5) {
 
 beforeEach(() => {
   putMock.mockReset().mockResolvedValue(undefined);
-  queryMock.mockReset().mockImplementation((sql: MatchableSql) => {
+  queryMock.mockReset().mockImplementation((sql: MatchableSql, args: unknown[] = []) => {
+    if (isAuthSessionActiveSql(sql) && args[0] === TEST_AUTH_SESSION_ID) {
+      return { rows: [{ ok: 1 }], rowCount: 1 };
+    }
     if (sql.includes("max_video_upload_size_mb")) {
       return { rows: [{ max_video_upload_size_mb: 500 }], rowCount: 1 };
     }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,7 +5,7 @@ import { Link, useI18nNavigate } from '@/lib/i18n';
 import { useTranslation } from 'react-i18next';
 import { useAuthForm } from '@/hooks/useAuthForm';
 import { apiClient } from '@/lib/api';
-import { authMeQueryOptions } from '@/lib/authQuery';
+import { queryKeys } from '@/lib/queryKeys';
 import { Eye, EyeOff } from 'lucide-react';
 import { InlineSpinner } from '@/components/common/InlineSpinner';
 import { AuthLayout } from '@/components/layout/AuthLayout';
@@ -37,7 +37,10 @@ export default function LoginPage() {
   const { formData, error, isLoading, handleChange, handleSubmit } = useAuthForm({
     onSubmit: async (data) => {
       await apiClient.login(data);
-      await queryClient.fetchQuery(authMeQueryOptions);
+      // AppNav/Home may already have cached auth.me=null (staleTime=60s).
+      // fetchQuery would reuse that and leave the UI logged-out until reload.
+      const user = await apiClient.getMe();
+      queryClient.setQueryData(queryKeys.auth.me, user);
     },
     initialData: { username: '', password: '' },
     onSuccessRedirect: () => {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -37,8 +37,9 @@ export default function LoginPage() {
   const { formData, error, isLoading, handleChange, handleSubmit } = useAuthForm({
     onSubmit: async (data) => {
       await apiClient.login(data);
-      // AppNav/Home may already have cached auth.me=null (staleTime=60s).
-      // fetchQuery would reuse that and leave the UI logged-out until reload.
+      // Cancel in-flight getMeOrNull (may still resolve to null) and replace the
+      // stale auth.me=null cache so Home/Nav see the signed-in user immediately.
+      await queryClient.cancelQueries({ queryKey: queryKeys.auth.me });
       const user = await apiClient.getMe();
       queryClient.setQueryData(queryKeys.auth.me, user);
     },

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -90,7 +90,7 @@ describe('LoginPage', () => {
     fireEvent.click(submitButton)
 
     await waitFor(() => {
-      expect(apiClient.getMeOrNull).toHaveBeenCalled()
+      expect(apiClient.getMe).toHaveBeenCalled()
       expect(mockNavigate).toHaveBeenCalledWith('/')
     })
   })


### PR DESCRIPTION
## Summary
- Fix login UI staying logged-out until reload by canceling in-flight `auth.me` queries and writing fresh user data into the React Query cache.
- Bind access JWTs to active `auth_sessions.sid`, and revoke app sessions plus OAuth/MCP tokens on password reset, email change, and account deactivation.
- Require `users.is_active` for OAuth bearer resolution; Connected Apps revoke now drops refresh tokens for the same application. Shared refresh-cookie helpers and clearer dead-cookie clearing on failed refresh.

## Test plan
- [ ] Log in on a page that already queried `auth.me` as null — Home/Nav should show signed-in state without hard reload
- [ ] After password reset / email change confirm, existing refresh cookies and OAuth/MCP tokens no longer work
- [ ] After admin `is_active=false` or user delete lock, OAuth bearer and app JWT fail
- [ ] Logout invalidates access JWT immediately (sid revoked)
- [ ] `npm test --workspace apps/api` (or `cd apps/api && npm test`)


Made with [Cursor](https://cursor.com)