### PR TITLE
Reduce worker AWS cost with SSM, arm64, and leaner ECR

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -150,16 +150,24 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build and push worker image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push worker image (linux/arm64)
         id: build-worker
         working-directory: apps/worker
         env:
           IMAGE_URI: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY_WORKER }}:${{ github.event.workflow_run.head_sha || github.sha }}
           IMAGE_URI_LATEST: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY_WORKER }}:latest
         run: |
-          docker build -f Dockerfile -t "$IMAGE_URI" -t "$IMAGE_URI_LATEST" .
-          docker push "$IMAGE_URI"
-          docker push "$IMAGE_URI_LATEST"
+          docker buildx build \
+            --platform linux/arm64 \
+            --provenance=false \
+            -f Dockerfile \
+            -t "$IMAGE_URI" \
+            -t "$IMAGE_URI_LATEST" \
+            --push \
+            .
           echo "image_uri=$IMAGE_URI" >> "$GITHUB_OUTPUT"
 
       - name: Update Lambda function code

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,15 +1,28 @@
-# SQS worker Lambda container image.
+# SQS worker Lambda container image (linux/arm64).
 FROM public.ecr.aws/lambda/python:3.12
 
-# FFmpeg / ffprobe for uploaded-video transcription
-RUN dnf install -y tar xz \
-  && curl -fsSL -o /tmp/ffmpeg.tar.xz \
-       https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz \
-  && tar -xJf /tmp/ffmpeg.tar.xz -C /tmp \
-  && cp /tmp/ffmpeg-*-amd64-static/ffmpeg /usr/local/bin/ \
-  && cp /tmp/ffmpeg-*-amd64-static/ffprobe /usr/local/bin/ \
-  && rm -rf /tmp/ffmpeg* \
-  && dnf clean all
+# Architecture for johnvansickle static ffmpeg (buildx sets TARGETARCH).
+ARG TARGETARCH=arm64
+
+# FFmpeg / ffprobe for uploaded-video audio extraction only.
+# Static build keeps the image free of shared-lib drag; tar/xz removed after install.
+RUN set -eux; \
+  case "${TARGETARCH}" in \
+    amd64|x86_64) FFARCH=amd64 ;; \
+    arm64|aarch64) FFARCH=arm64 ;; \
+    *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+  esac; \
+  dnf install -y tar xz; \
+  curl -fsSL -o /tmp/ffmpeg.tar.xz \
+    "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${FFARCH}-static.tar.xz"; \
+  tar -xJf /tmp/ffmpeg.tar.xz -C /tmp; \
+  cp /tmp/ffmpeg-*-${FFARCH}-static/ffmpeg /usr/local/bin/; \
+  cp /tmp/ffmpeg-*-${FFARCH}-static/ffprobe /usr/local/bin/; \
+  rm -rf /tmp/ffmpeg*; \
+  dnf remove -y tar xz; \
+  dnf clean all; \
+  ffmpeg -version >/dev/null; \
+  ffprobe -version >/dev/null
 
 COPY pyproject.toml README.md ./
 COPY worker_python ./worker_python

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -51,7 +51,8 @@ worker は modern schema と native job type のみを使用します。
 | `EMBEDDING_MODEL` / `EMBEDDING_VECTOR_SIZE` | `scene_embeddings` と一致するモデル・次元 |
 | `USE_S3_STORAGE` | S3 互換 object storage の利用 |
 | `R2_BUCKET_NAME` / `R2_S3_ENDPOINT` / `R2_S3_REGION` | R2 bucket / endpoint / region |
-| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 S3 API token（Lambda の `APP_SECRET_ARN` ではこの名前を使う。`AWS_ACCESS_KEY_ID` は実行ロール予約） |
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 S3 API token（Lambda の `APP_PARAM_NAME` JSON ではこの名前を使う。`AWS_ACCESS_KEY_ID` は実行ロール予約） |
+| `DB_PARAM_NAME` / `APP_PARAM_NAME` | SSM SecureString（JSON）。本番 Lambda が起動時に読む |
 | `USER_SECRET_ENCRYPTION_KEY` | AES-256-GCM のユーザー秘密復号鍵 |
 | `ENABLE_HEAVY_PIPELINE` | 文字起こし等の重量処理を有効化 |
 
