### PR TITLE
Fix MCP connector CORS and Accept for Claude Code

### DIFF
--- a/apps/api/src/features/mcp/routes.ts
+++ b/apps/api/src/features/mcp/routes.ts
@@ -49,7 +49,26 @@ const mcpAuth = createMiddleware<AppEnv>(async (c, next) => {
   );
 });
 
-mcpRoutes.use("*", mcpAuth, requireScope("read"));
+/**
+ * 一部クライアントは Accept に片方しか付けない。
+ * GET は text/event-stream（またはワイルドカード）が必要なので補完する。
+ */
+const normalizeMcpAccept = createMiddleware<AppEnv>(async (c, next) => {
+  const accept = c.req.header("Accept") ?? "";
+  const hasJson = accept.includes("application/json") || accept.includes("*/*");
+  const hasSse =
+    accept.includes("text/event-stream") || accept.includes("*/*");
+  if (!hasJson || !hasSse) {
+    try {
+      c.req.raw.headers.set("Accept", "application/json, text/event-stream");
+    } catch {
+      // Request headers が immutable な runtime ではそのまま進める。
+    }
+  }
+  return next();
+});
+
+mcpRoutes.use("*", normalizeMcpAccept, mcpAuth, requireScope("read"));
 
 mcpRoutes.all("/", async (c) => {
   const transport = new StreamableHTTPTransport({

--- a/apps/api/src/middleware/cors.ts
+++ b/apps/api/src/middleware/cors.ts
@@ -2,11 +2,64 @@ import { cors } from "hono/cors";
 import { createMiddleware } from "hono/factory";
 import type { AppEnv } from "../types/bindings";
 
+/** MCP / OAuth クライアントが付けるプロトコル固有ヘッダ。 */
+const PROTOCOL_ALLOW_HEADERS = [
+  "Content-Type",
+  "Authorization",
+  "X-API-Key",
+  "Accept",
+  "Mcp-Session-Id",
+  "Mcp-Protocol-Version",
+  "Last-Event-ID",
+];
+
+const PROTOCOL_EXPOSE_HEADERS = [
+  "WWW-Authenticate",
+  "Mcp-Session-Id",
+  "X-Request-Id",
+];
+
+const PROTOCOL_ALLOW_METHODS = ["GET", "POST", "DELETE", "OPTIONS"];
+
 /**
- * CORS。許可オリジンは env（Pages 本番ドメイン）に限定し、credentials(Cookie) を許可
- * （要件 AU-12 / SEC-7）。env はミドルウェア実行時に参照するため関数で包む。
+ * MCP / OAuth の公開プロトコル経路か。
+ * これらは SPA Cookie ではなく外部 MCP クライアント向けなので、
+ * `Access-Control-Allow-Origin: *`（credentials なし）で応答する。
+ */
+export function isMcpProtocolPath(pathname: string): boolean {
+  return (
+    pathname === "/api/mcp" ||
+    pathname.startsWith("/api/mcp/") ||
+    pathname.startsWith("/.well-known/") ||
+    pathname.startsWith("/api/oauth/.well-known/") ||
+    pathname === "/api/oauth/register" ||
+    pathname.startsWith("/api/oauth/register/") ||
+    pathname === "/api/oauth/token" ||
+    pathname === "/api/oauth/revoke_token" ||
+    pathname === "/api/oauth/introspect" ||
+    pathname === "/api/oauth/device-authorization"
+  );
+}
+
+/**
+ * CORS。
+ * - MCP / OAuth プロトコル: `*` + credentials なし（Claude Code / claude.ai コネクタ向け）
+ * - それ以外: env の許可オリジンに限定し credentials(Cookie) を許可
  */
 export const corsMiddleware = createMiddleware<AppEnv>(async (c, next) => {
+  const pathname = new URL(c.req.url).pathname;
+
+  if (isMcpProtocolPath(pathname)) {
+    const handler = cors({
+      origin: "*",
+      allowHeaders: PROTOCOL_ALLOW_HEADERS,
+      allowMethods: PROTOCOL_ALLOW_METHODS,
+      exposeHeaders: PROTOCOL_EXPOSE_HEADERS,
+      maxAge: 86400,
+    });
+    return handler(c, next);
+  }
+
   const allowed = (c.env.CORS_ALLOW_ORIGIN ?? "")
     .split(",")
     .map((s) => s.trim())

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createApp } from "../src/app";
 import { mcpRoutes } from "../src/features/mcp/routes";
 import { sha256Hex } from "../src/shared/crypto";
 
@@ -237,7 +238,7 @@ describe("MCP JSON-RPC", () => {
     expect(result.content[0].text).toBe("Video not found");
   });
 
-  it("GET without text/event-stream Accept returns JSON-RPC 406", async () => {
+  it("GET with application/json-only Accept is normalized to open SSE", async () => {
     const res = await mcpRoutes.request(
       "/",
       {
@@ -249,17 +250,14 @@ describe("MCP JSON-RPC", () => {
       },
       ENV,
     );
-    expect(res.status).toBe(406);
-    const body = await res.json();
-    expect(body.jsonrpc).toBe("2.0");
-    expect(body.error).toEqual(
-      expect.objectContaining({
-        message: expect.stringContaining("text/event-stream"),
-      }),
-    );
+    // Accept 補完により 406 にせず SSE を開く（Claude Code / Cowork 互換）。
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toContain("text/event-stream");
+    // ストリームを閉じる（テストがハングしないように）。
+    await res.body?.cancel();
   });
 
-  it("POST with unacceptable Accept returns JSON-RPC 406", async () => {
+  it("POST with non-MCP Accept is normalized and still serves JSON-RPC", async () => {
     const res = await mcpRoutes.request(
       "/",
       {
@@ -273,18 +271,9 @@ describe("MCP JSON-RPC", () => {
       },
       ENV,
     );
-    expect(res.status).toBe(406);
-    const body = await res.json();
-    expect(body).toEqual(
-      expect.objectContaining({
-        jsonrpc: "2.0",
-        error: expect.objectContaining({
-          message: expect.stringMatching(/application\/json|text\/event-stream/),
-        }),
-      }),
-    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ jsonrpc: "2.0", id: 1, result: {} });
   });
-
   it("DELETE ends the session with 200", async () => {
     const res = await mcpRoutes.request(
       "/",
@@ -303,5 +292,61 @@ describe("MCP JSON-RPC", () => {
   it("notification without id returns 202", async () => {
     const res = await post(jsonrpc("notifications/initialized", undefined, null));
     expect(res.status).toBe(202);
+  });
+});
+
+describe("MCP connector CORS", () => {
+  const app = createApp();
+
+  it("OPTIONS /api/mcp allows Claude.ai with wildcard origin and no credentials", async () => {
+    const res = await app.request(
+      "/api/mcp",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://claude.ai",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers":
+            "authorization,content-type,accept,mcp-protocol-version",
+        },
+      },
+      ENV,
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+    const allowHeaders = (
+      res.headers.get("Access-Control-Allow-Headers") ?? ""
+    ).toLowerCase();
+    expect(allowHeaders).toContain("authorization");
+    expect(allowHeaders).toContain("mcp-protocol-version");
+    expect(allowHeaders).toContain("accept");
+    const expose = (
+      res.headers.get("Access-Control-Expose-Headers") ?? ""
+    ).toLowerCase();
+    expect(expose).toContain("www-authenticate");
+  });
+
+  it("401 exposes WWW-Authenticate for browser clients", async () => {
+    const res = await app.request(
+      "/api/mcp",
+      {
+        method: "POST",
+        headers: {
+          Origin: "https://claude.ai",
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify(jsonrpc("initialize", initializeParams)),
+      },
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("WWW-Authenticate")).toContain("resource_metadata=");
+    const expose = (
+      res.headers.get("Access-Control-Expose-Headers") ?? ""
+    ).toLowerCase();
+    expect(expose).toContain("www-authenticate");
   });
 });

--- a/apps/api/test/oauth-as.test.ts
+++ b/apps/api/test/oauth-as.test.ts
@@ -85,6 +85,8 @@ describe("well-known metadata", () => {
     );
     expect(res.status).toBe(200);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    // credentials:true と ACAO:* の併用はブラウザが拒否するため付けない。
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
     const body = await res.json();
     expect(body.issuer).toBe("http://testserver");
     expect(body.authorization_endpoint).toBe(


### PR DESCRIPTION
## Summary
- Serve MCP/OAuth protocol endpoints with wildcard CORS and without credentials, so browser-based Claude connectors are not blocked by the `*` + `credentials` conflict
- Expose `WWW-Authenticate` and allow MCP protocol headers during preflight
- Normalize incomplete `Accept` headers to `application/json, text/event-stream` for Claude Code / Cowork handshake compatibility

## Test plan
- [ ] `cd apps/api && npm test -- test/mcp.test.ts test/oauth-as.test.ts`
- [ ] `cd apps/api && npm run typecheck`
- [ ] `curl -si -X OPTIONS https://HOST/api/mcp -H 'Origin: https://claude.ai' -H 'Access-Control-Request-Method: POST'` → `ACAO: *`, no `credentials`
- [ ] Unauthenticated POST `/api/mcp` still returns `401` with `WWW-Authenticate` + `resource_metadata`
- [ ] Re-add Claude Code connector: `claude mcp add --transport http videoq https://videoq.jp/api/mcp` and complete `/mcp` auth


Made with [Cursor](https://cursor.com)