### PR TITLE
fix(cd): npm ci before Workers deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,6 +116,11 @@ jobs:
           node-version: "22"
           cache: npm
           cache-dependency-path: apps/api/package-lock.json
+      # wrangler-action needs local node_modules; without npm ci it falls back to
+      # installing wrangler@3.x which conflicts with @cloudflare/workers-types@5.
+      - name: Install API dependencies
+        working-directory: apps/api
+        run: npm ci
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
## Summary
- After #815, CD correctly detected API changes, but **Deploy API** failed: `wrangler-action` had no local `node_modules`, tried to install `wrangler@3.90.0`, and hit an `ERESOLVE` conflict with `@cloudflare/workers-types@5`.
- Add `npm ci` in `apps/api` before deploy so the project’s Wrangler 4 is used.

## Test plan
- [ ] Merge and confirm CD **Deploy API (Cloudflare Workers)** succeeds
- [ ] Confirm Workers production deploy includes #814 auth hardening


Made with [Cursor](https://cursor.com)