### PR TITLE
Add Google sign-in with Better Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ POSTGRES_DB=postgres
 # USER_SECRET_ENCRYPTION_KEY: openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost
+# Google sign-in (optional; both required to enable)
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
 USER_SECRET_ENCRYPTION_KEY=
 CORS_ALLOW_ORIGIN=http://localhost,http://127.0.0.1,http://localhost:3000
 # Public address handled by Caddy. Keep the http:// prefix for local

--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -6,6 +6,9 @@
 BETTER_AUTH_SECRET=""
 # Public origin of this API (no trailing slash), e.g. http://localhost:8787
 BETTER_AUTH_URL="http://localhost:8787"
+# Google sign-in (optional). Redirect URI: {BETTER_AUTH_URL}/api/auth/callback/google
+# GOOGLE_CLIENT_ID=""
+# GOOGLE_CLIENT_SECRET=""
 # Base64url-encoded 32-byte AES-GCM key.
 USER_SECRET_ENCRYPTION_KEY=""
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -47,6 +47,8 @@ Better Auth（`/api/auth/*`）が正本です。
 - Cookie session（Better Auth）。SPA は `credentials: "include"` + `better-auth/react`
 - メール確認・パスワード再設定・メール変更は Better Auth verification フロー
 - 秘密鍵: `BETTER_AUTH_SECRET` / 公開 URL: `BETTER_AUTH_URL`
+- Google ログイン（任意）: `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET`  
+  Redirect URI: `{BETTER_AUTH_URL}/api/auth/callback/google`
 
 ### API key / OAuth
 

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -37,6 +37,43 @@ function authBaseURL(env: Bindings): string {
   );
 }
 