@@ -79,8 +80,11 @@ python scripts/process_pending.py --video-id 83
 
 ## Lambda image
 
+本番は **linux/arm64** コンテナ（ECR）です。
+
 ```bash
-docker build -f Dockerfile -t videoq-worker .
+docker buildx build --platform linux/arm64 -f Dockerfile -t videoq-worker .
 ```
 
-handler は `handler.handler` です。
+handler は `handler.handler` です。機密は SSM SecureString
+（`DB_PARAM_NAME` / `APP_PARAM_NAME`）から読み込みます。

--- a/apps/worker/tests/test_secrets_bootstrap.py
+++ b/apps/worker/tests/test_secrets_bootstrap.py
@@ -7,9 +7,9 @@ import os
 import worker_python.secrets_bootstrap as bootstrap
 
 
-def test_canonical_r2_keys_from_app_secret(monkeypatch):
+def test_canonical_r2_keys_from_app_param(monkeypatch):
     bootstrap._LOADED = False
-    monkeypatch.setenv("APP_SECRET_ARN", "arn:aws:secretsmanager:ap-northeast-1:1:secret:app")
+    monkeypatch.setenv("APP_PARAM_NAME", "/videoq/prod/app")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ASIA_ROLE_EXAMPLE")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "role-secret")
     for key in (
@@ -21,24 +21,30 @@ def test_canonical_r2_keys_from_app_secret(monkeypatch):
         "AWS_STORAGE_BUCKET_NAME",
         "AWS_S3_ENDPOINT_URL",
         "AWS_S3_REGION_NAME",
+        "DB_PARAM_NAME",
         "DB_SECRET_ARN",
+        "APP_SECRET_ARN",
     ):
         monkeypatch.delenv(key, raising=False)
 
     class FakeClient:
-        def get_secret_value(self, SecretId):  # noqa: N803
-            assert SecretId.endswith("secret:app")
+        def get_parameter(self, Name, WithDecryption):  # noqa: N803
+            assert Name == "/videoq/prod/app"
+            assert WithDecryption is True
             return {
-                "SecretString": (
-                    '{"R2_ACCESS_KEY_ID":"AKIA_R2","R2_SECRET_ACCESS_KEY":"r2-secret",'
-                    '"R2_BUCKET_NAME":"videoq-media-prod",'
-                    '"R2_S3_ENDPOINT":"https://example.r2.cloudflarestorage.com",'
-                    '"R2_S3_REGION":"auto"}'
-                )
+                "Parameter": {
+                    "Value": (
+                        '{"R2_ACCESS_KEY_ID":"AKIA_R2","R2_SECRET_ACCESS_KEY":"r2-secret",'
+                        '"R2_BUCKET_NAME":"videoq-media-prod",'
+                        '"R2_S3_ENDPOINT":"https://example.r2.cloudflarestorage.com",'
+                        '"R2_S3_REGION":"auto"}'
+                    )
+                }
             }
 
     class FakeBoto3:
-        def client(self, _name):
+        def client(self, name):
+            assert name == "ssm"
             return FakeClient()
 
     monkeypatch.setitem(__import__("sys").modules, "boto3", FakeBoto3())
@@ -56,28 +62,33 @@ def test_canonical_r2_keys_from_app_secret(monkeypatch):
 
 def test_legacy_aws_secret_keys_map_to_r2(monkeypatch):
     bootstrap._LOADED = False
-    monkeypatch.setenv("APP_SECRET_ARN", "arn:aws:secretsmanager:ap-northeast-1:1:secret:app")
+    monkeypatch.setenv("APP_PARAM_NAME", "/videoq/prod/app")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ASIA_ROLE_EXAMPLE")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "role-secret")
     for key in (
         "R2_ACCESS_KEY_ID",
         "R2_SECRET_ACCESS_KEY",
         "R2_BUCKET_NAME",
+        "DB_PARAM_NAME",
         "DB_SECRET_ARN",
+        "APP_SECRET_ARN",
     ):
         monkeypatch.delenv(key, raising=False)
 
     class FakeClient:
