### PR TITLE
refactor(api): mount Hono features with prefix routes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,19 +12,22 @@ import { groupRoutes } from "./features/groups/routes";
 import { tagRoutes } from "./features/tags/routes";
 import { membershipRoutes } from "./features/membership/routes";
 import { videoRoutes } from "./features/videos/routes";
-import { chatRoutes } from "./features/chat/routes";
+import { chatCompletionsRoutes, chatRoutes } from "./features/chat/routes";
 import { evaluationRoutes } from "./features/evaluation/routes";
 import { plogRoutes } from "./features/plog/routes";
-import { oauthRoutes } from "./features/oauth/routes";
+import { oauthRoutes, oauthWellKnownRoutes } from "./features/oauth/routes";
 import { oauthSupportRoutes } from "./features/oauth/support-routes";
-import { oauthOidcRoutes } from "./features/oauth/oidc";
+import {
+  oauthOidcRoutes,
+  oauthOidcWellKnownRoutes,
+} from "./features/oauth/oidc";
 import { mcpRoutes } from "./features/mcp/routes";
 import { mediaRoutes } from "./features/media/routes";
 import { adminRoutes } from "./features/admin/routes";
 import { schemaRoutes } from "./features/schema/routes";
 
 /**
- * Hono アプリの組み立て。全ドメインは features/* にマウントする。
+ * Hono アプリの組み立て。全ドメインは features/* に prefix マウントする。
  * URL 契約は trailing slash なし（クライアント・emit 側も同じ正本に揃える）。
  */
 export function createApp() {
@@ -37,21 +40,25 @@ export function createApp() {
   app.onError(onError);
 
   app.route("/", healthRoutes);
-  app.route("/", authRoutes);
-  app.route("/", groupRoutes);
-  app.route("/", tagRoutes);
-  app.route("/", membershipRoutes);
-  app.route("/", videoRoutes);
-  app.route("/", chatRoutes);
-  app.route("/", evaluationRoutes);
-  app.route("/", plogRoutes);
-  app.route("/", oauthRoutes);
-  app.route("/", oauthSupportRoutes);
-  app.route("/", oauthOidcRoutes);
-  app.route("/", mcpRoutes);
-  app.route("/", mediaRoutes);
-  app.route("/", adminRoutes);
-  app.route("/", schemaRoutes);
+  app.route("/", oauthWellKnownRoutes);
+  app.route("/", oauthOidcWellKnownRoutes);
+
+  app.route("/api/auth", authRoutes);
+  app.route("/api/videos", videoRoutes);
+  app.route("/api/videos", tagRoutes);
+  app.route("/api/videos", groupRoutes);
+  app.route("/api/videos", membershipRoutes);
+  app.route("/api/videos", plogRoutes);
+  app.route("/api/chat", chatRoutes);
+  app.route("/api/v1/chat", chatCompletionsRoutes);
+  app.route("/api/evaluation", evaluationRoutes);
+  app.route("/api/oauth", oauthRoutes);
+  app.route("/api/oauth", oauthSupportRoutes);
+  app.route("/api/oauth", oauthOidcRoutes);
+  app.route("/api/mcp", mcpRoutes);
+  app.route("/api/media", mediaRoutes);
+  app.route("/api/admin", adminRoutes);
+  app.route("/api", schemaRoutes);
 
   registerOpenApiDoc(app);
 
@@ -59,3 +66,5 @@ export function createApp() {
 
   return app;
 }
+
+export type AppType = ReturnType<typeof createApp>;

--- a/apps/api/src/features/admin/routes.ts
+++ b/apps/api/src/features/admin/routes.ts
@@ -34,7 +34,7 @@ import type { AppEnv } from "../../types/bindings";
 export const adminRoutes = createFeatureRouter();
 
 const requireSuperuser = createMiddleware<AppEnv>(async (c, next) => {
-  const userId = c.get("userId");
+  const userId = c.var.userId;
   if (userId == null) {
     return c.json(
       toErrorBody("UNAUTHORIZED", "Authentication credentials were not provided."),
@@ -57,7 +57,7 @@ const adminGuards = [
 
 const listUsersRoute = createRoute({
   method: "get",
-  path: "/api/admin/users",
+  path: "/users",
   tags: ["Admin"],
   summary: "List users (superuser)",
   middleware: [...adminGuards] as const,
@@ -83,7 +83,7 @@ adminRoutes.openapi(listUsersRoute, async (c) => {
 
 const getUserRoute = createRoute({
   method: "get",
-  path: "/api/admin/users/{id}",
+  path: "/users/{id}",
   tags: ["Admin"],
   summary: "Get user (superuser)",
   middleware: [...adminGuards] as const,
@@ -103,7 +103,7 @@ adminRoutes.openapi(getUserRoute, async (c) => {
 
 const patchQuotaRoute = createRoute({
   method: "patch",
-  path: "/api/admin/users/{id}/quota",
+  path: "/users/{id}/quota",
   tags: ["Admin"],
   summary: "Patch user quota",
   middleware: [...adminGuards] as const,
@@ -130,7 +130,7 @@ adminRoutes.openapi(patchQuotaRoute, async (c) => {
 
 const patchUsageRoute = createRoute({
   method: "patch",
-  path: "/api/admin/users/{id}/usage",
+  path: "/users/{id}/usage",
   tags: ["Admin"],
   summary: "Patch user usage counters",
   middleware: [...adminGuards] as const,
@@ -157,7 +157,7 @@ adminRoutes.openapi(patchUsageRoute, async (c) => {
 
 const patchFlagsRoute = createRoute({
   method: "patch",
-  path: "/api/admin/users/{id}/flags",
+  path: "/users/{id}/flags",
   tags: ["Admin"],
   summary: "Patch user flags",
   middleware: [...adminGuards] as const,
@@ -178,7 +178,7 @@ const patchFlagsRoute = createRoute({
 adminRoutes.openapi(patchFlagsRoute, async (c) => {
   const { id } = c.req.valid("param");
   const body = c.req.valid("json");
-  const res = await adminService.patchFlags(c.env, c.get("userId")!, id, body);
+  const res = await adminService.patchFlags(c.env, c.var.userId!, id, body);
   if ("notFound" in res) throw apiNotFound("User not found");
   if ("selfLockout" in res) {
     throw apiBadRequest(
@@ -191,7 +191,7 @@ adminRoutes.openapi(patchFlagsRoute, async (c) => {
 
 const deleteUserRoute = createRoute({
   method: "delete",
-  path: "/api/admin/users/{id}",
+  path: "/users/{id}",
   tags: ["Admin"],
   summary: "Hard-delete user (superuser)",
   middleware: [...adminGuards] as const,
@@ -209,7 +209,7 @@ const deleteUserRoute = createRoute({
 
 adminRoutes.openapi(deleteUserRoute, async (c) => {
   const { id } = c.req.valid("param");
-  const res = await adminService.deleteUser(c.env, c.get("userId")!, id);
+  const res = await adminService.deleteUser(c.env, c.var.userId!, id);
   if ("self" in res) {
     throw apiBadRequest("Cannot delete your own account via Admin.", "CANNOT_DELETE_SELF");
   }
@@ -222,7 +222,7 @@ adminRoutes.openapi(deleteUserRoute, async (c) => {
 
 const reindexRoute = createRoute({
   method: "post",
-  path: "/api/admin/embeddings/reindex-all",
+  path: "/embeddings/reindex-all",
   tags: ["Admin"],
   summary: "Enqueue full embedding reindex",
   middleware: [...adminGuards] as const,

--- a/apps/api/src/features/auth/routes.ts
+++ b/apps/api/src/features/auth/routes.ts
@@ -98,7 +98,7 @@ const passwordResetThrottle = createMiddleware<AppEnv>(async (c, next) => {
 });
 
 const emailChangeThrottle = createMiddleware<AppEnv>(async (c, next) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const denied = await enforceThrottles(c.env, [
     { scope: "email_change_user", ident: String(userId) },
   ]);
@@ -120,7 +120,7 @@ async function enforceValidatedIdentity(
 // --- Sessions ---
 const loginRoute = createRoute({
   method: "post",
-  path: "/api/auth/sessions",
+  path: "/sessions",
   tags: ["Auth"],
   summary: "Login and create a rotating refresh session",
   middleware: [requireJson, loginThrottle] as const,
@@ -158,7 +158,7 @@ authRoutes.openapi(loginRoute, async (c) => {
 
 const logoutRoute = createRoute({
   method: "delete",
-  path: "/api/auth/sessions",
+  path: "/sessions",
   tags: ["Auth"],
   summary: "Revoke refresh session",
   middleware: [requireTrustedOrigin] as const,
@@ -172,7 +172,7 @@ authRoutes.openapi(logoutRoute, async (c) => {
 
 const refreshRoute = createRoute({
   method: "post",
-  path: "/api/auth/tokens",
+  path: "/tokens",
   tags: ["Auth"],
   summary: "Rotate tokens from refresh cookie",
   middleware: [requireTrustedOrigin] as const,
@@ -202,7 +202,7 @@ authRoutes.openapi(refreshRoute, async (c) => {
 // --- Email verification ---
 const verifyEmailRoute = createRoute({
   method: "patch",
-  path: "/api/auth/email-verifications/{token}",
+  path: "/email-verifications/{token}",
   tags: ["Auth"],
   summary: "Verify email",
   request: { params: actionTokenParamSchema },
@@ -224,7 +224,7 @@ authRoutes.openapi(verifyEmailRoute, async (c) => {
 // --- Password reset ---
 const requestPasswordResetRoute = createRoute({
   method: "post",
-  path: "/api/auth/password-resets",
+  path: "/password-resets",
   tags: ["Auth"],
   summary: "Request password reset email",
   middleware: [passwordResetThrottle] as const,
@@ -258,7 +258,7 @@ authRoutes.openapi(requestPasswordResetRoute, async (c) => {
 
 const confirmPasswordResetRoute = createRoute({
   method: "patch",
-  path: "/api/auth/password-resets/{token}",
+  path: "/password-resets/{token}",
   tags: ["Auth"],
   summary: "Confirm password reset",
   request: {
@@ -297,7 +297,7 @@ authRoutes.openapi(confirmPasswordResetRoute, async (c) => {
 // --- Email change ---
 const requestEmailChangeRoute = createRoute({
   method: "patch",
-  path: "/api/auth/me/email",
+  path: "/me/email",
   tags: ["Auth"],
   summary: "Request email change",
   middleware: [jwtOnly, emailChangeThrottle] as const,
@@ -320,7 +320,7 @@ authRoutes.openapi(requestEmailChangeRoute, async (c) => {
   if (throttled) return throttled;
   const res = await authService.requestEmailChange(
     c.env,
-    c.get("userId")!,
+    c.var.userId!,
     email,
   );
   if (!res.ok) {
@@ -348,7 +348,7 @@ authRoutes.openapi(requestEmailChangeRoute, async (c) => {
 
 const confirmEmailChangeRoute = createRoute({
   method: "patch",
-  path: "/api/auth/email-change/{token}",
+  path: "/email-change/{token}",
   tags: ["Auth"],
   summary: "Confirm email change",
   request: { params: actionTokenParamSchema },
@@ -367,7 +367,7 @@ authRoutes.openapi(confirmEmailChangeRoute, async (c) => {
 // --- Signup ---
 const signupRoute = createRoute({
   method: "post",
-  path: "/api/auth/users",
+  path: "/users",
   tags: ["Auth"],
   summary: "Sign up",
   middleware: [requireJson, signupThrottle] as const,
@@ -409,7 +409,7 @@ authRoutes.openapi(signupRoute, async (c) => {
 // --- API keys ---
 const listApiKeysRoute = createRoute({
   method: "get",
-  path: "/api/auth/api-keys",
+  path: "/api-keys",
   tags: ["Auth"],
   summary: "List API keys",
   middleware: [jwtOnly] as const,
@@ -419,12 +419,12 @@ const listApiKeysRoute = createRoute({
   },
 });
 authRoutes.openapi(listApiKeysRoute, async (c) => {
-  return c.json(await authService.listUserApiKeys(c.env, c.get("userId")!), 200);
+  return c.json(await authService.listUserApiKeys(c.env, c.var.userId!), 200);
 });
 
 const createApiKeyRoute = createRoute({
   method: "post",
-  path: "/api/auth/api-keys",
+  path: "/api-keys",
   tags: ["Auth"],
   summary: "Create API key",
   middleware: [jwtOnly] as const,
@@ -444,7 +444,7 @@ authRoutes.openapi(createApiKeyRoute, async (c) => {
   const { name, access_level } = c.req.valid("json");
   const res = await authService.createUserApiKey(
     c.env,
-    c.get("userId")!,
+    c.var.userId!,
     name,
     access_level,
   );
@@ -454,7 +454,7 @@ authRoutes.openapi(createApiKeyRoute, async (c) => {
 
 const revokeApiKeyRoute = createRoute({
   method: "delete",
-  path: "/api/auth/api-keys/{id}",
+  path: "/api-keys/{id}",
   tags: ["Auth"],
   summary: "Revoke API key",
   middleware: [jwtOnly] as const,
@@ -467,7 +467,7 @@ const revokeApiKeyRoute = createRoute({
 });
 authRoutes.openapi(revokeApiKeyRoute, async (c) => {
   const { id } = c.req.valid("param");
-  const ok = await authService.revokeUserApiKey(c.env, c.get("userId")!, id);
+  const ok = await authService.revokeUserApiKey(c.env, c.var.userId!, id);
   if (!ok) return apiError(c, 404, "API key not found");
   return c.body(null, 204);
 });
@@ -475,7 +475,7 @@ authRoutes.openapi(revokeApiKeyRoute, async (c) => {
 // --- SearchAPI key ---
 const searchApiKeyStatusRoute = createRoute({
   method: "get",
-  path: "/api/auth/searchapi-key",
+  path: "/searchapi-key",
   tags: ["Auth"],
   summary: "SearchAPI key status",
   middleware: [jwtOnly] as const,
@@ -486,14 +486,14 @@ const searchApiKeyStatusRoute = createRoute({
 });
 authRoutes.openapi(searchApiKeyStatusRoute, async (c) => {
   return c.json(
-    await authService.searchApiKeyStatus(c.env, c.get("userId")!),
+    await authService.searchApiKeyStatus(c.env, c.var.userId!),
     200,
   );
 });
 
 const saveSearchApiKeyRoute = createRoute({
   method: "put",
-  path: "/api/auth/searchapi-key",
+  path: "/searchapi-key",
   tags: ["Auth"],
   summary: "Save SearchAPI key",
   middleware: [jwtOnly] as const,
@@ -513,7 +513,7 @@ authRoutes.openapi(saveSearchApiKeyRoute, async (c) => {
   const { api_key } = c.req.valid("json");
   const res = await authService.saveUserSearchApiKey(
     c.env,
-    c.get("userId")!,
+    c.var.userId!,
     api_key,
   );
   if (!res.ok) {
@@ -527,7 +527,7 @@ authRoutes.openapi(saveSearchApiKeyRoute, async (c) => {
 
 const removeSearchApiKeyRoute = createRoute({
   method: "delete",
-  path: "/api/auth/searchapi-key",
+  path: "/searchapi-key",
   tags: ["Auth"],
   summary: "Delete SearchAPI key",
   middleware: [jwtOnly] as const,
@@ -537,7 +537,7 @@ const removeSearchApiKeyRoute = createRoute({
   },
 });
 authRoutes.openapi(removeSearchApiKeyRoute, async (c) => {
-  const ok = await authService.removeUserSearchApiKey(c.env, c.get("userId")!);
+  const ok = await authService.removeUserSearchApiKey(c.env, c.var.userId!);
   if (!ok) return apiError(c, 404, "User not found", "NOT_FOUND");
   return c.json({ message: "SearchAPI API key deleted." }, 200);
 });
@@ -545,7 +545,7 @@ authRoutes.openapi(removeSearchApiKeyRoute, async (c) => {
 // --- Me ---
 const meRoute = createRoute({
   method: "get",
-  path: "/api/auth/me",
+  path: "/me",
   tags: ["Auth"],
   summary: "Current user",
   middleware: [meAuth] as const,
@@ -556,7 +556,7 @@ const meRoute = createRoute({
   },
 });
 authRoutes.openapi(meRoute, async (c) => {
-  const user = await authService.getMe(c.env, c.get("userId")!);
+  const user = await authService.getMe(c.env, c.var.userId!);
   if (!user) return c.json(toErrorBody("NOT_FOUND", "Not found."), 404);
   return c.json({ data: user }, 200);
 });

--- a/apps/api/src/features/chat/routes.ts
+++ b/apps/api/src/features/chat/routes.ts
@@ -1,5 +1,6 @@
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { streamSSE } from "hono/streaming";
 import {
   requireAuth,
@@ -45,8 +46,12 @@ import * as messageService from "./message-service";
 /**
  * チャット系。全エンドポイント OpenAPI + Zod。
  * body 検証は createRoute（defaultHook）に一本化。
+ * `/api/chat` プレフィックスはアプリ側でマウントする。
  */
 export const chatRoutes = createFeatureRouter();
+
+/** OpenAI 互換 completions。`/api/v1/chat` プレフィックスはアプリ側でマウントする。 */
+export const chatCompletionsRoutes = createFeatureRouter();
 
 const chatAuth = requireAuth(apiKeyMethod, jwtMethod);
 const groupNotFound = () =>
@@ -54,7 +59,7 @@ const groupNotFound = () =>
 
 const historyRoute = createRoute({
   method: "get",
-  path: "/api/chat/groups/{groupId}/history",
+  path: "/groups/{groupId}/history",
   tags: ["Chat"],
   summary: "Chat history (or CSV download)",
   middleware: [chatAuth] as const,
@@ -77,7 +82,7 @@ const historyRoute = createRoute({
 });
 
 chatRoutes.openapi(historyRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { groupId } = c.req.valid("param");
   const query = c.req.valid("query");
 
@@ -109,7 +114,7 @@ const resetGuards = [chatAuth, requireScope()] as const;
 
 const resetHistoryRoute = createRoute({
   method: "delete",
-  path: "/api/chat/groups/{groupId}/history",
+  path: "/groups/{groupId}/history",
   tags: ["Chat"],
   summary: "Reset chat history",
   middleware: [...resetGuards] as const,
@@ -122,14 +127,14 @@ const resetHistoryRoute = createRoute({
 
 chatRoutes.openapi(resetHistoryRoute, async (c) => {
   const { groupId } = c.req.valid("param");
-  const res = await chatService.resetHistory(c.env, groupId, c.get("userId")!);
+  const res = await chatService.resetHistory(c.env, groupId, c.var.userId!);
   if ("notFound" in res) throw groupNotFound();
   return c.body(null, 204);
 });
 
 const analyticsRoute = createRoute({
   method: "get",
-  path: "/api/chat/groups/{groupId}/analytics",
+  path: "/groups/{groupId}/analytics",
   tags: ["Chat"],
   summary: "Chat analytics",
   middleware: [chatAuth] as const,
@@ -145,7 +150,7 @@ chatRoutes.openapi(analyticsRoute, async (c) => {
   const res = await chatService.analyticsForGroup(
     c.env,
     groupId,
-    c.get("userId")!,
+    c.var.userId!,
   );
   if ("notFound" in res) throw groupNotFound();
   return c.json(res, 200);
@@ -178,7 +183,7 @@ const feedbackGuards = [feedbackAuth, requireScope("chat_write")] as const;
 
 const feedbackRoute = createRoute({
   method: "patch",
-  path: "/api/chat/logs/{logId}/feedback",
+  path: "/logs/{logId}/feedback",
   tags: ["Chat"],
   summary: "Set chat log feedback",
   middleware: [...feedbackGuards] as const,
@@ -215,7 +220,7 @@ chatRoutes.openapi(feedbackRoute, async (c) => {
     logId,
     feedback as "good" | "bad" | null,
     {
-      userId: c.get("userId"),
+      userId: c.var.userId,
       shareSlug: c.req.query("share_slug") || c.req.query("share_token"),
     },
   );
@@ -244,7 +249,7 @@ const chatThrottle = createMiddleware<AppEnv>(async (c, next) => {
   const denied = await enforceThrottles(c.env, [
     {
       scope: "chat_authenticated",
-      ident: c.get("userId") != null ? String(c.get("userId")) : null,
+      ident: c.var.userId != null ? String(c.var.userId) : null,
     },
     {
       scope: "chat_share_token_ip",
@@ -266,7 +271,7 @@ const sendGuards = [
 
 const sendMessageRoute = createRoute({
   method: "post",
-  path: "/api/chat/messages",
+  path: "/messages",
   tags: ["Chat"],
   summary: "Send chat message (RAG / study)",
   middleware: [...sendGuards] as const,
@@ -283,17 +288,17 @@ const sendMessageRoute = createRoute({
 });
 chatRoutes.openapi(sendMessageRoute, async (c) => {
   const res = await messageService.sendChatMessage(c.env, {
-    userId: c.get("userId") ?? null,
+    userId: c.var.userId ?? null,
     body: c.req.valid("json"),
     shareSlug: shareSlugOf(c),
     locale: messageService.requestLocaleFromHeader(c.req.header("Accept-Language")),
   });
-  return c.json(res.body, res.status as Parameters<typeof c.json>[1]);
+  return c.json(res.body, res.status as ContentfulStatusCode);
 });
 
 const streamMessageRoute = createRoute({
   method: "post",
-  path: "/api/chat/messages/stream",
+  path: "/messages/stream",
   tags: ["Chat"],
   summary: "Stream chat message (SSE)",
   middleware: [...sendGuards] as const,
@@ -313,14 +318,14 @@ const streamMessageRoute = createRoute({
 });
 chatRoutes.openapi(streamMessageRoute, async (c) => {
   const res = await messageService.streamChatMessage(c.env, {
-    userId: c.get("userId") ?? null,
+    userId: c.var.userId ?? null,
     body: c.req.valid("json"),
     shareSlug: shareSlugOf(c),
     locale: messageService.requestLocaleFromHeader(c.req.header("Accept-Language")),
     clientSignal: c.req.raw.signal,
   });
   if (res.kind === "json") {
-    return c.json(res.body, res.status as Parameters<typeof c.json>[1]);
+    return c.json(res.body, res.status as ContentfulStatusCode);
   }
   c.header("Cache-Control", "no-cache");
   c.header("Content-Encoding", "Identity");
@@ -347,7 +352,7 @@ const completionsGuards = [
 
 const completionsRoute = createRoute({
   method: "post",
-  path: "/api/v1/chat/completions",
+  path: "/completions",
   tags: ["Chat"],
   summary: "OpenAI-compatible chat completions",
   middleware: [...completionsGuards] as const,
@@ -362,13 +367,13 @@ const completionsRoute = createRoute({
     400: errorResponse("Bad request"),
   },
 });
-chatRoutes.openapi(completionsRoute, async (c) => {
+chatCompletionsRoutes.openapi(completionsRoute, async (c) => {
   const res = await messageService.openAiChatCompletions(c.env, {
-    userId: c.get("userId") ?? null,
+    userId: c.var.userId ?? null,
     body: c.req.valid("json"),
     localeFallback: messageService.requestLocaleFromHeader(
       c.req.header("Accept-Language"),
     ),
   });
-  return c.json(res.body, res.status as Parameters<typeof c.json>[1]);
+  return c.json(res.body, res.status as ContentfulStatusCode);
 });

--- a/apps/api/src/features/evaluation/routes.ts
+++ b/apps/api/src/features/evaluation/routes.ts
@@ -29,7 +29,7 @@ const evalAuth = requireAuth(apiKeyMethod, jwtMethod);
 
 const summaryRoute = createRoute({
   method: "get",
-  path: "/api/evaluation/groups/{groupId}/summary",
+  path: "/groups/{groupId}/summary",
   tags: ["Evaluation"],
   summary: "Group evaluation summary",
   middleware: [evalAuth] as const,
@@ -46,7 +46,7 @@ evaluationRoutes.openapi(summaryRoute, async (c) => {
   const res = await evaluationService.summaryForGroup(
     c.env,
     groupId,
-    c.get("userId")!,
+    c.var.userId!,
   );
   if ("notFound" in res) throw apiNotFound("Group not found");
   return c.json(res, 200);
@@ -54,7 +54,7 @@ evaluationRoutes.openapi(summaryRoute, async (c) => {
 
 const logsRoute = createRoute({
   method: "get",
-  path: "/api/evaluation/groups/{groupId}/logs",
+  path: "/groups/{groupId}/logs",
   tags: ["Evaluation"],
   summary: "Group evaluation logs",
   middleware: [evalAuth] as const,
@@ -75,7 +75,7 @@ evaluationRoutes.openapi(logsRoute, async (c) => {
   const res = await evaluationService.logsForGroup(
     c.env,
     groupId,
-    c.get("userId")!,
+    c.var.userId!,
     limit,
     offset,
   );

--- a/apps/api/src/features/groups/routes.ts
+++ b/apps/api/src/features/groups/routes.ts
@@ -49,7 +49,7 @@ const groupWriteGuards = [
 
 const listGroupsRoute = createRoute({
   method: "get",
-  path: "/api/videos/groups",
+  path: "/groups",
   tags: ["Groups"],
   summary: "List groups",
   middleware: [groupAuth] as const,
@@ -61,7 +61,7 @@ const listGroupsRoute = createRoute({
 });
 
 groupRoutes.openapi(listGroupsRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { limit, offset } = parseLimitOffset(c);
   const { count, results } = await groupService.listGroups(
     c.env,
@@ -74,7 +74,7 @@ groupRoutes.openapi(listGroupsRoute, async (c) => {
 
 const sharedGroupRoute = createRoute({
   method: "get",
-  path: "/api/videos/groups/share/{slug}",
+  path: "/groups/share/{slug}",
   tags: ["Groups"],
   summary: "Get shared group by slug",
   request: {
@@ -99,7 +99,7 @@ groupRoutes.openapi(sharedGroupRoute, async (c) => {
 
 const getGroupRoute = createRoute({
   method: "get",
-  path: "/api/videos/groups/{id}",
+  path: "/groups/{id}",
   tags: ["Groups"],
   summary: "Get group detail",
   middleware: [groupAuth] as const,
@@ -111,7 +111,7 @@ const getGroupRoute = createRoute({
 });
 
 groupRoutes.openapi(getGroupRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const group = await groupService.getGroup(c.env, id, userId);
   if (!group) throw apiNotFound("Group not found");
@@ -120,7 +120,7 @@ groupRoutes.openapi(getGroupRoute, async (c) => {
 
 const createGroupRoute = createRoute({
   method: "post",
-  path: "/api/videos/groups",
+  path: "/groups",
   tags: ["Groups"],
   summary: "Create group",
   middleware: [...groupWriteGuards] as const,
@@ -137,7 +137,7 @@ const createGroupRoute = createRoute({
 });
 
 groupRoutes.openapi(createGroupRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const body = c.req.valid("json");
   const group = await groupService.createUserGroup(
     c.env,
@@ -150,7 +150,7 @@ groupRoutes.openapi(createGroupRoute, async (c) => {
 
 const patchGroupRoute = createRoute({
   method: "patch",
-  path: "/api/videos/groups/{id}",
+  path: "/groups/{id}",
   tags: ["Groups"],
   summary: "Partial update group",
   middleware: [...groupWriteGuards] as const,
@@ -168,7 +168,7 @@ const patchGroupRoute = createRoute({
 });
 
 groupRoutes.openapi(patchGroupRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const body = c.req.valid("json");
   const result = await groupService.updateUserGroup(c.env, id, userId, body);
@@ -178,7 +178,7 @@ groupRoutes.openapi(patchGroupRoute, async (c) => {
 
 const putGroupRoute = createRoute({
   method: "put",
-  path: "/api/videos/groups/{id}",
+  path: "/groups/{id}",
   tags: ["Groups"],
   summary: "Replace group",
   middleware: [...groupWriteGuards] as const,
@@ -196,7 +196,7 @@ const putGroupRoute = createRoute({
 });
 
 groupRoutes.openapi(putGroupRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const body = c.req.valid("json");
   const result = await groupService.updateUserGroup(c.env, id, userId, {
@@ -209,7 +209,7 @@ groupRoutes.openapi(putGroupRoute, async (c) => {
 
 const deleteGroupRoute = createRoute({
   method: "delete",
-  path: "/api/videos/groups/{id}",
+  path: "/groups/{id}",
   tags: ["Groups"],
   summary: "Delete group",
   middleware: [...groupWriteGuards] as const,
@@ -221,7 +221,7 @@ const deleteGroupRoute = createRoute({
 });
 
 groupRoutes.openapi(deleteGroupRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const res = await groupService.removeGroup(c.env, id, userId);
   if ("notFound" in res) throw apiNotFound("Group not found");
@@ -230,7 +230,7 @@ groupRoutes.openapi(deleteGroupRoute, async (c) => {
 
 const reorderRoute = createRoute({
   method: "patch",
-  path: "/api/videos/groups/order",
+  path: "/groups/order",
   tags: ["Groups"],
   summary: "Reorder groups",
   middleware: [...groupWriteGuards] as const,
@@ -247,7 +247,7 @@ const reorderRoute = createRoute({
 });
 
 groupRoutes.openapi(reorderRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { group_ids } = c.req.valid("json");
   const res = await groupService.reorderUserGroups(c.env, userId, group_ids);
   if ("mismatch" in res) {
@@ -258,7 +258,7 @@ groupRoutes.openapi(reorderRoute, async (c) => {
 
 const createShareRoute = createRoute({
   method: "post",
-  path: "/api/videos/groups/{id}/share",
+  path: "/groups/{id}/share",
   tags: ["Groups"],
   summary: "Create or update share link",
   middleware: [...groupWriteGuards] as const,
@@ -279,7 +279,7 @@ const createShareRoute = createRoute({
 });
 
 groupRoutes.openapi(createShareRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const { share_slug } = c.req.valid("json");
   const result = await groupService.saveShareLink(c.env, id, userId, share_slug);
@@ -293,7 +293,7 @@ groupRoutes.openapi(createShareRoute, async (c) => {
 
 const deleteShareRoute = createRoute({
   method: "delete",
-  path: "/api/videos/groups/{id}/share",
+  path: "/groups/{id}/share",
   tags: ["Groups"],
   summary: "Remove share link",
   middleware: [...groupWriteGuards] as const,
@@ -305,7 +305,7 @@ const deleteShareRoute = createRoute({
 });
 
 groupRoutes.openapi(deleteShareRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const result = await groupService.clearShareLink(c.env, id, userId);
   if ("notFound" in result) throw apiNotFound("Group not found");

--- a/apps/api/src/features/mcp/routes.ts
+++ b/apps/api/src/features/mcp/routes.ts
@@ -60,7 +60,7 @@ const mcpGuards = [mcpAuth, requireScope("write")] as const;
 
 const postMcpRoute = createRoute({
   method: "post",
-  path: "/api/mcp",
+  path: "/",
   tags: ["MCP"],
   summary: "MCP JSON-RPC (Streamable HTTP)",
   description:
@@ -82,7 +82,7 @@ const postMcpRoute = createRoute({
 
 mcpRoutes.openapi(postMcpRoute, async (c) => {
   const result = await handleMcpHttpPayload(
-    { env: c.env, userId: c.get("userId")! },
+    { env: c.env, userId: c.var.userId! },
     c.req.valid("json"),
   );
   if (result.kind === "accepted") return c.body(null, 202);
@@ -92,7 +92,7 @@ mcpRoutes.openapi(postMcpRoute, async (c) => {
 
 const getMcpRoute = createRoute({
   method: "get",
-  path: "/api/mcp",
+  path: "/",
   tags: ["MCP"],
   summary: "MCP GET (SSE not implemented)",
   middleware: [...mcpGuards] as const,
@@ -107,7 +107,7 @@ mcpRoutes.openapi(getMcpRoute, (c) =>
 
 const deleteMcpRoute = createRoute({
   method: "delete",
-  path: "/api/mcp",
+  path: "/",
   tags: ["MCP"],
   summary: "MCP session end (stateless 204)",
   middleware: [...mcpGuards] as const,

--- a/apps/api/src/features/media/routes.ts
+++ b/apps/api/src/features/media/routes.ts
@@ -43,8 +43,8 @@ const mediaAuth = createMiddleware<AppEnv>(async (c, next) => {
 const serveMedia = async (c: Context<AppEnv>) => {
   const path = mediaService.mediaPathFromUrl(new URL(c.req.url).pathname);
   const authz = await mediaService.authorizeMediaPath(c.env, path, {
-    userId: c.get("userId"),
-    shareGroupId: c.get("shareGroupId"),
+    userId: c.var.userId,
+    shareGroupId: c.var.shareGroupId,
   });
   if ("notFound" in authz) return c.body(null, 404);
 
@@ -66,4 +66,4 @@ const serveMedia = async (c: Context<AppEnv>) => {
   return c.redirect(url, 302);
 };
 
-mediaRoutes.get("/api/media/*", mediaAuth, serveMedia);
+mediaRoutes.get("/*", mediaAuth, serveMedia);

--- a/apps/api/src/features/media/service.ts
+++ b/apps/api/src/features/media/service.ts
@@ -117,7 +117,9 @@ export async function buildR2MediaResponse(
 
 export function mediaPathFromUrl(pathname: string): string {
   const prefix = "/api/media/";
-  return decodeURIComponent(
-    pathname.startsWith(prefix) ? pathname.slice(prefix.length) : "",
-  ).replace(/^\/+/, "");
+  // createApp 経由は `/api/media/...`、feature 単体テストはマウント後の相対 path。
+  const raw = pathname.startsWith(prefix)
+    ? pathname.slice(prefix.length)
+    : pathname.replace(/^\/+/, "");
+  return decodeURIComponent(raw).replace(/^\/+/, "");
 }

--- a/apps/api/src/features/membership/routes.ts
+++ b/apps/api/src/features/membership/routes.ts
@@ -33,7 +33,7 @@ const writeGuards = [
 
 const addTagsRoute = createRoute({
   method: "post",
-  path: "/api/videos/{videoId}/tags",
+  path: "/{videoId}/tags",
   tags: ["Membership"],
   summary: "Attach tags to a video",
   middleware: [...writeGuards] as const,
@@ -52,7 +52,7 @@ const addTagsRoute = createRoute({
 });
 
 membershipRoutes.openapi(addTagsRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { videoId } = c.req.valid("param");
   const { tag_ids } = c.req.valid("json");
   const res = await membershipService.addTagsToVideo(
@@ -74,7 +74,7 @@ membershipRoutes.openapi(addTagsRoute, async (c) => {
 
 const removeTagRoute = createRoute({
   method: "delete",
-  path: "/api/videos/{videoId}/tags/{tagId}",
+  path: "/{videoId}/tags/{tagId}",
   tags: ["Membership"],
   summary: "Detach a tag from a video",
   middleware: [...writeGuards] as const,
@@ -86,7 +86,7 @@ const removeTagRoute = createRoute({
 });
 
 membershipRoutes.openapi(removeTagRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { videoId, tagId } = c.req.valid("param");
   const res = await membershipService.removeTagFromVideo(
     c.env,
@@ -100,7 +100,7 @@ membershipRoutes.openapi(removeTagRoute, async (c) => {
 
 const reorderVideosRoute = createRoute({
   method: "patch",
-  path: "/api/videos/groups/{groupId}/videos/order",
+  path: "/groups/{groupId}/videos/order",
   tags: ["Membership"],
   summary: "Reorder videos in a group",
   middleware: [...writeGuards] as const,
@@ -119,7 +119,7 @@ const reorderVideosRoute = createRoute({
 });
 
 membershipRoutes.openapi(reorderVideosRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { groupId } = c.req.valid("param");
   const { video_ids } = c.req.valid("json");
   const res = await membershipService.reorderGroupVideos(
@@ -135,7 +135,7 @@ membershipRoutes.openapi(reorderVideosRoute, async (c) => {
 
 const addVideosBulkRoute = createRoute({
   method: "post",
-  path: "/api/videos/groups/{groupId}/videos",
+  path: "/groups/{groupId}/videos",
   tags: ["Membership"],
   summary: "Add videos to a group (bulk)",
   middleware: [...writeGuards] as const,
@@ -154,7 +154,7 @@ const addVideosBulkRoute = createRoute({
 });
 
 membershipRoutes.openapi(addVideosBulkRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { groupId } = c.req.valid("param");
   const { video_ids } = c.req.valid("json");
   const res = await membershipService.addVideosToGroupBulk(
@@ -176,7 +176,7 @@ membershipRoutes.openapi(addVideosBulkRoute, async (c) => {
 
 const addVideoRoute = createRoute({
   method: "post",
-  path: "/api/videos/groups/{groupId}/videos/{videoId}",
+  path: "/groups/{groupId}/videos/{videoId}",
   tags: ["Membership"],
   summary: "Add a single video to a group",
   middleware: [...writeGuards] as const,
@@ -189,7 +189,7 @@ const addVideoRoute = createRoute({
 });
 
 membershipRoutes.openapi(addVideoRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { groupId, videoId } = c.req.valid("param");
   const res = await membershipService.addVideoToGroupOne(
     c.env,
@@ -204,7 +204,7 @@ membershipRoutes.openapi(addVideoRoute, async (c) => {
 
 const removeVideoRoute = createRoute({
   method: "delete",
-  path: "/api/videos/groups/{groupId}/videos/{videoId}",
+  path: "/groups/{groupId}/videos/{videoId}",
   tags: ["Membership"],
   summary: "Remove a video from a group",
   middleware: [...writeGuards] as const,
@@ -216,7 +216,7 @@ const removeVideoRoute = createRoute({
 });
 
 membershipRoutes.openapi(removeVideoRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { groupId, videoId } = c.req.valid("param");
   const res = await membershipService.removeVideoFromGroupOne(
     c.env,

--- a/apps/api/src/features/oauth/oidc.ts
+++ b/apps/api/src/features/oauth/oidc.ts
@@ -32,8 +32,12 @@ import { logoutShell } from "./html-templates";
 /**
  * VideoQ の OpenID Connect エンドポイント。
  * OIDC_ENABLED が無効な場合は 404 を返す。
+ * API ルートの `/api/oauth` プレフィックスはアプリ側でマウントする。
  */
 export const oauthOidcRoutes = createFeatureRouter();
+
+/** Discovery / JWKS（absolute path のままルートに載せる）。 */
+export const oauthOidcWellKnownRoutes = createFeatureRouter();
 
 function oidcDisabled(c: Context<AppEnv>): Response {
   return c.body(null, 404);
@@ -54,7 +58,7 @@ function registerOidcDiscoveryRoutes(basePath: string) {
       404: { description: "OIDC disabled" },
     },
   });
-  oauthOidcRoutes.openapi(discoveryRoute, (c) => {
+  oauthOidcWellKnownRoutes.openapi(discoveryRoute, (c) => {
     if (!requireOidc(c)) return oidcDisabled(c);
     c.header("Access-Control-Allow-Origin", "*");
     return c.json(oauthService.getOpenIdConfiguration(c.env, c.req.url), 200);
@@ -70,7 +74,7 @@ function registerOidcDiscoveryRoutes(basePath: string) {
       404: { description: "OIDC disabled" },
     },
   });
-  oauthOidcRoutes.openapi(jwksRoute, async (c) => {
+  oauthOidcWellKnownRoutes.openapi(jwksRoute, async (c) => {
     if (!requireOidc(c)) return oidcDisabled(c);
     const { body, cacheControl } = await oauthService.getJwks(c.env);
     c.header("Access-Control-Allow-Origin", "*");
@@ -108,7 +112,7 @@ const userinfoResponses = {
 
 const userinfoGetRoute = createRoute({
   method: "get",
-  path: "/api/oauth/userinfo",
+  path: "/userinfo",
   tags: ["OIDC"],
   summary: "OpenID Connect UserInfo",
   responses: userinfoResponses,
@@ -119,7 +123,7 @@ oauthOidcRoutes.openapi(userinfoGetRoute, (c) =>
 
 const userinfoPostRoute = createRoute({
   method: "post",
-  path: "/api/oauth/userinfo",
+  path: "/userinfo",
   tags: ["OIDC"],
   summary: "OpenID Connect UserInfo",
   request: {
@@ -258,5 +262,5 @@ const logoutPost = async (c: Context<AppEnv>) => {
 registerOidcDiscoveryRoutes("");
 registerOidcDiscoveryRoutes("/api/oauth");
 
-oauthOidcRoutes.get("/api/oauth/logout", logoutGet);
-oauthOidcRoutes.post("/api/oauth/logout", logoutPost);
+oauthOidcRoutes.get("/logout", logoutGet);
+oauthOidcRoutes.post("/logout", logoutPost);

--- a/apps/api/src/features/oauth/routes.ts
+++ b/apps/api/src/features/oauth/routes.ts
@@ -41,21 +41,24 @@ import * as authorizeService from "./authorize-service";
 /**
  * OAuth 2.1 Authorization Server + Settings UI トークン管理。
  *
- * Well-known:
+ * Well-known (`oauthWellKnownRoutes`, absolute paths):
  *   GET /.well-known/oauth-authorization-server(+ optional path)
  *   GET /.well-known/oauth-protected-resource(+ /api/mcp)
  *
- * AS:
- *   GET/POST /api/oauth/authorize
- *   POST     /api/oauth/token
- *   POST     /api/oauth/register
- *   GET      /api/oauth/register/:clientId
- *   POST     /api/oauth/revoke_token
+ * AS (`oauthRoutes`, `/api/oauth` プレフィックスはアプリ側でマウント):
+ *   GET/POST /authorize
+ *   POST     /token
+ *   POST     /register
+ *   GET      /register/:clientId
+ *   POST     /revoke_token
  *
  * Settings UI:
- *   GET/DELETE /api/oauth/tokens(/:id)
+ *   GET/DELETE /tokens(/:id)
  */
 export const oauthRoutes = createFeatureRouter();
+
+/** RFC 8414/9728 well-known metadata（absolute path のままルートに載せる）。 */
+export const oauthWellKnownRoutes = createFeatureRouter();
 
 const jwtOnly = requireAuth(jwtMethod);
 
@@ -75,7 +78,7 @@ function registerAuthorizationServerMetadataRoutes(basePath: string) {
       200: jsonResponse(oauthAuthorizationServerMetadataSchema),
     },
   });
-  oauthRoutes.openapi(bareRoute, (c) => {
+  oauthWellKnownRoutes.openapi(bareRoute, (c) => {
     corsStar(c);
     return c.json(
       oauthService.getAuthorizationServerMetadata(c.env, c.req.url),
@@ -92,7 +95,7 @@ function registerAuthorizationServerMetadataRoutes(basePath: string) {
       200: jsonResponse(oauthAuthorizationServerMetadataSchema),
     },
   });
-  oauthRoutes.openapi(suffixRoute, (c) => {
+  oauthWellKnownRoutes.openapi(suffixRoute, (c) => {
     corsStar(c);
     return c.json(
       oauthService.getAuthorizationServerMetadata(c.env, c.req.url),
@@ -111,7 +114,7 @@ function registerProtectedResourceMetadataRoutes(basePath: string) {
       200: jsonResponse(oauthProtectedResourceMetadataSchema),
     },
   });
-  oauthRoutes.openapi(bareRoute, (c) => {
+  oauthWellKnownRoutes.openapi(bareRoute, (c) => {
     corsStar(c);
     return c.json(
       oauthService.getProtectedResourceMetadata(c.env, c.req.url),
@@ -128,7 +131,7 @@ function registerProtectedResourceMetadataRoutes(basePath: string) {
       200: jsonResponse(oauthProtectedResourceMetadataSchema),
     },
   });
-  oauthRoutes.openapi(suffixRoute, (c) => {
+  oauthWellKnownRoutes.openapi(suffixRoute, (c) => {
     corsStar(c);
     return c.json(
       oauthService.getProtectedResourceMetadata(c.env, c.req.url),
@@ -154,7 +157,7 @@ registerProtectedResourceMetadataRoutes(
 
 const listTokensRoute = createRoute({
   method: "get",
-  path: "/api/oauth/tokens",
+  path: "/tokens",
   tags: ["OAuth"],
   summary: "List authorized OAuth tokens for the current user",
   middleware: [jwtOnly] as const,
@@ -165,13 +168,13 @@ const listTokensRoute = createRoute({
 });
 
 oauthRoutes.openapi(listTokensRoute, async (c) => {
-  const body = await oauthService.listTokens(c.env, c.get("userId")!);
+  const body = await oauthService.listTokens(c.env, c.var.userId!);
   return c.json(body, 200);
 });
 
 const revokeTokenRoute = createRoute({
   method: "delete",
-  path: "/api/oauth/tokens/{tokenId}",
+  path: "/tokens/{tokenId}",
   tags: ["OAuth"],
   summary: "Revoke an authorized OAuth token",
   middleware: [jwtOnly] as const,
@@ -188,7 +191,7 @@ oauthRoutes.openapi(revokeTokenRoute, async (c) => {
   const { tokenId } = c.req.valid("param");
   const ok = await oauthService.revokeAuthorizedTokenForUser(
     c.env,
-    c.get("userId")!,
+    c.var.userId!,
     tokenId,
   );
   if (!ok) return c.body(null, 404);
@@ -348,8 +351,8 @@ const authorizePost = async (c: Context<AppEnv>) => {
   return issueCodeAndRedirect(c, userId, prepared.app, prepared.params);
 };
 
-oauthRoutes.get("/api/oauth/authorize", authorizeGet);
-oauthRoutes.post("/api/oauth/authorize", authorizePost);
+oauthRoutes.get("/authorize", authorizeGet);
+oauthRoutes.post("/authorize", authorizePost);
 
 // ─── token ────────────────────────────────────────────────────
 
@@ -444,7 +447,7 @@ const tokenPost = async (
 
 const tokenRoute = createRoute({
   method: "post",
-  path: "/api/oauth/token",
+  path: "/token",
   tags: ["OAuth"],
   summary: "OAuth 2 token endpoint",
   request: {
@@ -551,7 +554,7 @@ const registerDelete = async (c: Context<AppEnv>) => {
 
 const registerPostRoute = createRoute({
   method: "post",
-  path: "/api/oauth/register",
+  path: "/register",
   tags: ["OAuth"],
   summary: "Dynamic client registration (RFC 7591)",
   request: {
@@ -568,7 +571,7 @@ const registerPostRoute = createRoute({
 
 const registerGetRoute = createRoute({
   method: "get",
-  path: "/api/oauth/register/{clientId}",
+  path: "/register/{clientId}",
   tags: ["OAuth"],
   summary: "Read dynamic client registration (RFC 7592)",
   request: { params: dcrClientIdParamSchema },
@@ -580,7 +583,7 @@ const registerGetRoute = createRoute({
 
 const registerPutRoute = createRoute({
   method: "put",
-  path: "/api/oauth/register/{clientId}",
+  path: "/register/{clientId}",
   tags: ["OAuth"],
   summary: "Update dynamic client registration (RFC 7592)",
   request: {
@@ -599,7 +602,7 @@ const registerPutRoute = createRoute({
 
 const registerDeleteRoute = createRoute({
   method: "delete",
-  path: "/api/oauth/register/{clientId}",
+  path: "/register/{clientId}",
   tags: ["OAuth"],
   summary: "Delete dynamic client registration (RFC 7592)",
   request: { params: dcrClientIdParamSchema },
@@ -639,7 +642,7 @@ const revokePost = async (
 
 const revokeRoute = createRoute({
   method: "post",
-  path: "/api/oauth/revoke_token",
+  path: "/revoke_token",
   tags: ["OAuth"],
   summary: "OAuth 2 token revocation (RFC 7009)",
   request: {

--- a/apps/api/src/features/oauth/support-routes.ts
+++ b/apps/api/src/features/oauth/support-routes.ts
@@ -71,7 +71,7 @@ function deviceConfirmPath(clientId: string, userCode: string): string {
 
 const introspectRoute = createRoute({
   method: "post",
-  path: "/api/oauth/introspect",
+  path: "/introspect",
   tags: ["OAuth"],
   summary: "Token introspection (RFC 7662)",
   request: {
@@ -120,7 +120,7 @@ oauthSupportRoutes.openapi(introspectRoute, (c) =>
 
 const deviceAuthorizationRoute = createRoute({
   method: "post",
-  path: "/api/oauth/device-authorization",
+  path: "/device-authorization",
   tags: ["OAuth"],
   summary: "Device authorization (RFC 8628)",
   request: {
@@ -198,8 +198,8 @@ const deviceUserCodePost = async (c: Context<AppEnv>) => {
   return c.redirect(deviceConfirmPath(flow.clientId, flow.userCode), 302);
 };
 
-oauthSupportRoutes.get("/api/oauth/device", deviceUserCodeGet);
-oauthSupportRoutes.post("/api/oauth/device", deviceUserCodePost);
+oauthSupportRoutes.get("/device", deviceUserCodeGet);
+oauthSupportRoutes.post("/device", deviceUserCodePost);
 
 const deviceConfirmGet = async (c: Context<AppEnv>) => {
   const userId = await cookieUserId(c);
@@ -258,11 +258,11 @@ const deviceConfirmPost = async (c: Context<AppEnv>) => {
 };
 
 oauthSupportRoutes.get(
-  "/api/oauth/device-confirm/:clientId/:userCode",
+  "/device-confirm/:clientId/:userCode",
   deviceConfirmGet,
 );
 oauthSupportRoutes.post(
-  "/api/oauth/device-confirm/:clientId/:userCode",
+  "/device-confirm/:clientId/:userCode",
   deviceConfirmPost,
 );
 
@@ -284,7 +284,7 @@ const deviceStatus = async (c: Context<AppEnv>) => {
 };
 
 oauthSupportRoutes.get(
-  "/api/oauth/device-grant-status/:clientId/:userCode",
+  "/device-grant-status/:clientId/:userCode",
   deviceStatus,
 );
 
@@ -447,14 +447,14 @@ const appsDeletePost = async (c: Context<AppEnv>) => {
   return c.redirect("/api/oauth/applications", 302);
 };
 
-oauthSupportRoutes.get("/api/oauth/applications", appsList);
-oauthSupportRoutes.get("/api/oauth/applications/register", appsRegisterGet);
-oauthSupportRoutes.post("/api/oauth/applications/register", appsRegisterPost);
-oauthSupportRoutes.get("/api/oauth/applications/:id{[0-9]+}", appsDetail);
-oauthSupportRoutes.get("/api/oauth/applications/:id{[0-9]+}/update", appsUpdateGet);
-oauthSupportRoutes.post("/api/oauth/applications/:id{[0-9]+}/update", appsUpdatePost);
-oauthSupportRoutes.get("/api/oauth/applications/:id{[0-9]+}/delete", appsDeleteGet);
-oauthSupportRoutes.post("/api/oauth/applications/:id{[0-9]+}/delete", appsDeletePost);
+oauthSupportRoutes.get("/applications", appsList);
+oauthSupportRoutes.get("/applications/register", appsRegisterGet);
+oauthSupportRoutes.post("/applications/register", appsRegisterPost);
+oauthSupportRoutes.get("/applications/:id{[0-9]+}", appsDetail);
+oauthSupportRoutes.get("/applications/:id{[0-9]+}/update", appsUpdateGet);
+oauthSupportRoutes.post("/applications/:id{[0-9]+}/update", appsUpdatePost);
+oauthSupportRoutes.get("/applications/:id{[0-9]+}/delete", appsDeleteGet);
+oauthSupportRoutes.post("/applications/:id{[0-9]+}/delete", appsDeletePost);
 
 // ─── authorized_tokens HTML ──────────────────────────────────
 
@@ -515,8 +515,8 @@ const tokensHtmlDelete = async (c: Context<AppEnv>) => {
   return c.redirect("/api/oauth/authorized_tokens", 302);
 };
 
-oauthSupportRoutes.get("/api/oauth/authorized_tokens", tokensHtmlList);
+oauthSupportRoutes.get("/authorized_tokens", tokensHtmlList);
 oauthSupportRoutes.post(
-  "/api/oauth/authorized_tokens/:id{[0-9]+}/delete",
+  "/authorized_tokens/:id{[0-9]+}/delete",
   tokensHtmlDelete,
 );

--- a/apps/api/src/features/plog/routes.ts
+++ b/apps/api/src/features/plog/routes.ts
@@ -76,7 +76,7 @@ const jsonBody = <S extends z.ZodType>(schema: S) => ({
 
 const learnerStateRoute = createRoute({
   method: "get",
-  path: "/api/videos/{videoId}/plog/learner-state",
+  path: "/{videoId}/plog/learner-state",
   tags: ["Plog"],
   summary: "Get learner state",
   middleware: [plogAuth] as const,
@@ -92,7 +92,7 @@ plogRoutes.openapi(learnerStateRoute, async (c) => {
   const res = await plogService.learnerStateForVideo(
     c.env,
     videoId,
-    c.get("userId")!,
+    c.var.userId!,
   );
   if ("notFound" in res) throw videoNotFoundError();
   return c.json(res, 200);
@@ -100,7 +100,7 @@ plogRoutes.openapi(learnerStateRoute, async (c) => {
 
 const resetLearnerRoute = createRoute({
   method: "delete",
-  path: "/api/videos/{videoId}/plog/learner-state",
+  path: "/{videoId}/plog/learner-state",
   tags: ["Plog"],
   summary: "Reset learner state",
   middleware: [...learnerResetGuards] as const,
@@ -116,7 +116,7 @@ plogRoutes.openapi(resetLearnerRoute, async (c) => {
   const res = await plogService.resetLearnerForVideo(
     c.env,
     videoId,
-    c.get("userId")!,
+    c.var.userId!,
   );
   if ("notFound" in res) throw videoNotFoundError();
   return c.json({ deleted: res.deleted }, 200);
@@ -124,7 +124,7 @@ plogRoutes.openapi(resetLearnerRoute, async (c) => {
 
 const graphRoute = createRoute({
   method: "get",
-  path: "/api/videos/{videoId}/plog",
+  path: "/{videoId}/plog",
   tags: ["Plog"],
   summary: "Get plog graph",
   middleware: [plogAuth] as const,
@@ -137,14 +137,14 @@ const graphRoute = createRoute({
 
 plogRoutes.openapi(graphRoute, async (c) => {
   const { videoId } = c.req.valid("param");
-  const res = await plogService.graphForVideo(c.env, videoId, c.get("userId")!);
+  const res = await plogService.graphForVideo(c.env, videoId, c.var.userId!);
   if ("notFound" in res) throw videoNotFoundError();
   return c.json(res, 200);
 });
 
 const rebuildRoute = createRoute({
   method: "post",
-  path: "/api/videos/{videoId}/plog/rebuild",
+  path: "/{videoId}/plog/rebuild",
   tags: ["Plog"],
   summary: "Enqueue plog rebuild",
   middleware: [...plogWriteGuards] as const,
@@ -157,7 +157,7 @@ const rebuildRoute = createRoute({
 
 plogRoutes.openapi(rebuildRoute, async (c) => {
   const { videoId } = c.req.valid("param");
-  const res = await plogService.rebuildPlog(c.env, videoId, c.get("userId")!);
+  const res = await plogService.rebuildPlog(c.env, videoId, c.var.userId!);
   if ("notFound" in res) {
     throw new ApiError(404, "VALIDATION_ERROR", res.notFound ?? "Not found");
   }
@@ -169,7 +169,7 @@ plogRoutes.openapi(rebuildRoute, async (c) => {
 
 const createConceptRoute = createRoute({
   method: "post",
-  path: "/api/videos/{videoId}/plog/concepts",
+  path: "/{videoId}/plog/concepts",
   tags: ["Plog"],
   summary: "Create plog concept",
   middleware: [...plogWriteGuards] as const,
@@ -186,7 +186,7 @@ const createConceptRoute = createRoute({
 
 plogRoutes.openapi(createConceptRoute, async (c) => {
   const { videoId } = c.req.valid("param");
-  await requireOwnedVideoId(c.env, videoId, c.get("userId")!);
+  await requireOwnedVideoId(c.env, videoId, c.var.userId!);
   const body = c.req.valid("json");
   const intro = plogService.parsePlogSeconds(body.intro_sec);
   if (typeof intro === "object") throw editBadRequest(intro.error);
@@ -203,7 +203,7 @@ plogRoutes.openapi(createConceptRoute, async (c) => {
 
 const updateConceptRoute = createRoute({
   method: "patch",
-  path: "/api/videos/{videoId}/plog/concepts/{conceptId}",
+  path: "/{videoId}/plog/concepts/{conceptId}",
   tags: ["Plog"],
   summary: "Update plog concept",
   middleware: [...plogWriteGuards] as const,
@@ -220,7 +220,7 @@ const updateConceptRoute = createRoute({
 
 plogRoutes.openapi(updateConceptRoute, async (c) => {
   const { videoId, conceptId } = c.req.valid("param");
-  await requireOwnedVideoId(c.env, videoId, c.get("userId")!);
+  await requireOwnedVideoId(c.env, videoId, c.var.userId!);
   const body = c.req.valid("json");
   const patch: {
     label?: string;
@@ -244,7 +244,7 @@ plogRoutes.openapi(updateConceptRoute, async (c) => {
 
 const deleteConceptRoute = createRoute({
   method: "delete",
-  path: "/api/videos/{videoId}/plog/concepts/{conceptId}",
+  path: "/{videoId}/plog/concepts/{conceptId}",
   tags: ["Plog"],
   summary: "Delete plog concept",
   middleware: [...plogWriteGuards] as const,
@@ -257,7 +257,7 @@ const deleteConceptRoute = createRoute({
 
 plogRoutes.openapi(deleteConceptRoute, async (c) => {
   const { videoId, conceptId } = c.req.valid("param");
-  await requireOwnedVideoId(c.env, videoId, c.get("userId")!);
+  await requireOwnedVideoId(c.env, videoId, c.var.userId!);
   return c.json(
     respondEdit(await plogService.editDeleteConcept(c.env, videoId, conceptId)),
     200,
@@ -266,7 +266,7 @@ plogRoutes.openapi(deleteConceptRoute, async (c) => {
 
 const mergeConceptRoute = createRoute({
   method: "post",
-  path: "/api/videos/{videoId}/plog/concepts/{conceptId}/merge",
+  path: "/{videoId}/plog/concepts/{conceptId}/merge",
   tags: ["Plog"],
   summary: "Merge plog concepts",
   middleware: [...plogWriteGuards] as const,
@@ -283,7 +283,7 @@ const mergeConceptRoute = createRoute({
 
 plogRoutes.openapi(mergeConceptRoute, async (c) => {
   const { videoId, conceptId } = c.req.valid("param");
-  await requireOwnedVideoId(c.env, videoId, c.get("userId")!);
+  await requireOwnedVideoId(c.env, videoId, c.var.userId!);
   const body = c.req.valid("json");
   const absorbId = plogService.parsePlogInteger(body.absorb_id);
   if (typeof absorbId === "object") throw editBadRequest(absorbId.error);
@@ -297,7 +297,7 @@ plogRoutes.openapi(mergeConceptRoute, async (c) => {
 
 const updateLearningObjectRoute = createRoute({
   method: "patch",
-  path: "/api/videos/{videoId}/plog/concepts/{conceptId}/learning-object",
+  path: "/{videoId}/plog/concepts/{conceptId}/learning-object",
   tags: ["Plog"],
   summary: "Update plog learning object",
   middleware: [...plogWriteGuards] as const,
@@ -313,7 +313,7 @@ const updateLearningObjectRoute = createRoute({
 
 plogRoutes.openapi(updateLearningObjectRoute, async (c) => {
   const { videoId, conceptId } = c.req.valid("param");
-  await requireOwnedVideoId(c.env, videoId, c.get("userId")!);
+  await requireOwnedVideoId(c.env, videoId, c.var.userId!);
   const body = c.req.valid("json");
   const patch: Parameters<typeof plogService.editUpdateLearningObject>[3] = {};
   if (body.opening_question !== undefined) patch.openingQuestion = body.opening_question;
@@ -332,7 +332,7 @@ plogRoutes.openapi(updateLearningObjectRoute, async (c) => {
 
 const createEdgeRoute = createRoute({
   method: "post",
-  path: "/api/videos/{videoId}/plog/edges",
+  path: "/{videoId}/plog/edges",
   tags: ["Plog"],
   summary: "Create plog edge",
   middleware: [...plogWriteGuards] as const,
@@ -349,7 +349,7 @@ const createEdgeRoute = createRoute({
 
 plogRoutes.openapi(createEdgeRoute, async (c) => {
   const { videoId } = c.req.valid("param");
-  await requireOwnedVideoId(c.env, videoId, c.get("userId")!);
+  await requireOwnedVideoId(c.env, videoId, c.var.userId!);
   const body = c.req.valid("json");
   const sourceId = plogService.parsePlogInteger(body.source_id);
   if (typeof sourceId === "object") throw editBadRequest(sourceId.error);
@@ -368,7 +368,7 @@ plogRoutes.openapi(createEdgeRoute, async (c) => {
 
 const updateEdgeRoute = createRoute({
   method: "patch",
-  path: "/api/videos/{videoId}/plog/edges/{edgeId}",
+  path: "/{videoId}/plog/edges/{edgeId}",
   tags: ["Plog"],
   summary: "Update plog edge",
   middleware: [...plogWriteGuards] as const,
@@ -385,7 +385,7 @@ const updateEdgeRoute = createRoute({
 
 plogRoutes.openapi(updateEdgeRoute, async (c) => {
   const { videoId, edgeId } = c.req.valid("param");
-  await requireOwnedVideoId(c.env, videoId, c.get("userId")!);
+  await requireOwnedVideoId(c.env, videoId, c.var.userId!);
   const data = c.req.valid("json");
   const patch: {
     sourceId?: number;
@@ -421,7 +421,7 @@ plogRoutes.openapi(updateEdgeRoute, async (c) => {
 
 const deleteEdgeRoute = createRoute({
   method: "delete",
-  path: "/api/videos/{videoId}/plog/edges/{edgeId}",
+  path: "/{videoId}/plog/edges/{edgeId}",
   tags: ["Plog"],
   summary: "Delete plog edge",
   middleware: [...plogWriteGuards] as const,
@@ -434,7 +434,7 @@ const deleteEdgeRoute = createRoute({
 
 plogRoutes.openapi(deleteEdgeRoute, async (c) => {
   const { videoId, edgeId } = c.req.valid("param");
-  await requireOwnedVideoId(c.env, videoId, c.get("userId")!);
+  await requireOwnedVideoId(c.env, videoId, c.var.userId!);
   return c.json(
     respondEdit(await plogService.editDeleteEdge(c.env, videoId, edgeId)),
     200,

--- a/apps/api/src/features/schema/routes.ts
+++ b/apps/api/src/features/schema/routes.ts
@@ -20,4 +20,4 @@ const redocHtml = `<!DOCTYPE html>
 </body>
 </html>`;
 
-schemaRoutes.get("/api/redoc", (c) => c.html(redocHtml));
+schemaRoutes.get("/redoc", (c) => c.html(redocHtml));

--- a/apps/api/src/features/tags/routes.ts
+++ b/apps/api/src/features/tags/routes.ts
@@ -37,7 +37,7 @@ const tagWriteGuards = [
 
 const listTagsRoute = createRoute({
   method: "get",
-  path: "/api/videos/tags",
+  path: "/tags",
   tags: ["Tags"],
   summary: "List tags",
   middleware: [tagAuth] as const,
@@ -49,7 +49,7 @@ const listTagsRoute = createRoute({
 });
 
 tagRoutes.openapi(listTagsRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { limit, offset } = parseLimitOffset(c);
   const { count, results } = await tagService.listTags(c.env, userId, limit, offset);
   return c.json(listResponse(results, { total: count, limit, offset }), 200);
@@ -57,7 +57,7 @@ tagRoutes.openapi(listTagsRoute, async (c) => {
 
 const getTagRoute = createRoute({
   method: "get",
-  path: "/api/videos/tags/{id}",
+  path: "/tags/{id}",
   tags: ["Tags"],
   summary: "Get tag detail",
   middleware: [tagAuth] as const,
@@ -70,7 +70,7 @@ const getTagRoute = createRoute({
 });
 
 tagRoutes.openapi(getTagRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const tag = await tagService.getTag(c.env, id, userId);
   if (!tag) throw apiNotFound("Tag not found");
@@ -79,7 +79,7 @@ tagRoutes.openapi(getTagRoute, async (c) => {
 
 const createTagRoute = createRoute({
   method: "post",
-  path: "/api/videos/tags",
+  path: "/tags",
   tags: ["Tags"],
   summary: "Create tag",
   middleware: [...tagWriteGuards] as const,
@@ -94,7 +94,7 @@ const createTagRoute = createRoute({
 });
 
 tagRoutes.openapi(createTagRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const body = c.req.valid("json");
   const result = await tagService.createUserTag(c.env, userId, body.name, body.color);
   if ("error" in result) throw apiBadRequest(result.error ?? "Bad request");
@@ -103,7 +103,7 @@ tagRoutes.openapi(createTagRoute, async (c) => {
 
 const patchTagRoute = createRoute({
   method: "patch",
-  path: "/api/videos/tags/{id}",
+  path: "/tags/{id}",
   tags: ["Tags"],
   summary: "Partial update tag",
   middleware: [...tagWriteGuards] as const,
@@ -119,7 +119,7 @@ const patchTagRoute = createRoute({
 });
 
 tagRoutes.openapi(patchTagRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const body = c.req.valid("json");
   const result = await tagService.updateUserTag(c.env, id, userId, body);
@@ -130,7 +130,7 @@ tagRoutes.openapi(patchTagRoute, async (c) => {
 
 const putTagRoute = createRoute({
   method: "put",
-  path: "/api/videos/tags/{id}",
+  path: "/tags/{id}",
   tags: ["Tags"],
   summary: "Replace tag",
   middleware: [...tagWriteGuards] as const,
@@ -146,7 +146,7 @@ const putTagRoute = createRoute({
 });
 
 tagRoutes.openapi(putTagRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const body = c.req.valid("json");
   const result = await tagService.updateUserTag(c.env, id, userId, body);
@@ -157,7 +157,7 @@ tagRoutes.openapi(putTagRoute, async (c) => {
 
 const deleteTagRoute = createRoute({
   method: "delete",
-  path: "/api/videos/tags/{id}",
+  path: "/tags/{id}",
   tags: ["Tags"],
   summary: "Delete tag",
   middleware: [...tagWriteGuards] as const,
@@ -169,7 +169,7 @@ const deleteTagRoute = createRoute({
 });
 
 tagRoutes.openapi(deleteTagRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const res = await tagService.removeTag(c.env, id, userId);
   if ("notFound" in res) throw apiNotFound("Tag not found");

--- a/apps/api/src/features/videos/routes.ts
+++ b/apps/api/src/features/videos/routes.ts
@@ -44,7 +44,7 @@ const videoWriteGuards = [
 
 const listVideosRoute = createRoute({
   method: "get",
-  path: "/api/videos",
+  path: "/",
   tags: ["Videos"],
   summary: "List videos",
   middleware: [videoAuth] as const,
@@ -56,7 +56,7 @@ const listVideosRoute = createRoute({
 });
 
 videoRoutes.openapi(listVideosRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const query = c.req.valid("query");
   const { limit, offset } = parseLimitOffset(c);
   const { count, results } = await videoService.listUserVideos(
@@ -71,7 +71,7 @@ videoRoutes.openapi(listVideosRoute, async (c) => {
 
 const getVideoRoute = createRoute({
   method: "get",
-  path: "/api/videos/{id}",
+  path: "/{id}",
   tags: ["Videos"],
   summary: "Get video detail",
   middleware: [videoAuth] as const,
@@ -84,7 +84,7 @@ const getVideoRoute = createRoute({
 });
 
 videoRoutes.openapi(getVideoRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const video = await videoService.getUserVideo(c.env, id, userId);
   if (!video) throw apiNotFound("Video not found");
@@ -93,7 +93,7 @@ videoRoutes.openapi(getVideoRoute, async (c) => {
 
 const createVideoRoute = createRoute({
   method: "post",
-  path: "/api/videos",
+  path: "/",
   tags: ["Videos"],
   summary: "Upload a video",
   middleware: [...videoWriteGuards] as const,
@@ -114,7 +114,7 @@ const createVideoRoute = createRoute({
 videoRoutes.openapi(createVideoRoute, async (c) => {
   const res = await videoService.createVideoFromMultipart(
     c.env,
-    c.get("userId")!,
+    c.var.userId!,
     c.req.valid("form") as Record<string, string | File>,
   );
   if (!res.ok) {
@@ -125,7 +125,7 @@ videoRoutes.openapi(createVideoRoute, async (c) => {
 
 const requestUploadRoute = createRoute({
   method: "post",
-  path: "/api/videos/uploads",
+  path: "/uploads",
   tags: ["Videos"],
   summary: "Request presigned upload URL",
   middleware: [...videoWriteGuards] as const,
@@ -143,7 +143,7 @@ const requestUploadRoute = createRoute({
 });
 
 videoRoutes.openapi(requestUploadRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const body = c.req.valid("json");
   const res = await videoService.requestPresignedUpload(c.env, userId, body);
   if ("fieldError" in res && res.fieldError) {
@@ -172,7 +172,7 @@ videoRoutes.openapi(requestUploadRoute, async (c) => {
 
 const createYoutubeRoute = createRoute({
   method: "post",
-  path: "/api/videos/youtube",
+  path: "/youtube",
   tags: ["Videos"],
   summary: "Register a YouTube video",
   middleware: [...videoWriteGuards] as const,
@@ -190,7 +190,7 @@ const createYoutubeRoute = createRoute({
 });
 
 videoRoutes.openapi(createYoutubeRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const body = c.req.valid("json");
   const res = await videoService.createUserYoutubeVideo(c.env, userId, body);
   if ("fieldError" in res && res.fieldError) {
@@ -201,7 +201,7 @@ videoRoutes.openapi(createYoutubeRoute, async (c) => {
 
 const patchVideoRoute = createRoute({
   method: "patch",
-  path: "/api/videos/{id}",
+  path: "/{id}",
   tags: ["Videos"],
   summary: "Patch video (or confirm upload)",
   middleware: [...videoWriteGuards] as const,
@@ -220,7 +220,7 @@ const patchVideoRoute = createRoute({
 });
 
 videoRoutes.openapi(patchVideoRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const body = c.req.valid("json");
 
@@ -246,7 +246,7 @@ videoRoutes.openapi(patchVideoRoute, async (c) => {
 
 const putVideoRoute = createRoute({
   method: "put",
-  path: "/api/videos/{id}",
+  path: "/{id}",
   tags: ["Videos"],
   summary: "Replace video metadata",
   middleware: [...videoWriteGuards] as const,
@@ -265,7 +265,7 @@ const putVideoRoute = createRoute({
 });
 
 videoRoutes.openapi(putVideoRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const body = c.req.valid("json");
 
@@ -279,7 +279,7 @@ videoRoutes.openapi(putVideoRoute, async (c) => {
 
 const deleteVideoRoute = createRoute({
   method: "delete",
-  path: "/api/videos/{id}",
+  path: "/{id}",
   tags: ["Videos"],
   summary: "Delete video",
   middleware: [...videoWriteGuards] as const,
@@ -291,7 +291,7 @@ const deleteVideoRoute = createRoute({
 });
 
 videoRoutes.openapi(deleteVideoRoute, async (c) => {
-  const userId = c.get("userId")!;
+  const userId = c.var.userId!;
   const { id } = c.req.valid("param");
   const res = await videoService.deleteUserVideo(c.env, id, userId);
   if ("notFound" in res) throw apiNotFound("Video not found");

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,12 +1,14 @@
-import { createApp } from "./app";
+import { createApp, type AppType } from "./app";
 import { reconcileAbandonedUploads } from "./lib/upload-reconcile";
 import type { Bindings } from "./types/bindings";
+
+export type { AppType };
 
 // Cloudflare Workers のエントリ（fetch + scheduled）。
 const app = createApp();
 
 export default {
-  fetch: app.fetch.bind(app),
+  fetch: app.fetch,
   async scheduled(
     _controller: ScheduledController,
     env: Bindings,

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -135,8 +135,8 @@ export function isScopeAllowed(accessLevel: string, requiredScope: string): bool
  */
 export const requireScope = (scope?: string) =>
   createMiddleware<AppEnv>(async (c, next) => {
-    const accessLevel = c.get("apiKeyAccessLevel");
-    if (c.get("authVia") === "apikey" && accessLevel) {
+    const accessLevel = c.var.apiKeyAccessLevel;
+    if (c.var.authVia === "apikey" && accessLevel) {
       const required =
         scope ??
         (["GET", "HEAD", "OPTIONS"].includes(c.req.method) ? "read" : "write");

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -38,7 +38,7 @@ export function onError(e: Error, c: Context<AppEnv>): Response {
   console.error(
     JSON.stringify({
       level: "error",
-      requestId: c.get("requestId"),
+      requestId: c.var.requestId,
       path: new URL(c.req.url).pathname,
       error: e?.message ?? String(e),
       stack: e?.stack,

--- a/apps/api/src/middleware/logger.ts
+++ b/apps/api/src/middleware/logger.ts
@@ -12,7 +12,7 @@ export const accessLogger = createMiddleware<AppEnv>(async (c, next) => {
   console.log(
     JSON.stringify({
       level: "info",
-      requestId: c.get("requestId"),
+      requestId: c.var.requestId,
       method: c.req.method,
       path: new URL(c.req.url).pathname,
       status: c.res.status,

--- a/apps/api/test/admin.test.ts
+++ b/apps/api/test/admin.test.ts
@@ -87,14 +87,14 @@ describe("admin API", () => {
       if (sql.includes("SELECT is_superuser")) return [{ is_superuser: false }];
       return [];
     };
-    const res = await req("/api/admin/users", {
+    const res = await req("/users", {
       headers: { authorization: `Bearer ${await token(2)}` },
     });
     expect(res.status).toBe(403);
   });
 
   it("一覧は 200", async () => {
-    const res = await req("/api/admin/users?q=ali", {
+    const res = await req("/users?q=ali", {
       headers: { authorization: `Bearer ${await token()}` },
     });
     expect(res.status).toBe(200);
@@ -104,7 +104,7 @@ describe("admin API", () => {
   });
 
   it("quota PATCH", async () => {
-    const res = await req("/api/admin/users/9/quota", {
+    const res = await req("/users/9/quota", {
       method: "PATCH",
       headers: {
         authorization: `Bearer ${await token()}`,
@@ -117,7 +117,7 @@ describe("admin API", () => {
   });
 
   it("flags PATCH", async () => {
-    const res = await req("/api/admin/users/9/flags", {
+    const res = await req("/users/9/flags", {
       method: "PATCH",
       headers: {
         authorization: `Bearer ${await token()}`,
@@ -157,7 +157,7 @@ describe("admin API", () => {
       }
       return [];
     };
-    const res = await req("/api/admin/users/1/flags", {
+    const res = await req("/users/1/flags", {
       method: "PATCH",
       headers: {
         authorization: `Bearer ${await token(1)}`,
@@ -169,7 +169,7 @@ describe("admin API", () => {
   });
 
   it("reindex-all は 202 + job_id", async () => {
-    const res = await req("/api/admin/embeddings/reindex-all", {
+    const res = await req("/embeddings/reindex-all", {
       method: "POST",
       headers: { authorization: `Bearer ${await token()}` },
     });
@@ -179,7 +179,7 @@ describe("admin API", () => {
   });
 
   it("ユーザー削除は 202 でジョブを投入する", async () => {
-    const res = await req("/api/admin/users/9", {
+    const res = await req("/users/9", {
       method: "DELETE",
       headers: { authorization: `Bearer ${await token(1)}` },
     });
@@ -201,7 +201,7 @@ describe("admin API", () => {
   });
 
   it("is_active=false で OAuth トークンも消す", async () => {
-    const res = await req("/api/admin/users/9/flags", {
+    const res = await req("/users/9/flags", {
       method: "PATCH",
       headers: {
         authorization: `Bearer ${await token()}`,
@@ -220,7 +220,7 @@ describe("admin API", () => {
 
   it("SQS 投入失敗時は同期 hard-delete にフォールバックする", async () => {
     enqueueDelete.mockResolvedValueOnce(null);
-    const res = await req("/api/admin/users/9", {
+    const res = await req("/users/9", {
       method: "DELETE",
       headers: { authorization: `Bearer ${await token(1)}` },
     });
@@ -263,7 +263,7 @@ describe("admin API", () => {
       }
       return [];
     };
-    const res = await req("/api/admin/users/1", {
+    const res = await req("/users/1", {
       method: "DELETE",
       headers: { authorization: `Bearer ${await token(1)}` },
     });
@@ -297,7 +297,7 @@ describe("admin API", () => {
       }
       return [];
     };
-    const res = await req("/api/admin/users/9", {
+    const res = await req("/users/9", {
       method: "DELETE",
       headers: { authorization: `Bearer ${await token(1)}` },
     });

--- a/apps/api/test/apikeys.test.ts
+++ b/apps/api/test/apikeys.test.ts
@@ -32,12 +32,12 @@ async function accessToken(userId = 5) {
 async function postCreate(body: string, token?: string) {
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (token) headers["authorization"] = `Bearer ${token}`;
-  return authRoutes.request("/api/auth/api-keys", { method: "POST", headers, body }, ENV);
+  return authRoutes.request("/api-keys", { method: "POST", headers, body }, ENV);
 }
 
 describe("api-keys management", () => {
   it("GET /api-keys 認証なし → 401", async () => {
-    const res = await authRoutes.request("/api/auth/api-keys", { method: "GET" }, ENV);
+    const res = await authRoutes.request("/api-keys", { method: "GET" }, ENV);
     expect(res.status).toBe(401);
   });
 

--- a/apps/api/test/auth-email-change.test.ts
+++ b/apps/api/test/auth-email-change.test.ts
@@ -43,7 +43,7 @@ const jsonPatch = async (body: unknown) => ({
 describe("POST /password-resets（DB 到達前の分岐）", () => {
   it("email 欠落 → 400 required", async () => {
     const res = await authRoutes.request(
-      "/api/auth/password-resets",
+      "/password-resets",
       { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
       ENV,
     );
@@ -54,7 +54,7 @@ describe("POST /password-resets（DB 到達前の分岐）", () => {
 
   it("不正な email → 400 EmailField", async () => {
     const res = await authRoutes.request(
-      "/api/auth/password-resets",
+      "/password-resets",
       {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -69,7 +69,7 @@ describe("POST /password-resets（DB 到達前の分岐）", () => {
 
   it("null は blank ではなく null エラー", async () => {
     const res = await authRoutes.request(
-      "/api/auth/password-resets",
+      "/password-resets",
       {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -85,19 +85,19 @@ describe("POST /password-resets（DB 到達前の分岐）", () => {
 
 describe("PATCH /me/email（DB 到達前の分岐）", () => {
   it("認証なし → 401", async () => {
-    const res = await authRoutes.request("/api/auth/me/email", { method: "PATCH" }, ENV);
+    const res = await authRoutes.request("/me/email", { method: "PATCH" }, ENV);
     expect(res.status).toBe(401);
   });
 
   it("認証あり + email 欠落 → 400 required", async () => {
-    const res = await authRoutes.request("/api/auth/me/email", await jsonPatch({}), ENV);
+    const res = await authRoutes.request("/me/email", await jsonPatch({}), ENV);
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error.details.email).toEqual(["Invalid input: expected string, received undefined"]);
   });
 
   it("認証あり + 不正 email → 400 EmailField", async () => {
-    const res = await authRoutes.request("/api/auth/me/email", await jsonPatch({ email: "nope" }), ENV);
+    const res = await authRoutes.request("/me/email", await jsonPatch({ email: "nope" }), ENV);
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error.details.email).toEqual(["Enter a valid email address."]);
@@ -107,7 +107,7 @@ describe("PATCH /me/email（DB 到達前の分岐）", () => {
 describe("PATCH /email-change/:token（DB 到達前の分岐）", () => {
   it("不正 token → 400 Invalid or expired email change link.", async () => {
     const res = await authRoutes.request(
-      "/api/auth/email-change/invalid-token",
+      "/email-change/invalid-token",
       { method: "PATCH" },
       ENV,
     );

--- a/apps/api/test/auth-login-contract.test.ts
+++ b/apps/api/test/auth-login-contract.test.ts
@@ -17,10 +17,10 @@ vi.mock("../src/features/auth/service", () => ({
   }),
 }));
 
-describe("POST /api/auth/sessions response contract", () => {
+describe("POST /sessions response contract", () => {
   it("Bearer access token を body、opaque refresh を cookie で返す", async () => {
     const res = await authRoutes.request(
-      "/api/auth/sessions",
+      "/sessions",
       {
         method: "POST",
         headers: { "content-type": "application/json" },

--- a/apps/api/test/auth-login.test.ts
+++ b/apps/api/test/auth-login.test.ts
@@ -12,7 +12,7 @@ function post(body: string, contentType?: string) {
   const headers: Record<string, string> = {};
   if (contentType) headers["content-type"] = contentType;
   return authRoutes.request(
-    "/api/auth/sessions",
+    "/sessions",
     { method: "POST", headers, body },
     ENV,
   );
@@ -67,7 +67,7 @@ describe("POST /sessions login guards", () => {
 describe("DELETE /sessions logout", () => {
   it("常に 204（refresh cookie のみ削除）", async () => {
     const res = await authRoutes.request(
-      "/api/auth/sessions",
+      "/sessions",
       { method: "DELETE", headers: { Origin: "http://localhost:3000" } },
       ENV,
     );

--- a/apps/api/test/auth-refresh.test.ts
+++ b/apps/api/test/auth-refresh.test.ts
@@ -33,7 +33,7 @@ function postTokens(cookie?: string) {
     Origin: "http://localhost:3000",
   };
   if (cookie) headers["cookie"] = cookie;
-  return authRoutes.request("/api/auth/tokens", { method: "POST", headers }, ENV);
+  return authRoutes.request("/tokens", { method: "POST", headers }, ENV);
 }
 
 beforeEach(() => {
@@ -44,7 +44,7 @@ beforeEach(() => {
 describe("POST /tokens refresh", () => {
   it("Origin欠落は403", async () => {
     const res = await authRoutes.request(
-      "/api/auth/tokens",
+      "/tokens",
       { method: "POST" },
       ENV,
     );

--- a/apps/api/test/auth-session-hardening.test.ts
+++ b/apps/api/test/auth-session-hardening.test.ts
@@ -43,7 +43,7 @@ beforeEach(() => {
 describe("JWT sid session binding", () => {
   it("失効済み sid の access JWT は 401", async () => {
     const token = await signAccessToken(SECRET, 5, "videoq", "revoked-session");
-    const res = await authRoutes.request("/api/auth/me", {
+    const res = await authRoutes.request("/me", {
       headers: { authorization: `Bearer ${token}` },
     }, ENV);
     expect(res.status).toBe(401);
@@ -70,7 +70,7 @@ describe("JWT sid session binding", () => {
     };
     const token = await signAccessToken(SECRET, 5, "videoq", "live-session");
     // 認証後のバリデーションまで到達すれば sid チェックは成功している。
-    const res = await authRoutes.request("/api/auth/me/email", {
+    const res = await authRoutes.request("/me/email", {
       method: "PATCH",
       headers: {
         authorization: `Bearer ${token}`,
@@ -93,7 +93,7 @@ describe("credential change revokes sessions and OAuth", () => {
       }
       return [];
     };
-    const res = await authRoutes.request("/api/auth/password-resets/opaque-token", {
+    const res = await authRoutes.request("/password-resets/opaque-token", {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ new_password: "CorrectHorseBattery1!" }),
@@ -135,7 +135,7 @@ describe("credential change revokes sessions and OAuth", () => {
       }
       return [];
     };
-    const res = await authRoutes.request("/api/auth/email-change/opaque-token", {
+    const res = await authRoutes.request("/email-change/opaque-token", {
       method: "PATCH",
     }, ENV);
     expect(res.status).toBe(200);

--- a/apps/api/test/auth-signup.test.ts
+++ b/apps/api/test/auth-signup.test.ts
@@ -10,7 +10,7 @@ const ENV = {
 
 function post(body: string, ct = "application/json") {
   return authRoutes.request(
-    "/api/auth/users",
+    "/users",
     { method: "POST", headers: ct ? { "content-type": ct } : {}, body },
     ENV,
   );

--- a/apps/api/test/auth-verify.test.ts
+++ b/apps/api/test/auth-verify.test.ts
@@ -21,7 +21,7 @@ const ENV = {
 describe("PATCH email-verifications / password-resets（DB 到達前の分岐）", () => {
   it("不正 token の email 検証 → 400 Invalid or expired verification link.", async () => {
     const res = await authRoutes.request(
-      "/api/auth/email-verifications/invalid-token",
+      "/email-verifications/invalid-token",
       { method: "PATCH" },
       ENV,
     );
@@ -32,7 +32,7 @@ describe("PATCH email-verifications / password-resets（DB 到達前の分岐）
 
   it("password reset: new_password 欠落 → 400 required（uid/token 検証より前）", async () => {
     const res = await authRoutes.request(
-      "/api/auth/password-resets/sometoken",
+      "/password-resets/sometoken",
       { method: "PATCH", headers: { "content-type": "application/json" }, body: "{}" },
       ENV,
     );
@@ -43,7 +43,7 @@ describe("PATCH email-verifications / password-resets（DB 到達前の分岐）
 
   it("password reset: 12 文字未満 → 400 min_length（validate_password より前）", async () => {
     const res = await authRoutes.request(
-      "/api/auth/password-resets/sometoken",
+      "/password-resets/sometoken",
       {
         method: "PATCH",
         headers: { "content-type": "application/json" },
@@ -60,7 +60,7 @@ describe("PATCH email-verifications / password-resets（DB 到達前の分岐）
 
   it("password reset: 数字のみの 12+ password → validate_password が走る", async () => {
     const res = await authRoutes.request(
-      "/api/auth/password-resets/sometoken",
+      "/password-resets/sometoken",
       {
         method: "PATCH",
         headers: { "content-type": "application/json" },

--- a/apps/api/test/chat-completions.test.ts
+++ b/apps/api/test/chat-completions.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
-import { chatRoutes } from "../src/features/chat/routes";
+import { chatCompletionsRoutes } from "../src/features/chat/routes";
 import { openAiCompletionBodySchema } from "../src/features/chat/schemas";
 import { signAccessToken } from "./helpers/auth";
 
 /**
- * OpenAI 互換 POST /api/v1/chat/completions（OpenAIChatCompletionsView）。
+ * OpenAI 互換 POST /completions（OpenAIChatCompletionsView）。
  * 認証は Bearer <API キー> / ApiKey / JWT の順、共有アクセスは無し。
  */
 import {
@@ -75,8 +75,8 @@ async function accessToken(userId = 5) {
 }
 
 const post = (body: unknown, headers: Record<string, string> = {}) =>
-  chatRoutes.request(
-    "/api/v1/chat/completions",
+  chatCompletionsRoutes.request(
+    "/completions",
     {
       method: "POST",
       headers: { "content-type": "application/json", ...headers },
@@ -104,7 +104,7 @@ function stubOpenAi(content = "Answer [1].") {
   return requests;
 }
 
-describe("POST /api/v1/chat/completions", () => {
+describe("POST /completions", () => {
   it("認証なしは 401", async () => {
     const res = await post({ messages: [{ role: "user", content: "hi" }] });
     expect(res.status).toBe(401);
@@ -267,8 +267,8 @@ describe("POST /api/v1/chat/completions", () => {
 
   it("LLM キー未設定は 400 invalid_request_error、プロバイダ障害は 500 api_error", async () => {
     vi.stubGlobal("fetch", async () => new Response("boom", { status: 500 }));
-    const res = await chatRoutes.request(
-      "/api/v1/chat/completions",
+    const res = await chatCompletionsRoutes.request(
+      "/completions",
       {
         method: "POST",
         headers: {
@@ -285,8 +285,8 @@ describe("POST /api/v1/chat/completions", () => {
     // 上流のレスポンス本文は伏せる（ChatView と同じ扱い）
     expect(body.error.message).toBe("An internal server error occurred.");
 
-    const noKey = await chatRoutes.request(
-      "/api/v1/chat/completions",
+    const noKey = await chatCompletionsRoutes.request(
+      "/completions",
       {
         method: "POST",
         headers: {
@@ -311,8 +311,8 @@ describe("POST /api/v1/chat/completions", () => {
 
   it("末尾スラッシュ無しパスを正とする（Phase 3）", async () => {
     stubOpenAi();
-    const res = await chatRoutes.request(
-      "/api/v1/chat/completions",
+    const res = await chatCompletionsRoutes.request(
+      "/completions",
       {
         method: "POST",
         headers: {

--- a/apps/api/test/chat-history.test.ts
+++ b/apps/api/test/chat-history.test.ts
@@ -91,10 +91,10 @@ const request = async (path: string, method: string, token?: string) =>
     ENV,
   );
 
-describe("GET /api/chat/groups/:id/history/?download=csv", () => {
+describe("GET /groups/:id/history/?download=csv", () => {
   it("CRLF・最小引用・compact JSON の CSV を返す", async () => {
     const res = await request(
-      "/api/chat/groups/3/history?download=csv",
+      "/groups/3/history?download=csv",
       "GET",
       await accessToken(),
     );
@@ -112,7 +112,7 @@ describe("GET /api/chat/groups/:id/history/?download=csv", () => {
     rowsFor = (sql) =>
       sql.includes("video_groups") ? [] : defaultRows(sql);
     const res = await request(
-      "/api/chat/groups/3/history?download=csv",
+      "/groups/3/history?download=csv",
       "GET",
       await accessToken(),
     );
@@ -123,7 +123,7 @@ describe("GET /api/chat/groups/:id/history/?download=csv", () => {
   });
 
   it("未認証は 401", async () => {
-    const res = await request("/api/chat/groups/3/history?download=csv", "GET");
+    const res = await request("/groups/3/history?download=csv", "GET");
     expect(res.status).toBe(401);
   });
 });
@@ -179,9 +179,9 @@ describe("CSV の細部", () => {
   });
 });
 
-describe("DELETE /api/chat/groups/:id/history/", () => {
+describe("DELETE /groups/:id/history/", () => {
   it("評価 → chat log の順に削除して 204 を返す", async () => {
-    const res = await request("/api/chat/groups/3/history", "DELETE", await accessToken());
+    const res = await request("/groups/3/history", "DELETE", await accessToken());
     expect(res.status).toBe(204);
     expect(await res.text()).toBe("");
 
@@ -197,7 +197,7 @@ describe("DELETE /api/chat/groups/:id/history/", () => {
 
   it("グループが無ければ ROLLBACK して 404", async () => {
     rowsFor = () => [];
-    const res = await request("/api/chat/groups/3/history", "DELETE", await accessToken());
+    const res = await request("/groups/3/history", "DELETE", await accessToken());
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({
       error: { code: "VALIDATION_ERROR", message: "Group not found." },
@@ -206,7 +206,7 @@ describe("DELETE /api/chat/groups/:id/history/", () => {
   });
 
   it("未認証は 401", async () => {
-    const res = await request("/api/chat/groups/3/history", "DELETE");
+    const res = await request("/groups/3/history", "DELETE");
     expect(res.status).toBe(401);
   });
 });

--- a/apps/api/test/chat-send.test.ts
+++ b/apps/api/test/chat-send.test.ts
@@ -156,16 +156,16 @@ const sseEvents = (text: string) =>
     .filter((f) => f.startsWith("data: "))
     .map((f) => JSON.parse(f.slice(6)));
 
-describe("POST /api/chat/messages（非ストリーミング）", () => {
+describe("POST /messages（非ストリーミング）", () => {
   it("認証なしは 401", async () => {
-    const res = await post("/api/chat/messages", {
+    const res = await post("/messages", {
       messages: [{ role: "user", content: "hi" }],
     });
     expect(res.status).toBe(401);
   });
 
   it("バリデーション失敗は {error:{code,message,details}}", async () => {
-    const res = await post("/api/chat/messages", {}, { token: await accessToken() });
+    const res = await post("/messages", {}, { token: await accessToken() });
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error.code).toBe("VALIDATION_ERROR");
@@ -173,7 +173,7 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
   });
 
   it("messages が空配列なら 400（Zod min(1)）", async () => {
-    const res = await post("/api/chat/messages", { messages: [] }, { token: await accessToken() });
+    const res = await post("/messages", { messages: [] }, { token: await accessToken() });
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error.code).toBe("VALIDATION_ERROR");
@@ -191,7 +191,7 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
       put: async () => {},
     };
     const res = await post(
-      "/api/chat/messages",
+      "/messages",
       {
         messages: [{ role: "user", content: "hi" }],
         group_id: 3,
@@ -215,7 +215,7 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
   it("group_id ありで RAG → citations / chat_log_id を返し、利用量を記録する", async () => {
     const requests = stubOpenAi({});
     const res = await post(
-      "/api/chat/messages",
+      "/messages",
       { messages: [{ role: "user", content: "何が起きた?" }], group_id: 3 },
       {
         token: await accessToken(),
@@ -282,7 +282,7 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
   it("グループが解決できなければ 404", async () => {
     rowsFor = (sql) => (sql.includes("video_groups") ? [] : defaultRows(sql));
     const res = await post(
-      "/api/chat/messages",
+      "/messages",
       { messages: [{ role: "user", content: "hi" }], group_id: 3 },
       { token: await accessToken(), env: OPENAI_ENV },
     );
@@ -298,7 +298,7 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
         ? [{ is_over_quota: false, ai_answers_limit: 100, used_ai_answers: 100 }]
         : defaultRows(sql);
     const res = await post(
-      "/api/chat/messages",
+      "/messages",
       { messages: [{ role: "user", content: "hi" }] },
       { token: await accessToken(), env: OPENAI_ENV },
     );
@@ -317,7 +317,7 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
         ? [{ isOverQuota: true, aiAnswersLimit: null, usedAiAnswers: 0 }]
         : defaultRows(sql);
     const res = await post(
-      "/api/chat/messages",
+      "/messages",
       { messages: [{ role: "user", content: "hi" }] },
       { token: await accessToken(), env: OPENAI_ENV },
     );
@@ -333,7 +333,7 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
   it("LLM プロバイダ障害は 500 でメッセージをマスクする", async () => {
     vi.stubGlobal("fetch", async () => new Response("upstream boom", { status: 503 }));
     const res = await post(
-      "/api/chat/messages",
+      "/messages",
       { messages: [{ role: "user", content: "hi" }] },
       { token: await accessToken(), env: OPENAI_ENV },
     );
@@ -346,7 +346,7 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
   it("共有アクセス（share_slug）は group 所有者で処理し is_shared_origin=true で保存", async () => {
     stubOpenAi({});
     const res = await chatRoutes.request(
-      "/api/chat/messages?share_slug=abc123",
+      "/messages?share_slug=abc123",
       {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -374,7 +374,7 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
 
   it("共有アクセスで group_id が無ければ 400", async () => {
     const res = await chatRoutes.request(
-      "/api/chat/messages?share_token=abc123",
+      "/messages?share_token=abc123",
       {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -389,10 +389,10 @@ describe("POST /api/chat/messages（非ストリーミング）", () => {
   });
 });
 
-describe("POST /api/chat/messages/stream（SSE）", () => {
+describe("POST /messages/stream（SSE）", () => {
   it("バリデーション失敗は非ストリームと同じ {error:{code,message,details}}", async () => {
     const res = await post(
-      "/api/chat/messages/stream",
+      "/messages/stream",
       { messages: [{ role: "bad", content: "hi" }] },
       { token: await accessToken() },
     );
@@ -404,7 +404,7 @@ describe("POST /api/chat/messages/stream（SSE）", () => {
 
   it("messages が空配列なら 400（Zod min(1)、ストリーム開始前）", async () => {
     const res = await post(
-      "/api/chat/messages/stream",
+      "/messages/stream",
       { messages: [] },
       { token: await accessToken() },
     );
@@ -417,7 +417,7 @@ describe("POST /api/chat/messages/stream（SSE）", () => {
   it("チャンク → done（citations 付き）の順で流す", async () => {
     stubOpenAi({ stream: true, content: "Hello!" });
     const res = await post(
-      "/api/chat/messages/stream",
+      "/messages/stream",
       { messages: [{ role: "user", content: "hi" }], group_id: 3 },
       { token: await accessToken(), env: OPENAI_ENV },
     );
@@ -456,7 +456,7 @@ describe("POST /api/chat/messages/stream（SSE）", () => {
         ? [{ isOverQuota: true, aiAnswersLimit: null, usedAiAnswers: 0 }]
         : defaultRows(sql);
     const res = await post(
-      "/api/chat/messages/stream",
+      "/messages/stream",
       { messages: [{ role: "user", content: "hi" }] },
       { token: await accessToken(), env: OPENAI_ENV },
     );
@@ -472,7 +472,7 @@ describe("POST /api/chat/messages/stream（SSE）", () => {
 
   it("OpenAI キー未設定は SSE の LLM_CONFIGURATION_ERROR", async () => {
     const res = await post(
-      "/api/chat/messages/stream",
+      "/messages/stream",
       { messages: [{ role: "user", content: "hi" }] },
       { token: await accessToken() },
     );
@@ -491,7 +491,7 @@ describe("POST /api/chat/messages/stream（SSE）", () => {
   it("生成中のプロバイダ障害は SSE の LLM_PROVIDER_ERROR（メッセージはマスク）", async () => {
     vi.stubGlobal("fetch", async () => new Response("boom", { status: 502 }));
     const res = await post(
-      "/api/chat/messages/stream",
+      "/messages/stream",
       { messages: [{ role: "user", content: "hi" }] },
       { token: await accessToken(), env: OPENAI_ENV },
     );

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -59,7 +59,7 @@ const jsonrpc = (method: string, params?: unknown, id: number | null = 1) => {
 
 const post = (body: unknown, headers: Record<string, string> = {}) =>
   mcpRoutes.request(
-    "/api/mcp",
+    "/",
     {
       method: "POST",
       headers: {
@@ -75,7 +75,7 @@ const post = (body: unknown, headers: Record<string, string> = {}) =>
 describe("MCP auth", () => {
   it("rejects unauthenticated with WWW-Authenticate resource_metadata", async () => {
     const res = await mcpRoutes.request(
-      "/api/mcp",
+      "/",
       {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -93,7 +93,7 @@ describe("MCP auth", () => {
 
   it("accepts X-API-Key", async () => {
     const res = await mcpRoutes.request(
-      "/api/mcp",
+      "/",
       {
         method: "POST",
         headers: {
@@ -120,7 +120,7 @@ describe("MCP auth", () => {
       return [];
     };
     const res = await mcpRoutes.request(
-      "/api/mcp",
+      "/",
       {
         method: "POST",
         headers: {
@@ -144,7 +144,7 @@ describe("MCP auth", () => {
 });
 
 describe("MCP JSON-RPC", () => {
-  it("serves /api/mcp without trailing slash (no redirect)", async () => {
+  it("serves / without trailing slash (no redirect)", async () => {
     const res = await post(jsonrpc("initialize", { protocolVersion: "2025-03-26" }));
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -210,7 +210,7 @@ describe("MCP JSON-RPC", () => {
 
   it("GET returns 405", async () => {
     const res = await mcpRoutes.request(
-      "/api/mcp",
+      "/",
       { method: "GET", headers: { authorization: `Bearer ${RAW_KEY}` } },
       ENV,
     );
@@ -219,7 +219,7 @@ describe("MCP JSON-RPC", () => {
 
   it("DELETE returns 204", async () => {
     const res = await mcpRoutes.request(
-      "/api/mcp",
+      "/",
       { method: "DELETE", headers: { authorization: `Bearer ${RAW_KEY}` } },
       ENV,
     );

--- a/apps/api/test/media.test.ts
+++ b/apps/api/test/media.test.ts
@@ -71,15 +71,15 @@ describe("isSafeMediaPath", () => {
   });
 });
 
-describe("GET /api/media/*", () => {
+describe("GET /*", () => {
   it("401 without credentials", async () => {
-    const res = await mediaRoutes.request("/api/media/videos/a.mp4", {}, ENV);
+    const res = await mediaRoutes.request("/videos/a.mp4", {}, ENV);
     expect(res.status).toBe(401);
   });
 
   it("404 on path traversal even when authenticated", async () => {
     const res = await mediaRoutes.request(
-      "/api/media/../secret",
+      "/../secret",
       { headers: { authorization: `Bearer ${await accessToken()}` } },
       ENV,
     );
@@ -94,7 +94,7 @@ describe("GET /api/media/*", () => {
       return [];
     };
     const res = await mediaRoutes.request(
-      "/api/media/videos/a.mp4",
+      "/videos/a.mp4",
       { headers: { authorization: `Bearer ${await accessToken()}` } },
       ENV,
     );
@@ -113,7 +113,7 @@ describe("GET /api/media/*", () => {
       return [];
     };
     const res = await mediaRoutes.request(
-      "/api/media/videos/a.mp4?share_slug=abc",
+      "/videos/a.mp4?share_slug=abc",
       {},
       ENV,
     );

--- a/apps/api/test/oauth-dcr-mgmt.test.ts
+++ b/apps/api/test/oauth-dcr-mgmt.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { oauthRoutes } from "../src/features/oauth/routes";
+import {
+  oauthRoutes,
+  oauthWellKnownRoutes,
+} from "../src/features/oauth/routes";
 import { DCR_REGISTRATION_SCOPE } from "../src/lib/oauth";
 
 import { executeFakePgQuery, type MatchableSql, type PgQueryInput } from "./helpers/pg-fake";
@@ -52,9 +55,9 @@ beforeEach(() => {
 });
 
 describe("OAuth metadata prefix alias", () => {
-  it("/api/oauth/.well-known/oauth-authorization-server も 200（root と同一内容）", async () => {
-    const res = await oauthRoutes.request(
-      "/api/oauth/.well-known/oauth-authorization-server",
+  it("/.well-known/oauth-authorization-server も 200（root と同一内容）", async () => {
+    const res = await oauthWellKnownRoutes.request(
+      "/.well-known/oauth-authorization-server",
       {},
       ENV,
     );
@@ -68,7 +71,7 @@ describe("OAuth metadata prefix alias", () => {
 describe("DCR management (RFC 7592)", () => {
   it("DELETE 認証なし → 401 invalid_token", async () => {
     const res = await oauthRoutes.request(
-      "/api/oauth/register/client-abc",
+      "/register/client-abc",
       { method: "DELETE" },
       ENV,
     );
@@ -79,7 +82,7 @@ describe("DCR management (RFC 7592)", () => {
   it("DELETE 有効トークン → 204", async () => {
     rowsFor = (sql) => (/JOIN oauth_applications/.test(sql) ? [regRow] : []);
     const res = await oauthRoutes.request(
-      "/api/oauth/register/client-abc",
+      "/register/client-abc",
       { method: "DELETE", headers: { Authorization: "Bearer old-reg-token" } },
       ENV,
     );
@@ -89,7 +92,7 @@ describe("DCR management (RFC 7592)", () => {
   it("PUT 有効トークン + メタデータ → 200 + 新しい registration_access_token", async () => {
     rowsFor = (sql) => (/JOIN oauth_applications/.test(sql) ? [regRow] : []);
     const res = await oauthRoutes.request(
-      "/api/oauth/register/client-abc",
+      "/register/client-abc",
       {
         method: "PUT",
         headers: { Authorization: "Bearer old-reg-token", "content-type": "application/json" },
@@ -109,7 +112,7 @@ describe("DCR management (RFC 7592)", () => {
   it("PUT 不正メタデータ（redirect_uris 非配列）→ 400", async () => {
     rowsFor = (sql) => (/JOIN oauth_applications/.test(sql) ? [regRow] : []);
     const res = await oauthRoutes.request(
-      "/api/oauth/register/client-abc",
+      "/register/client-abc",
       {
         method: "PUT",
         headers: { Authorization: "Bearer old-reg-token", "content-type": "application/json" },

--- a/apps/api/test/oauth-tokens.test.ts
+++ b/apps/api/test/oauth-tokens.test.ts
@@ -47,9 +47,9 @@ async function accessToken(userId = 7) {
   return signAccessToken(SECRET, userId);
 }
 
-describe("GET /api/oauth/tokens/", () => {
+describe("GET /tokens/", () => {
   it("rejects unauthenticated requests", async () => {
-    const res = await oauthRoutes.request("/api/oauth/tokens", { method: "GET" }, ENV);
+    const res = await oauthRoutes.request("/tokens", { method: "GET" }, ENV);
     expect(res.status).toBe(401);
   });
 
@@ -70,7 +70,7 @@ describe("GET /api/oauth/tokens/", () => {
       return [];
     };
     const res = await oauthRoutes.request(
-      "/api/oauth/tokens",
+      "/tokens",
       {
         method: "GET",
         headers: { Authorization: `Bearer ${await accessToken()}` },
@@ -95,7 +95,7 @@ describe("GET /api/oauth/tokens/", () => {
   });
 });
 
-describe("DELETE /api/oauth/tokens/:id/", () => {
+describe("DELETE /tokens/:id/", () => {
   it("returns 204 and revokes refresh tokens for the same app", async () => {
     rowsFor = (sql) => {
       if (
@@ -108,7 +108,7 @@ describe("DELETE /api/oauth/tokens/:id/", () => {
       return [];
     };
     const res = await oauthRoutes.request(
-      "/api/oauth/tokens/11",
+      "/tokens/11",
       {
         method: "DELETE",
         headers: { Authorization: `Bearer ${await accessToken()}` },
@@ -133,7 +133,7 @@ describe("DELETE /api/oauth/tokens/:id/", () => {
   it("returns 404 when token is missing", async () => {
     rowsFor = () => [];
     const res = await oauthRoutes.request(
-      "/api/oauth/tokens/999",
+      "/tokens/999",
       {
         method: "DELETE",
         headers: { Authorization: `Bearer ${await accessToken()}` },

--- a/apps/api/test/plog-edit.test.ts
+++ b/apps/api/test/plog-edit.test.ts
@@ -117,10 +117,10 @@ const req = async (
     ENV,
   );
 
-describe("POST /api/videos/:id/plog/concepts/", () => {
+describe("POST /:id/plog/concepts/", () => {
   it("label 必須・作成で 201", async () => {
     const empty = await req(
-      "/api/videos/1/plog/concepts",
+      "/1/plog/concepts",
       "POST",
       { label: "  " },
       await token(),
@@ -131,7 +131,7 @@ describe("POST /api/videos/:id/plog/concepts/", () => {
     });
 
     const res = await req(
-      "/api/videos/1/plog/concepts",
+      "/1/plog/concepts",
       "POST",
       { label: "AND", node_type: "object", intro_sec: 1.5 },
       await token(),
@@ -154,7 +154,7 @@ describe("POST /api/videos/:id/plog/concepts/", () => {
       return [];
     };
     const res = await req(
-      "/api/videos/1/plog/concepts",
+      "/1/plog/concepts",
       "POST",
       { label: "X" },
       await token(),
@@ -171,7 +171,7 @@ describe("POST /api/videos/:id/plog/concepts/", () => {
   it("他人の動画は 404", async () => {
     rowsFor = () => [];
     const res = await req(
-      "/api/videos/1/plog/concepts",
+      "/1/plog/concepts",
       "POST",
       { label: "X" },
       await token(),
@@ -183,7 +183,7 @@ describe("POST /api/videos/:id/plog/concepts/", () => {
   });
 });
 
-describe("POST /api/videos/:id/plog/edges/", () => {
+describe("POST /:id/plog/edges/", () => {
   it("サイクルになる ordering 辺は 400", async () => {
     rowsFor = (sql, args) => {
       if (sql.includes("videos") && sql.includes("user_id")) return [{ id: 1 }];
@@ -199,7 +199,7 @@ describe("POST /api/videos/:id/plog/edges/", () => {
       return [];
     };
     const res = await req(
-      "/api/videos/1/plog/edges",
+      "/1/plog/edges",
       "POST",
       { source_id: 10, target_id: 11, edge_type: "prerequisite_of" },
       await token(),
@@ -242,7 +242,7 @@ describe("POST /api/videos/:id/plog/edges/", () => {
       return [];
     };
     const res = await req(
-      "/api/videos/1/plog/edges",
+      "/1/plog/edges",
       "POST",
       { source_id: 10, target_id: 11, edge_type: "prerequisite_of" },
       await token(),
@@ -266,7 +266,7 @@ describe("DELETE concept / learner-state", () => {
       return [];
     };
     const res = await req(
-      "/api/videos/1/plog/concepts/10",
+      "/1/plog/concepts/10",
       "DELETE",
       undefined,
       await token(),
@@ -288,7 +288,7 @@ describe("DELETE concept / learner-state", () => {
       return [];
     };
     const res = await req(
-      "/api/videos/1/plog/learner-state",
+      "/1/plog/learner-state",
       "DELETE",
       undefined,
       await token(),
@@ -301,7 +301,7 @@ describe("DELETE concept / learner-state", () => {
 describe("POST merge", () => {
   it("同一 ID は 400、成功時は survivor を返す", async () => {
     const same = await req(
-      "/api/videos/1/plog/concepts/10/merge",
+      "/1/plog/concepts/10/merge",
       "POST",
       { absorb_id: 10 },
       await token(),
@@ -334,7 +334,7 @@ describe("POST merge", () => {
       return [];
     };
     const res = await req(
-      "/api/videos/1/plog/concepts/10/merge",
+      "/1/plog/concepts/10/merge",
       "POST",
       { absorb_id: 11 },
       await token(),

--- a/apps/api/test/schema.test.ts
+++ b/apps/api/test/schema.test.ts
@@ -14,6 +14,11 @@ describe("OpenAPI / docs", () => {
     const body = (await res.json()) as { openapi: string; paths: Record<string, unknown> };
     expect(body.openapi).toMatch(/^3\./);
     expect(Object.keys(body.paths).length).toBeGreaterThan(0);
+    // prefix マウント後も公開 path が合成されていること
+    expect(body.paths).toHaveProperty("/api/auth/sessions");
+    expect(body.paths).toHaveProperty("/api/videos");
+    expect(body.paths).toHaveProperty("/api/chat/messages");
+    expect(body.paths).toHaveProperty("/api/v1/chat/completions");
   });
 
   it("GET /api/docs は HTML（Scalar）", async () => {

--- a/apps/api/test/searchapi-key.test.ts
+++ b/apps/api/test/searchapi-key.test.ts
@@ -38,37 +38,37 @@ const put = async (body: unknown) => ({
   body: JSON.stringify(body),
 });
 
-describe("/api/auth/searchapi-key のガードと serializer（DB 到達前）", () => {
+describe("/searchapi-key のガードと serializer（DB 到達前）", () => {
   it("認証なしは 401（GET/PUT/DELETE）", async () => {
     for (const method of ["GET", "PUT", "DELETE"]) {
-      const res = await authRoutes.request("/api/auth/searchapi-key", { method }, ENV);
+      const res = await authRoutes.request("/searchapi-key", { method }, ENV);
       expect(res.status, method).toBe(401);
     }
   });
 
   it("api_key 欠落 → 400 required", async () => {
-    const res = await authRoutes.request("/api/auth/searchapi-key", await put({}), ENV);
+    const res = await authRoutes.request("/searchapi-key", await put({}), ENV);
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error.details.api_key).toEqual(["Invalid input: expected string, received undefined"]);
   });
 
   it("空文字は CharField の blank エラー", async () => {
-    const res = await authRoutes.request("/api/auth/searchapi-key", await put({ api_key: "" }), ENV);
+    const res = await authRoutes.request("/searchapi-key", await put({ api_key: "" }), ENV);
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error.details.api_key).toEqual(["Too small: expected string to have >=1 characters"]);
   });
 
   it("空白のみは trim_whitespace 後に blank 扱い", async () => {
-    const res = await authRoutes.request("/api/auth/searchapi-key", await put({ api_key: "   " }), ENV);
+    const res = await authRoutes.request("/searchapi-key", await put({ api_key: "   " }), ENV);
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error.details.api_key).toEqual(["Too small: expected string to have >=1 characters"]);
   });
 
   it("null は null エラー", async () => {
-    const res = await authRoutes.request("/api/auth/searchapi-key", await put({ api_key: null }), ENV);
+    const res = await authRoutes.request("/searchapi-key", await put({ api_key: null }), ENV);
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error.details.api_key).toEqual(["Invalid input: expected string, received null"]);

--- a/apps/api/test/videos-multipart.test.ts
+++ b/apps/api/test/videos-multipart.test.ts
@@ -105,12 +105,12 @@ beforeEach(() => {
   });
 });
 
-describe("POST /api/videos/ — USE_S3_STORAGE=true（廃線）", () => {
+describe("POST / — USE_S3_STORAGE=true（廃線）", () => {
   const ENV = { ...baseEnv, USE_S3_STORAGE: "true" } as unknown as Record<string, unknown>;
 
   it("認証済みでも 400 で署名 URL 経路を案内する", async () => {
     const res = await videoRoutes.request(
-      "/api/videos",
+      "/",
       {
         method: "POST",
         headers: {
@@ -132,12 +132,12 @@ describe("POST /api/videos/ — USE_S3_STORAGE=true（廃線）", () => {
   });
 });
 
-describe("POST /api/videos/ — USE_S3_STORAGE=false（multipart）", () => {
+describe("POST / — USE_S3_STORAGE=false（multipart）", () => {
   const ENV = { ...baseEnv, USE_S3_STORAGE: "false" } as unknown as Record<string, unknown>;
 
   it("未認証は 401", async () => {
     const res = await videoRoutes.request(
-      "/api/videos",
+      "/",
       { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
       ENV,
     );
@@ -151,7 +151,7 @@ describe("POST /api/videos/ — USE_S3_STORAGE=false（multipart）", () => {
     form.append("description", "");
 
     const res = await videoRoutes.request(
-      "/api/videos",
+      "/",
       {
         method: "POST",
         headers: { authorization: `Bearer ${await accessToken()}` },
@@ -169,11 +169,11 @@ describe("POST /api/videos/ — USE_S3_STORAGE=false（multipart）", () => {
   });
 });
 
-describe("POST /api/videos/uploads/ — local では不可", () => {
+describe("POST /uploads/ — local では不可", () => {
   it("USE_S3_STORAGE=false は 400", async () => {
     const ENV = { ...baseEnv, USE_S3_STORAGE: "false" } as unknown as Record<string, unknown>;
     const res = await videoRoutes.request(
-      "/api/videos/uploads",
+      "/uploads",
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Summary
- Mount feature routers with Hono `app.route()` prefixes and relative paths (public URLs unchanged)
- Split chat completions / OAuth·OIDC well-known routers; export `AppType` and use `c.var` for Variables
- Update feature unit tests for relative request paths and assert OpenAPI still synthesizes mounted paths

## Test plan
- [x] `cd apps/api && npm run typecheck`
- [x] `cd apps/api && npx vitest run` (291 tests)
- [ ] Smoke `/api/openapi.json` paths for auth/videos/chat/completions after deploy preview
- [ ] Hit a few authenticated endpoints (login, list videos, chat message) against Workers preview


Made with [Cursor](https://cursor.com)