+/** Normalize an email local-part (or name) into a BA username candidate. */
+export function usernameFromEmail(email: string): string {
+  const local = email.split("@")[0] ?? "user";
+  let base = local
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (base.length < 3) base = `user_${base}`.replace(/_+/g, "_");
+  if (base.length < 3) base = "user";
+  return base.slice(0, 150);
+}
+
+async function allocateUniqueUsername(db: Db, preferred: string): Promise<string> {
+  let seed = preferred.includes("@")
+    ? usernameFromEmail(preferred)
+    : preferred
+        .toLowerCase()
+        .replace(/[^a-z0-9_]/g, "_")
+        .replace(/_+/g, "_")
+        .replace(/^_+|_+$/g, "")
+        .slice(0, 150);
+  if (seed.length < 3) seed = usernameFromEmail(preferred.includes("@") ? preferred : `${seed || "user"}@x`);
+
+  for (let i = 0; i < 50; i++) {
+    const suffix = i === 0 ? "" : `_${i}`;
+    const candidate = `${seed.slice(0, Math.max(1, 150 - suffix.length))}${suffix}`;
+    const rows = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.username, candidate))
+      .limit(1);
+    if (rows.length === 0) return candidate;
+  }
+  return `user_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
 /**
  * Per-request Better Auth instance bound to the Hyperdrive-backed Drizzle client.
  * Do not reuse across requests — the DB client is request-scoped.
@@ -44,6 +81,9 @@ function authBaseURL(env: Bindings): string {
 export function createAuth(env: Bindings, db: Db) {
   const quota = resolveSignupQuotaDefaults(env);
   const baseURL = authBaseURL(env);
+  const googleClientId = env.GOOGLE_CLIENT_ID?.trim();
+  const googleClientSecret = env.GOOGLE_CLIENT_SECRET?.trim();
+  const googleEnabled = Boolean(googleClientId && googleClientSecret);
 
   return betterAuth({
     database: drizzleAdapter(db, {
@@ -106,6 +146,38 @@ export function createAuth(env: Bindings, db: Db) {
           "",
           url,
         ]);
+      },
+    },
+    socialProviders: googleEnabled
+      ? {
+          google: {
+            clientId: googleClientId!,
+            clientSecret: googleClientSecret!,
+            prompt: "select_account",
+            mapProfileToUser: async (profile) => {
+              const email =
+                typeof profile.email === "string" ? profile.email : "";
+              const preferred =
+                typeof profile.name === "string" && profile.name.trim()
+                  ? profile.name.trim()
+                  : email;
+              const allocated = await allocateUniqueUsername(db, email || preferred);
+              return {
+                name: preferred || allocated,
+                email,
+                emailVerified: Boolean(profile.email_verified),
+                image: typeof profile.picture === "string" ? profile.picture : undefined,
+                username: allocated,
+                displayUsername: allocated,
+              };
+            },
+          },
+        }
+      : {},
+    account: {
+      accountLinking: {
+        enabled: true,
+        trustedProviders: ["google"],
       },
     },
     user: {
@@ -240,10 +312,18 @@ export function createAuth(env: Bindings, db: Db) {
         create: {
           before: async (user) => {
             const q = resolveSignupQuotaDefaults(env);
-            const username =
-              typeof user.username === "string" ? user.username : undefined;
+            let username =
+              typeof user.username === "string" && user.username.trim()
+                ? user.username.trim()
+                : undefined;
+            if (!username) {
+              username = await allocateUniqueUsername(
+                db,
+                typeof user.email === "string" ? user.email : "user",
+              );
+            }
             const displayUsername =
-              typeof user.displayUsername === "string"
+              typeof user.displayUsername === "string" && user.displayUsername.trim()
                 ? user.displayUsername
                 : username;
             const name =
@@ -254,6 +334,7 @@ export function createAuth(env: Bindings, db: Db) {
               data: {
                 ...user,
                 name,
+                username,
                 displayUsername,
                 maxVideoUploadSizeMb: q.maxVideoUploadSizeMb,
                 aiAnswersLimit: q.aiAnswersLimit,

--- a/apps/api/src/types/bindings.ts
+++ b/apps/api/src/types/bindings.ts
@@ -69,6 +69,10 @@ export type Bindings = {
   BETTER_AUTH_SECRET?: string;
   /** Public base URL for Better Auth (issuer). Falls back to OAUTH_ISSUER_URL / FRONTEND_URL. */
   BETTER_AUTH_URL?: string;
+  /** Google OAuth Web client ID (enables Google sign-in when set with secret). */
+  GOOGLE_CLIENT_ID?: string;
+  /** Google OAuth Web client secret. */
+  GOOGLE_CLIENT_SECRET?: string;
   /**
    * @deprecated Removed after Better Auth migration. Kept optional so old .dev.vars
    * still load; prefer BETTER_AUTH_SECRET.

--- a/apps/api/test/username-from-email.test.ts
+++ b/apps/api/test/username-from-email.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { usernameFromEmail } from "../src/lib/auth";
+
+describe("usernameFromEmail", () => {
+  it("normalizes the local part", () => {
+    expect(usernameFromEmail("Alice.Bob+tag@example.com")).toBe("alice_bob_tag");
+  });
+
+  it("pads short local parts", () => {
+    expect(usernameFromEmail("ab@example.com").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("truncates long local parts", () => {
+    const long = `${"a".repeat(200)}@example.com`;
+    expect(usernameFromEmail(long).length).toBeLessThanOrEqual(150);
+  });
+});

--- a/frontend/src/components/auth/GoogleSignInButton.tsx
+++ b/frontend/src/components/auth/GoogleSignInButton.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { apiClient } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { InlineSpinner } from '@/components/common/InlineSpinner';
+import { ErrorMessage } from '@/components/auth/ErrorMessage';
+
+type GoogleSignInButtonProps = {
+  callbackURL?: string;
+  labelKey?: string;
+};
+
+function GoogleMark({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="#EA4335"
+        d="M12 10.2v3.6h5.1c-.2 1.2-.9 2.3-1.9 3l3.1 2.4c1.8-1.7 2.9-4.2 2.9-7.2 0-.7-.1-1.4-.2-2H12z"
+      />
+      <path
+        fill="#34A853"
+        d="M6.6 14.3l-.9.7-2.7 2.1C4.7 20.3 8.1 22.2 12 22.2c2.7 0 5-.9 6.7-2.4l-3.1-2.4c-.9.6-2 1-3.6 1-2.8 0-5.1-1.9-5.9-4.4z"
+      />
+      <path
+        fill="#4A90E2"
+        d="M3 7.1C2.4 8.3 2 9.6 2 11s.4 2.7 1 3.9l3.6-2.8C6.3 11.4 6.2 10.7 6.2 10c0-.7.1-1.4.4-2.1L3 7.1z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M12 5.8c1.5 0 2.8.5 3.8 1.5l2.8-2.8C16.9 2.7 14.7 1.8 12 1.8 8.1 1.8 4.7 3.7 3 7.1l3.6 2.8C7 7.4 9.2 5.8 12 5.8z"
+      />
+    </svg>
+  );
+}
+
+export function GoogleSignInButton({
+  callbackURL = '/',
+  labelKey = 'auth.login.continueWithGoogle',
+}: GoogleSignInButtonProps) {
+  const { t } = useTranslation();
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onClick() {
+    setLoading(true);
+    setError(null);
+    try {
+      await apiClient.loginWithGoogle(callbackURL);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('auth.login.googleFailed'));
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && <ErrorMessage message={error} />}
+      <Button
+        type="button"
+        variant="outline"
+        size="lg"
+        className="w-full"
+        disabled={loading}
+        onClick={() => void onClick()}
+      >
+        {loading ? (
+          <span className="flex items-center justify-center gap-2">
+            <InlineSpinner className="w-4 h-4" />
+            {t('auth.login.googleRedirecting')}
+          </span>
+        ) : (
+          <span className="flex items-center justify-center gap-2">
+            <GoogleMark className="h-5 w-5" />
+            {t(labelKey)}
+          </span>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -301,6 +301,9 @@
       "submit": "Sign in",
       "submitting": "Signing in...",
       "orDivider": "or",
+      "continueWithGoogle": "Continue with Google",
+      "googleRedirecting": "Redirecting to Google...",
+      "googleFailed": "Google sign-in failed",
       "footerQuestion": "Don't have an account?",
       "footerLink": "Register here",
       "forgotPassword": "Forgot your password?"
@@ -311,6 +314,7 @@
       "submit": "Create account",
       "submitting": "Creating...",
       "orDivider": "or",
+      "continueWithGoogle": "Sign up with Google",
       "footerQuestion": "Already have an account?",
       "footerLink": "Sign in here",
       "passwordMismatch": "Passwords do not match"

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -301,6 +301,9 @@
       "submit": "ログイン",
       "submitting": "ログイン中...",
       "orDivider": "または",
+      "continueWithGoogle": "Googleで続行",
+      "googleRedirecting": "Googleへ移動中...",
+      "googleFailed": "Googleログインに失敗しました",
       "footerQuestion": "アカウントをお持ちでない方は",
       "footerLink": "こちらから登録",
       "forgotPassword": "パスワードをお忘れですか？"
@@ -311,6 +314,7 @@
       "submit": "新規登録する",
       "submitting": "登録中...",
       "orDivider": "または",
+      "continueWithGoogle": "Googleで登録",
       "footerQuestion": "すでにアカウントをお持ちの方は",
       "footerLink": "こちらからログイン",
       "passwordMismatch": "パスワードが一致しません"

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -16,6 +16,7 @@ const { authClientMock } = vi.hoisted(() => {
     signOut: vi.fn(() => ok()),
     signIn: {
       username: vi.fn(() => ok()),
+      social: vi.fn(() => ok()),
     },
     signUp: {
       email: vi.fn(() => ok()),
@@ -153,6 +154,14 @@ describe('ApiClient', () => {
       expect(authClientMock.signIn.username).toHaveBeenCalledWith({
         username: 'user',
         password: 'pw',
+      });
+    });
+
+    it('loginWithGoogle should call Better Auth social sign-in', async () => {
+      await apiClient.loginWithGoogle('/videos');
+      expect(authClientMock.signIn.social).toHaveBeenCalledWith({
+        provider: 'google',
+        callbackURL: '/videos',
       });
     });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -641,6 +641,18 @@ export class ApiClient {
     return { access_token: '' };
   }
 
+  /** Redirects to Google OAuth via Better Auth (`signIn.social`). */
+  async loginWithGoogle(callbackURL = '/'): Promise<void> {
+    const { authClient } = await import('@/lib/auth-client');
+    const { error } = await authClient.signIn.social({
+      provider: 'google',
+      callbackURL,
+    });
+    if (error) {
+      throw new ApiError(error.message || 'Google sign-in failed', error.code || 'GOOGLE_SIGN_IN_FAILED');
+    }
+  }
+
   async requestPasswordReset(data: PasswordResetRequest): Promise<void> {
     const { authClient } = await import('@/lib/auth-client');
     const { error } = await authClient.requestPasswordReset({

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,8 +13,8 @@ import { AuthPageIntro } from '@/components/layout/AuthPageIntro';
 import { FormField } from '@/components/auth/FormField';
 import { ErrorMessage } from '@/components/auth/ErrorMessage';
 import { AuthFormFooter } from '@/components/auth/AuthFormFooter';
-import { Button } from '@/components/ui/button';
-import { Divider } from '@/components/ui/divider';
+import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
+import { Button } from '@/components/ui/button';import { Divider } from '@/components/ui/divider';
 import { UtilityLink } from '@/components/ui/utility-link';
 
 // Only allow same-origin absolute paths to prevent open redirects to attacker
@@ -123,6 +123,8 @@ export default function LoginPage() {
           {t('auth.login.orDivider')}
         </span>
       </div>
+
+      <GoogleSignInButton callbackURL={nextPath || '/'} />
 
       <div className="mt-8 text-center">
         <AuthFormFooter

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -10,6 +10,7 @@ import { AuthPageIntro } from '@/components/layout/AuthPageIntro';
 import { FormField } from '@/components/auth/FormField';
 import { ErrorMessage } from '@/components/auth/ErrorMessage';
 import { AuthFormFooter } from '@/components/auth/AuthFormFooter';
+import { GoogleSignInButton } from '@/components/auth/GoogleSignInButton';
 import { Button } from '@/components/ui/button';
 import { Divider } from '@/components/ui/divider';
 
@@ -137,6 +138,11 @@ export default function SignupPage() {
           {t('auth.signup.orDivider')}
         </span>
       </div>
+
+      <GoogleSignInButton
+        callbackURL="/"
+        labelKey="auth.signup.continueWithGoogle"
+      />
 
       <div className="mt-8 text-center">
         <AuthFormFooter

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@/lib/api', () => ({
     getMe: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     getMeOrNull: vi.fn(() => Promise.resolve({ id: '1', username: 'testuser', email: 'test@example.com' })),
     login: vi.fn(),
+    loginWithGoogle: vi.fn(() => Promise.resolve()),
   },
 }))
 
@@ -54,6 +55,18 @@ describe('LoginPage', () => {
     render(<LoginPage />)
 
     expect(screen.getByText('auth.login.footerLink')).toBeInTheDocument()
+  })
+
+  it('should render Google sign-in and call loginWithGoogle', async () => {
+    render(<LoginPage />)
+
+    const googleButton = screen.getByText('auth.login.continueWithGoogle')
+    expect(googleButton).toBeInTheDocument()
+    fireEvent.click(googleButton)
+
+    await waitFor(() => {
+      expect(apiClient.loginWithGoogle).toHaveBeenCalledWith('/')
+    })
   })
 
   it('should call apiClient.login on submit', async () => {

--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -37,7 +37,15 @@ npx wrangler secret put R2_SECRET_ACCESS_KEY
 npx wrangler secret put SQS_QUEUE_URL
 npx wrangler secret put AWS_ACCESS_KEY_ID
 npx wrangler secret put AWS_SECRET_ACCESS_KEY
+# Google sign-in (optional; both required)
+npx wrangler secret put GOOGLE_CLIENT_ID
+npx wrangler secret put GOOGLE_CLIENT_SECRET
 ```