-        def get_secret_value(self, SecretId):  # noqa: N803
+        def get_parameter(self, Name, WithDecryption):  # noqa: N803
             return {
-                "SecretString": (
-                    '{"AWS_ACCESS_KEY_ID":"AKIA_LEGACY","AWS_SECRET_ACCESS_KEY":"legacy",'
-                    '"AWS_STORAGE_BUCKET_NAME":"videoq-media-prod"}'
-                )
+                "Parameter": {
+                    "Value": (
+                        '{"AWS_ACCESS_KEY_ID":"AKIA_LEGACY","AWS_SECRET_ACCESS_KEY":"legacy",'
+                        '"AWS_STORAGE_BUCKET_NAME":"videoq-media-prod"}'
+                    )
+                }
             }
 
     class FakeBoto3:
-        def client(self, _name):
+        def client(self, name):
+            assert name == "ssm"
             return FakeClient()
 
     monkeypatch.setitem(__import__("sys").modules, "boto3", FakeBoto3())
@@ -86,3 +97,32 @@ def test_legacy_aws_secret_keys_map_to_r2(monkeypatch):
     assert os.environ["AWS_ACCESS_KEY_ID"] == "ASIA_ROLE_EXAMPLE"
     assert os.environ["R2_ACCESS_KEY_ID"] == "AKIA_LEGACY"
     assert os.environ["R2_BUCKET_NAME"] == "videoq-media-prod"
