### PR TITLE
Fix account/me 500 from unqualified video_count subquery

### DIFF
--- a/apps/api/src/repositories/group-repository.ts
+++ b/apps/api/src/repositories/group-repository.ts
@@ -40,7 +40,8 @@ export type GroupDetail = {
   videos: (VideoListItem & { order: number })[];
 };
 
-const groupVideoCount = sql<number>`(SELECT count(DISTINCT m.video_id)::int FROM video_group_members m WHERE m.group_id = ${videoGroups.id})`.as(
+// Must be "video_groups"."id": ${videoGroups.id} becomes bare "id" → m.id.
+const groupVideoCount = sql<number>`(SELECT count(DISTINCT m.video_id)::int FROM video_group_members m WHERE m.group_id = "video_groups"."id")`.as(
   "video_count",
 );
 // Outer table must be qualified — ${videos.id} becomes bare "id" (ambiguous vs t.id).

--- a/apps/api/src/repositories/tag-repository.ts
+++ b/apps/api/src/repositories/tag-repository.ts
@@ -53,7 +53,8 @@ export type TagDetail = TagListItem & {
   videos: VideoListItem[];
 };
 
-const videoCountSubquery = sql<number>`(SELECT count(*) FROM video_tags vt WHERE vt.tag_id = ${tags.id})::int`.as(
+// Must be "tags"."id": ${tags.id} becomes bare "id" → vt.id.
+const videoCountSubquery = sql<number>`(SELECT count(*) FROM video_tags vt WHERE vt.tag_id = "tags"."id")::int`.as(
   "video_count",
 );
 

--- a/apps/api/src/repositories/user-repository.ts
+++ b/apps/api/src/repositories/user-repository.ts
@@ -44,7 +44,8 @@ export async function getCurrentUser(
         used_ai_answers: users.usedAiAnswers,
         ai_answers_limit: users.aiAnswersLimit,
         is_over_quota: users.isOverQuota,
-        video_count: sql<number>`(SELECT count(*)::int FROM videos v WHERE v.user_id = ${users.id})`.as(
+        // Must be "users"."id": ${users.id} becomes bare "id" → videos.id in this subquery.
+        video_count: sql<number>`(SELECT count(*)::int FROM videos v WHERE v.user_id = "users"."id")`.as(
           "video_count",
         ),
       })


### PR DESCRIPTION
## Summary
- After UUID user ids, `/api/account/me` returned 500 because Drizzle expands `${users.id}` to bare `"id"`, which Postgres resolves to `videos.id` (bigint) inside the correlated subquery (`text = bigint`).
- Qualify outer ids in the same `video_count` patterns for users, groups, and tags (`"users"."id"`, `"video_groups"."id"`, `"tags"."id"`), matching the existing `"videos"."id"` fix.

## Test plan
- [ ] Deploy API and log in on production
- [ ] Confirm `GET /api/account/me` returns 200 (no Internal Server Error)
- [ ] Confirm group list / tag list `video_count` looks correct for accounts with memberships/tags


Made with [Cursor](https://cursor.com)