### PR TITLE
fix(api): stop /videos/groups matching /videos/{id}

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -44,11 +44,13 @@ export function createApp() {
   app.route("/", oauthOidcWellKnownRoutes);
 
   app.route("/api/auth", authRoutes);
-  app.route("/api/videos", videoRoutes);
-  app.route("/api/videos", tagRoutes);
+  // Static segments (/groups, /tags, /{id}/plog, …) must be registered before
+  // videoRoutes' /{id}, or "groups" is coerced as a video id (NaN → 400).
   app.route("/api/videos", groupRoutes);
+  app.route("/api/videos", tagRoutes);
   app.route("/api/videos", membershipRoutes);
   app.route("/api/videos", plogRoutes);
+  app.route("/api/videos", videoRoutes);
   app.route("/api/chat", chatRoutes);
   app.route("/api/v1/chat", chatCompletionsRoutes);
   app.route("/api/evaluation", evaluationRoutes);

--- a/apps/api/test/videos-route-order.test.ts
+++ b/apps/api/test/videos-route-order.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../src/app";
+import { signAccessToken } from "./helpers/auth";
+
+const SECRET = "route-order-secret";
+
+const ENV = {
+  ENVIRONMENT: "test",
+  CORS_ALLOW_ORIGIN: "http://localhost:5173",
+  AUTH_JWT_SECRET: SECRET,
+} as unknown as Parameters<ReturnType<typeof createApp>["request"]>[2];
+
+vi.mock("../src/repositories/auth-repository", () => ({
+  isAuthSessionActive: vi.fn(async () => true),
+}));
+
+vi.mock("../src/features/groups/service", () => ({
+  listGroups: vi.fn(async () => ({ count: 0, results: [] })),
+}));
+
+describe("GET /api/videos/groups route order", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not treat 'groups' as a video id (NaN validation)", async () => {
+    const app = createApp();
+    const token = await signAccessToken(SECRET);
+    const res = await app.request(
+      "/api/videos/groups",
+      { headers: { Authorization: `Bearer ${token}` } },
+      ENV,
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).not.toMatchObject({
+      error: { message: expect.stringContaining("NaN") },
+    });
+    expect(body).toMatchObject({
+      data: [],
+      meta: { total: 0 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- After the Hono prefix-mount refactor, `videoRoutes` (`/{id}`) was registered before `groupRoutes` / `tagRoutes`.
- Authenticated `GET /api/videos/groups` was captured as video id `"groups"`, Zod coerced it to `NaN`, and the UI showed `Invalid input: expected number, received NaN`.
- Mount static segment routers before `videoRoutes`, and add a regression test.

## Test plan
- [x] `npm test -- test/videos-route-order.test.ts` in `apps/api`
- [ ] After deploy, open https://videoq.jp/ja/videos/groups while logged in


Made with [Cursor](https://cursor.com)