+
+Google Cloud Console の OAuth Web クライアントに Authorized redirect URI を登録:
+
+- 本番: `https://videoq.jp/api/auth/callback/google`
+- ローカル: `{BETTER_AUTH_URL}/api/auth/callback/google`（例: `http://localhost:8787/api/auth/callback/google`）
 
 `BETTER_AUTH_SECRET` と `USER_SECRET_ENCRYPTION_KEY` は別々に生成します
 （例: `openssl rand -base64 48`）。


### PR DESCRIPTION
## Summary
- Enable optional Google OAuth via Better Auth (`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`), with trusted-email account linking for existing users.
- Auto-generate unique usernames from the Google email local-part for new social signups.
- Add Google continue buttons on login/signup and document redirect URIs / secrets for deploy.

## Test plan
- [ ] Create a Google Cloud OAuth Web client and set redirect URI to `{BETTER_AUTH_URL}/api/auth/callback/google`
- [ ] Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` (local `.dev.vars` and production `wrangler secret`)
- [ ] Redeploy API, open `/login`, click Google, and complete OAuth
- [ ] Confirm a new Google user gets a session and an auto-generated username
- [ ] Confirm an existing same-email user is linked (not duplicated)
- [ ] Confirm username/password login still works when Google secrets are unset


Made with [Cursor](https://cursor.com)