### PR TITLE
fix(cd): detect path changes on merge commits for CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,11 +30,19 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
-      # workflow_run: omit base so paths-filter uses the GitHub API file list.
+      # workflow_run has no push before/after. Merge commits also have an empty
+      # `git log -n1 --name-status`, so the default "last commit" fallback
+      # always reports 0 files. Compare first-parent (previous main tip) → HEAD.
+      - name: Resolve paths-filter base
+        id: path_base
+        if: github.event_name != 'workflow_dispatch'
+        run: echo "sha=$(git rev-parse HEAD^1)" >> "$GITHUB_OUTPUT"
       - uses: dorny/paths-filter@v3
         id: filter
         if: github.event_name != 'workflow_dispatch'
         with:
+          base: ${{ steps.path_base.outputs.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             api:
               - 'apps/api/**'


### PR DESCRIPTION
## Summary
- CD after #814 skipped API deploy because `dorny/paths-filter` on `workflow_run` fell back to “last commit” and merge commits expose **0 files**.
- Resolve `base` as `HEAD^1` (previous main tip) and `ref` as the CI head SHA so `apps/api/**` changes are detected again.

## Test plan
- [ ] Merge this PR and confirm Detect Changes sets `api=true` when API files changed
- [ ] Confirm a docs-only / frontend-only main merge still skips API deploy
- [ ] Manually run **Actions → CD → Run workflow** on `main` to deploy the skipped #814 API changes


Made with [Cursor](https://cursor.com)