+
+
+def test_legacy_env_names_still_resolve_params(monkeypatch):
+    """DB_SECRET_ARN / APP_SECRET_ARN env keys can hold SSM names during cutover."""
+    bootstrap._LOADED = False
+    monkeypatch.setenv("DB_SECRET_ARN", "/videoq/prod/db")
+    monkeypatch.delenv("DB_PARAM_NAME", raising=False)
+    monkeypatch.delenv("APP_PARAM_NAME", raising=False)
+    monkeypatch.delenv("APP_SECRET_ARN", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    class FakeClient:
+        def get_parameter(self, Name, WithDecryption):  # noqa: N803
+            assert Name == "/videoq/prod/db"
+            return {
+                "Parameter": {
+                    "Value": '{"DATABASE_URL":"postgresql://example/db"}'
+                }
+            }
+
+    class FakeBoto3:
+        def client(self, name):
+            assert name == "ssm"
+            return FakeClient()
+
+    monkeypatch.setitem(__import__("sys").modules, "boto3", FakeBoto3())
+    bootstrap.ensure_secrets_loaded()
+
+    assert os.environ["DATABASE_URL"] == "postgresql://example/db"

--- a/apps/worker/worker_python/secrets_bootstrap.py
+++ b/apps/worker/worker_python/secrets_bootstrap.py
@@ -1,8 +1,8 @@
-"""Load Secrets Manager payloads into process env for Lambda.
+"""Load SSM SecureString payloads into process env for Lambda.
 
 Lambda injects reserved AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for the
 execution role. R2 credentials must therefore live under R2_* names in
-APP_SECRET_ARN and are loaded into R2_* process env vars.
+APP_PARAM_NAME and are loaded into R2_* process env vars.
 """
 
 from __future__ import annotations
@@ -39,9 +39,9 @@ def ensure_secrets_loaded() -> None:
         return
     _LOADED = True
 
-    db_arn = os.environ.get("DB_SECRET_ARN", "").strip()
-    app_arn = os.environ.get("APP_SECRET_ARN", "").strip()
-    if not db_arn and not app_arn:
+    db_param = _param_ref("DB_PARAM_NAME", "DB_SECRET_ARN")
+    app_param = _param_ref("APP_PARAM_NAME", "APP_SECRET_ARN")
+    if not db_param and not app_param:
         return
 
     try:
@@ -50,17 +50,17 @@ def ensure_secrets_loaded() -> None:
         logger.warning("boto3 unavailable; skipping secrets bootstrap")
         return
 
-    client = boto3.client("secretsmanager")
+    client = boto3.client("ssm")
 
-    if db_arn and not os.environ.get("DATABASE_URL"):
-        payload = _get_json_secret(client, db_arn)
+    if db_param and not os.environ.get("DATABASE_URL"):
+        payload = _get_json_parameter(client, db_param)
         url = (payload.get("DATABASE_URL") or "").strip()
         if url:
             os.environ["DATABASE_URL"] = url
-            logger.info("Loaded DATABASE_URL from DB_SECRET_ARN")
+            logger.info("Loaded DATABASE_URL from DB_PARAM_NAME")
 
-    if app_arn:
-        payload = _get_json_secret(client, app_arn)
+    if app_param:
+        payload = _get_json_parameter(client, app_param)
         # Prefer canonical R2_* secret keys over legacy AWS_* aliases when both exist.
         for src, dest in _APP_ENV_MAP.items():
             if os.environ.get(dest):
@@ -72,7 +72,15 @@ def ensure_secrets_loaded() -> None:
         _mirror_if_missing("R2_BUCKET_NAME", "AWS_STORAGE_BUCKET_NAME")
         _mirror_if_missing("R2_S3_ENDPOINT", "AWS_S3_ENDPOINT_URL")
         _mirror_if_missing("R2_S3_REGION", "AWS_S3_REGION_NAME")
-        logger.info("Loaded app secrets from APP_SECRET_ARN")
+        logger.info("Loaded app secrets from APP_PARAM_NAME")
+
+
+def _param_ref(*env_keys: str) -> str:
+    for key in env_keys:
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+    return ""
 
 
 def _mirror_if_missing(src: str, dest: str) -> None:
@@ -83,9 +91,9 @@ def _mirror_if_missing(src: str, dest: str) -> None:
         os.environ[dest] = value
 
 
-def _get_json_secret(client: object, arn: str) -> dict:
-    response = client.get_secret_value(SecretId=arn)  # type: ignore[attr-defined]
-    raw = response.get("SecretString") or ""
+def _get_json_parameter(client: object, name: str) -> dict:
+    response = client.get_parameter(Name=name, WithDecryption=True)  # type: ignore[attr-defined]
+    raw = (response.get("Parameter") or {}).get("Value") or ""
     if not raw:
         return {}
     data = json.loads(raw)

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -86,7 +86,52 @@ curl https://videoq.jp/api/openapi.json
 
 ## 4. Worker infrastructure
 
-Terraform は SQS、worker Lambda、ECR、IAM など AWS 側の非同期基盤を管理します。
+Terraform は SQS、worker Lambda（**arm64**）、ECR、IAM、SSM Parameter Store
+など AWS 側の非同期基盤を管理します。
+
+### Secrets Manager → SSM への移行（既存環境）
+
+worker 機密は **SSM SecureString**（`/videoq/<env>/db`, `/videoq/<env>/app`）に置きます。
+`terraform apply` で旧 Secrets Manager リソースが削除される前に、値をコピーしてください。
+
+```bash
+REGION=ap-northeast-1
+
+# 1) 現行 Secrets Manager から読む
+DB_JSON=$(aws secretsmanager get-secret-value \
+  --secret-id videoq/prod/db --region "$REGION" \
+  --query SecretString --output text)
+APP_JSON=$(aws secretsmanager get-secret-value \
+  --secret-id videoq/prod/app --region "$REGION" \
+  --query SecretString --output text)
+
+# 2) SSM へ書き込み（未作成なら作成、既存なら上書き）
+aws ssm put-parameter --region "$REGION" \
+  --name /videoq/prod/db --type SecureString \
+  --value "$DB_JSON" --overwrite
+aws ssm put-parameter --region "$REGION" \
+  --name /videoq/prod/app --type SecureString \
+  --value "$APP_JSON" --overwrite
+
+# 3) すでに手動作成済みなら Terraform state へ取り込む
+cd infra
+terraform import aws_ssm_parameter.db /videoq/prod/db
+terraform import aws_ssm_parameter.app /videoq/prod/app
+
+# 4) 旧 Secrets Manager は prevent_destroy のため、state から外して apply する
+terraform state rm aws_secretsmanager_secret.db
+terraform state rm aws_secretsmanager_secret.app
+
+# 5) 旧シークレットを手動削除（課金停止。必要なら recovery window 付きでも可）
+aws secretsmanager delete-secret --region "$REGION" \
+  --secret-id videoq/prod/db --force-delete-without-recovery
+aws secretsmanager delete-secret --region "$REGION" \
+  --secret-id videoq/prod/app --force-delete-without-recovery
+```
+
+新規環境では `terraform apply` がプレースホルダ値で SSM を作ります。直後に上記
+`put-parameter --overwrite` で実値を入れてください（`value` は Terraform が
+ignore するため apply で上書きされません）。
 
 ```bash
 cd infra
@@ -97,7 +142,14 @@ terraform plan
 terraform apply
 ```
 
-worker image:
+IAM ポリシー JSON を更新した場合は `infra/iam/README.md` の更新手順で
+`videoq-terraform-deploy` を差し替えてから apply してください。
+
+**arm64 cutover:** Lambda の `architectures = ["arm64"]` とイメージ arch は一致が必須です。
+`terraform apply` の前に、下の手順で **arm64 イメージを ECR に push** してください
+（amd64 のまま arch だけ変えると更新が失敗します）。
+
+worker image（**linux/arm64**）:
 
 ```bash
 REGION=ap-northeast-1
@@ -106,9 +158,8 @@ WORKER_ECR=<account>.dkr.ecr.$REGION.amazonaws.com/videoq-worker-prod
 aws ecr get-login-password --region "$REGION" |
   docker login --username AWS --password-stdin "${WORKER_ECR%%/*}"
 
-docker build --platform linux/amd64 --provenance=false \
+docker buildx build --platform linux/arm64 --provenance=false --push \
   -f apps/worker/Dockerfile -t "$WORKER_ECR:latest" ./apps/worker
-docker push "$WORKER_ECR:latest"
 
 aws lambda update-function-code \
   --function-name videoq-worker-prod \
@@ -116,9 +167,10 @@ aws lambda update-function-code \
   --region "$REGION"
 ```
 
-### App secret (`videoq/<env>/app`) JSON schema
+### App parameter (`/videoq/<env>/app`) JSON schema
 
-Secrets Manager の app secret は **R2 用キー名を `R2_*` にする**（Terraform は secret 器のみ管理）。
+SSM SecureString の app パラメータは **R2 用キー名を `R2_*` にする**
+（Terraform はパラメータ器のみ管理。値は CLI で設定）。
 
 ```json
 {

--- a/infra/iam/README.md
+++ b/infra/iam/README.md
@@ -10,9 +10,9 @@ GitHub Actions が使う IAM ユーザー `videoq-github-actions-cd` に付与�
 | `videoq-backend-cd` | ECR へイメージ push + Lambda コード更新 | cd.yml |
 | `videoq-terraform-deploy` | インフラの CRUD (plan の refresh / apply) | terraform-plan / terraform-apply |
 
-スコープ方針: `iam`/`PassRole` は `videoq-*` ロール限定、Secrets は `videoq/prod/*`、
-SQS/Lambda/ECR は該当リソース限定。`cloudfront`/`apigateway` は resource-level 非対応
-のため広め。
+スコープ方針: `iam`/`PassRole` は `videoq-*` ロール限定、SSM は
+`parameter/videoq/prod/*`、SQS/Lambda/ECR は該当リソース限定。旧 Secrets Manager
+削除用の限定権限も `videoq-terraform-deploy` に含む。
 
 ## 適用手順
 

--- a/infra/iam/videoq-terraform-deploy.json
+++ b/infra/iam/videoq-terraform-deploy.json
@@ -21,17 +21,36 @@
       "Resource": "arn:aws:ecr:ap-northeast-1:<ACCOUNT_ID>:repository/videoq-worker-prod"
     },
     {
-      "Sid": "SecretsManagerManage",
+      "Sid": "SsmParameterManage",
       "Effect": "Allow",
       "Action": [
-        "secretsmanager:CreateSecret",
+        "ssm:AddTagsToResource",
+        "ssm:RemoveTagsFromResource",
+        "ssm:ListTagsForResource",
+        "ssm:PutParameter",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:DescribeParameters",
+        "ssm:DeleteParameter",
+        "ssm:GetParameterHistory"
+      ],
+      "Resource": "arn:aws:ssm:ap-northeast-1:<ACCOUNT_ID>:parameter/videoq/prod/*"
+    },
+    {
+      "Sid": "SsmDescribeParameters",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:DescribeParameters"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SecretsManagerCleanup",
+      "Effect": "Allow",
+      "Action": [
         "secretsmanager:DescribeSecret",
-        "secretsmanager:GetResourcePolicy",
-        "secretsmanager:PutResourcePolicy",
-        "secretsmanager:DeleteResourcePolicy",
-        "secretsmanager:TagResource",
-        "secretsmanager:UntagResource",
-        "secretsmanager:UpdateSecret"
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:GetResourcePolicy"
       ],
       "Resource": "arn:aws:secretsmanager:ap-northeast-1:<ACCOUNT_ID>:secret:videoq/prod/*"
     },

--- a/infra/lambda_worker.tf
+++ b/infra/lambda_worker.tf
@@ -10,12 +10,29 @@ resource "aws_iam_role_policy_attachment" "worker_basic_execution" {
 
 data "aws_iam_policy_document" "worker_permissions" {
   statement {
-    effect  = "Allow"
-    actions = ["secretsmanager:GetSecretValue"]
-    resources = [
-      aws_secretsmanager_secret.db.arn,
-      aws_secretsmanager_secret.app.arn,
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
     ]
+    resources = [
+      aws_ssm_parameter.db.arn,
+      aws_ssm_parameter.app.arn,
+    ]
+  }
+
+  # Decrypt SecureString values encrypted with the default aws/ssm key.
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${var.aws_region}.amazonaws.com"]
+    }
   }
 
   statement {
@@ -43,6 +60,7 @@ resource "aws_lambda_function" "worker" {
   role          = aws_iam_role.worker.arn
   package_type  = "Image"
   image_uri     = "${aws_ecr_repository.worker.repository_url}:${var.image_tag}"
+  architectures = ["arm64"]
   memory_size   = var.worker_lambda_memory_mb
   timeout       = var.worker_lambda_timeout_seconds
 

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -8,8 +8,8 @@ locals {
 
   lambda_basic_execution_policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   common_lambda_environment = {
-    DB_SECRET_ARN         = aws_secretsmanager_secret.db.arn
-    APP_SECRET_ARN        = aws_secretsmanager_secret.app.arn
+    DB_PARAM_NAME         = aws_ssm_parameter.db.name
+    APP_PARAM_NAME        = aws_ssm_parameter.app.name
     USE_S3_STORAGE        = "true"
     SQS_QUEUE_NAME        = aws_sqs_queue.main.name
     SQS_QUEUE_URL         = aws_sqs_queue.main.id
@@ -24,11 +24,24 @@ locals {
     rules = [
       {
         rulePriority = 1
-        description  = "Keep only the last 5 images"
+        description  = "Expire untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep only the last 2 tagged images"
         selection = {
           tagStatus   = "any"
           countType   = "imageCountMoreThan"
-          countNumber = 5
+          countNumber = 2
         }
         action = {
           type = "expire"

--- a/infra/openai.tf
+++ b/infra/openai.tf
@@ -3,8 +3,8 @@
 # transcription as infrastructure as code.
 #
 # Note: This provider cannot manage API keys. Continue issuing the runtime
-# OPENAI_API_KEY manually from the dashboard and saving it in the app secret
-# (secrets.tf).
+# OPENAI_API_KEY manually from the dashboard and saving it in the app SSM
+# SecureString (/videoq/<env>/app; see secrets.tf).
 #
 # While var.manage_openai_project is false (the default), every resource has
 # count=0, so plan/apply works without OPENAI_ADMIN_KEY. Set the variable to true

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,19 +1,14 @@
-output "db_secret_arn" {
-  description = "Neon DB secret ARN"
-  value       = aws_secretsmanager_secret.db.arn
+output "db_param_name" {
+  description = "Neon DB SSM SecureString parameter name"
+  value       = aws_ssm_parameter.db.name
 }
 
-output "app_secret_arn" {
-  description = "App + R2 secrets ARN"
-  value       = aws_secretsmanager_secret.app.arn
+output "app_param_name" {
+  description = "App + R2 SSM SecureString parameter name"
+  value       = aws_ssm_parameter.app.name
 }
 
 output "worker_ecr_uri" {
   description = "Worker Lambda ECR URI"
   value       = aws_ecr_repository.worker.repository_url
-}
-
-output "openai_project_id" {
-  description = "Terraform 管理下の OpenAI プロジェクト ID (未管理なら null)"
-  value       = try(openai_project.videoq[0].project_id, null)
 }

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -1,22 +1,26 @@
-# Secrets Manager
+# SSM Parameter Store (SecureString)
 #
 # External service credentials (Neon / Cloudflare R2) are set manually via CLI
-# after the initial apply. No secret versions are managed here.
+# after the initial apply. Terraform manages the parameter shells only;
+# `value` is ignored after create so apply never overwrites live secrets.
 
 # Neon PostgreSQL connection string.
 # Format: {"DATABASE_URL": "postgresql://...?sslmode=require"}
-resource "aws_secretsmanager_secret" "db" {
-  name        = "${local.name_prefix}/${var.env_name}/db"
+resource "aws_ssm_parameter" "db" {
+  name        = "/${local.name_prefix}/${var.env_name}/db"
   description = "Neon PostgreSQL DATABASE_URL (pooler endpoint)"
+  type        = "SecureString"
+  value       = jsonencode({ DATABASE_URL = "REPLACE_ME" })
 
   lifecycle {
+    ignore_changes  = [value]
     prevent_destroy = true
   }
 }
 
 # App secrets + R2 credentials for the SQS Lambda worker.
 #
-# Expected JSON keys (set via CLI / Console — not Terraform-managed versions):
+# Expected JSON keys (set via CLI / Console — not Terraform-managed values):
 #
 #   OPENAI_API_KEY
 #   USER_SECRET_ENCRYPTION_KEY
@@ -28,12 +32,23 @@ resource "aws_secretsmanager_secret" "db" {
 #
 # Do NOT store R2 credentials as AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
 # Lambda injects those names for the execution role; colliding names are skipped
-# or break AWS API calls (SQS / Secrets Manager).
-resource "aws_secretsmanager_secret" "app" {
-  name        = "${local.name_prefix}/${var.env_name}/app"
+# or break AWS API calls (SQS / SSM).
+resource "aws_ssm_parameter" "app" {
+  name        = "/${local.name_prefix}/${var.env_name}/app"
   description = "App secrets + R2 credentials (use R2_* key names, never AWS_ACCESS_KEY_ID)"
+  type        = "SecureString"
+  value = jsonencode({
+    OPENAI_API_KEY             = "REPLACE_ME"
+    USER_SECRET_ENCRYPTION_KEY = "REPLACE_ME"
+    R2_ACCESS_KEY_ID           = "REPLACE_ME"
+    R2_SECRET_ACCESS_KEY       = "REPLACE_ME"
+    R2_BUCKET_NAME             = "REPLACE_ME"
+    R2_S3_ENDPOINT             = "REPLACE_ME"
+    R2_S3_REGION               = "auto"
+  })
 
   lifecycle {
+    ignore_changes  = [value]
     prevent_destroy = true
   }
 }


### PR DESCRIPTION
## Summary
- Move Lambda worker secrets from Secrets Manager to SSM SecureString (`/videoq/<env>/db`, `/app`) to remove the ~$0.80/mo fixed cost.
- Run the worker Lambda/container on **arm64** (about 20% cheaper GB-seconds) and build/push with `linux/arm64` in CD.
- Tighten ECR lifecycle (untagged expire + keep last 2) and slim the Dockerfile ffmpeg install path.

## Test plan
- [ ] Update `videoq-terraform-deploy` IAM policy from `infra/iam/videoq-terraform-deploy.json`
- [ ] Copy Secrets Manager values to SSM, `terraform import` params, `state rm` old secrets, delete old secrets (see `infra/DEPLOY.md`)
- [ ] Push an **arm64** worker image to ECR **before** applying `architectures = ["arm64"]`
- [ ] `terraform apply` and confirm Lambda env uses `DB_PARAM_NAME` / `APP_PARAM_NAME`
- [ ] Smoke: upload video transcription (ffmpeg) and a job that needs DB/R2/OpenAI secrets
- [ ] Confirm worker unit tests still pass (`apps/worker` pytest)


Made with [Cursor](https://cursor.com)