### PR TITLE
Fix mobile layout overflow and safe-area spacing

### DIFF
--- a/frontend/src/components/common/FeedbackProvider.tsx
+++ b/frontend/src/components/common/FeedbackProvider.tsx
@@ -182,7 +182,7 @@ export function FeedbackProvider({ children }: { children: ReactNode }) {
       )}
 
       {toasts.length > 0 && (
-        <div className="fixed bottom-4 right-4 z-50 flex w-[min(calc(100vw-2rem),24rem)] flex-col gap-2">
+        <div className="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] right-4 z-50 flex w-[min(calc(100%-2rem),24rem)] flex-col gap-2 max-lg:bottom-[calc(5rem+env(safe-area-inset-bottom))]">
           {toasts.map((toastItem) => (
             <div
               key={toastItem.id}

--- a/frontend/src/components/layout/AppNav.tsx
+++ b/frontend/src/components/layout/AppNav.tsx
@@ -317,81 +317,83 @@ export function AppNav({ activePage }: AppNavProps) {
         </div>
 
         {isMenuOpen ? (
-          <div className="absolute inset-x-0 top-full z-50">
-            <div
-              id={megaMenuId}
-              className="max-h-[calc(100dvh-var(--app-header-offset,5rem))] overflow-y-auto border-t border-solid-gray-300 bg-white/90 shadow-[0_0.25rem_0.25rem_0_#00000029] backdrop-blur-[0.5rem] [scrollbar-gutter:stable]"
-            >
-              <nav
-                className={`mx-auto w-full py-10 md:py-12 ${APP_CONTAINER_CLASS}`}
-                aria-label={t('navigation.menu')}
-              >
-                <ul className="grid grid-cols-1 gap-x-10 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
-                  {navLinks.map(({ href, label, key }) => (
-                    <li
-                      key={key}
-                      className="flex min-h-12 items-center pl-5"
-                    >
-                      <Link
-                        href={href}
-                        className={megaMenuLinkClassName}
-                        aria-current={activePage === key ? 'page' : undefined}
-                        onClick={closeMenu}
-                      >
-                        {label}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-
-                <div className="my-8 h-px bg-solid-gray-300" aria-hidden="true" />
-
-                <ul className="grid grid-cols-1 gap-x-10 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
-                  {locales.map((code) => (
-                    <li key={code} className="flex min-h-12 items-center pl-5">
-                      <button
-                        type="button"
-                        lang={code}
-                        className={cn(megaMenuLinkClassName, 'bg-transparent text-left')}
-                        aria-current={locale === code ? 'true' : undefined}
-                        onClick={() => {
-                          switchLocale(code);
-                          closeMenu();
-                        }}
-                      >
-                        {LOCALE_LABELS[code]}
-                      </button>
-                    </li>
-                  ))}
-                  <li className="flex min-h-12 items-center pl-5">
-                    {!isAuthenticated ? (
-                      <Link
-                        href="/login"
-                        className={megaMenuLinkClassName}
-                        onClick={closeMenu}
-                      >
-                        {t('auth.login.submit')}
-                      </Link>
-                    ) : (
-                      <button
-                        type="button"
-                        className={cn(megaMenuLinkClassName, 'bg-transparent text-left')}
-                        onClick={() => void handleLogout()}
-                      >
-                        {t('navigation.logout')}
-                      </button>
-                    )}
-                  </li>
-                </ul>
-              </nav>
-            </div>
+          <>
             <button
               type="button"
-              className="h-screen w-full cursor-default bg-black/20"
+              className="fixed top-[var(--app-header-offset,5rem)] inset-x-0 bottom-0 z-40 cursor-default bg-black/20"
               aria-label={t('navigation.closeMenu')}
               onClick={closeMenu}
             />
-          </div>
+            <div className="absolute inset-x-0 top-full z-50">
+              <div
+                id={megaMenuId}
+                className="max-h-[calc(100dvh-var(--app-header-offset,5rem))] overflow-y-auto border-t border-solid-gray-300 bg-white/90 shadow-[0_0.25rem_0.25rem_0_#00000029] backdrop-blur-[0.5rem] [scrollbar-gutter:stable]"
+              >
+                <nav
+                  className={`mx-auto w-full py-10 md:py-12 ${APP_CONTAINER_CLASS}`}
+                  aria-label={t('navigation.menu')}
+                >
+                  <ul className="grid grid-cols-1 gap-x-10 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
+                    {navLinks.map(({ href, label, key }) => (
+                      <li
+                        key={key}
+                        className="flex min-h-12 items-center pl-5"
+                      >
+                        <Link
+                          href={href}
+                          className={megaMenuLinkClassName}
+                          aria-current={activePage === key ? 'page' : undefined}
+                          onClick={closeMenu}
+                        >
+                          {label}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <div className="my-8 h-px bg-solid-gray-300" aria-hidden="true" />
+
+                  <ul className="grid grid-cols-1 gap-x-10 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
+                    {locales.map((code) => (
+                      <li key={code} className="flex min-h-12 items-center pl-5">
+                        <button
+                          type="button"
+                          lang={code}
+                          className={cn(megaMenuLinkClassName, 'bg-transparent text-left')}
+                          aria-current={locale === code ? 'true' : undefined}
+                          onClick={() => {
+                            switchLocale(code);
+                            closeMenu();
+                          }}
+                        >
+                          {LOCALE_LABELS[code]}
+                        </button>
+                      </li>
+                    ))}
+                    <li className="flex min-h-12 items-center pl-5">
+                      {!isAuthenticated ? (
+                        <Link
+                          href="/login"
+                          className={megaMenuLinkClassName}
+                          onClick={closeMenu}
+                        >
+                          {t('auth.login.submit')}
+                        </Link>
+                      ) : (
+                        <button
+                          type="button"
+                          className={cn(megaMenuLinkClassName, 'bg-transparent text-left')}
+                          onClick={() => void handleLogout()}
+                        >
+                          {t('navigation.logout')}
+                        </button>
+                      )}
+                    </li>
+                  </ul>
+                </nav>
+              </div>
+            </div>
+          </>
         ) : null}
       </header>
 

--- a/frontend/src/components/video/detail/VideoDetailView.tsx
+++ b/frontend/src/components/video/detail/VideoDetailView.tsx
@@ -725,7 +725,7 @@ export function VideoDetailView({
               />
             </div>
 
-            {video.status === 'completed' && (
+            {video.status === 'completed' && !(isMobile && mobileTab !== 'video') && (
               <PlogPanel videoId={video.id} />
             )}
           </main>

--- a/frontend/src/components/video/group-detail/VideoGroupDetailView.tsx
+++ b/frontend/src/components/video/group-detail/VideoGroupDetailView.tsx
@@ -833,7 +833,7 @@ function GroupMobileNav({
   };
 
   return (
-    <nav className="fixed bottom-0 left-0 z-50 flex h-16 w-full items-center justify-around border-t border-solid-gray-420 bg-white px-4 lg:hidden">
+    <nav className="fixed bottom-0 left-0 z-50 flex min-h-16 w-full items-center justify-around border-t border-solid-gray-420 bg-white px-4 pb-[env(safe-area-inset-bottom)] lg:hidden">
       {(['videos', 'player'] as MobileTab[]).map((tab) => {
         const Icon = mobileTabIcon[tab];
         const isActive = mobileTab === tab;
@@ -954,7 +954,7 @@ export function VideoGroupDetailView({
             />
           )}
 
-          <main className="mx-auto flex w-full max-w-[1600px] flex-col gap-4 overflow-y-auto px-6 py-4 pb-20 lg:h-[calc(100dvh-var(--app-header-offset,5rem))] lg:gap-5 lg:overflow-hidden lg:px-8 lg:pb-4">
+          <main className="mx-auto flex w-full max-w-[1600px] flex-col gap-4 overflow-y-auto px-6 py-4 pb-[calc(5rem+env(safe-area-inset-bottom))] lg:h-[calc(100dvh-var(--app-header-offset,5rem))] lg:gap-5 lg:overflow-hidden lg:px-8 lg:pb-4">
             <div className="shrink-0 space-y-4">
               <Breadcrumbs aria-label={t('common.actions.backToList')}>
                 <BreadcrumbsLabel className="sr-only">

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -342,72 +342,74 @@ export default function AdminPage() {
         ) : (
           <>
             <div className="mb-3 text-std-16N-170 text-solid-gray-700">{pageLabel}</div>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t('admin.users.columns.id')}</TableHead>
-                  <TableHead>{t('admin.users.columns.username')}</TableHead>
-                  <TableHead>{t('admin.users.columns.email')}</TableHead>
-                  <TableHead>{t('admin.users.columns.flags')}</TableHead>
-                  <TableHead>{t('admin.users.columns.quota')}</TableHead>
-                  <TableHead>{t('admin.users.columns.actions')}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {visibleUsers.map((row) => (
-                  <TableRow key={row.id}>
-                    <TableCell>{row.id}</TableCell>
-                    <TableCell>{row.username}</TableCell>
-                    <TableCell>{row.email}</TableCell>
-                    <TableCell>
-                      <div className="flex flex-wrap gap-2">
-                        {row.is_superuser && (
-                          <ChipLabel>{t('admin.users.flags.superuser')}</ChipLabel>
-                        )}
-                        {row.is_staff && <ChipLabel>{t('admin.users.flags.staff')}</ChipLabel>}
-                        {!row.is_active && (
-                          <ChipLabel color="red">{t('admin.users.flags.inactive')}</ChipLabel>
-                        )}
-                        {row.is_over_quota && (
-                          <ChipLabel color="orange">{t('admin.users.flags.overQuota')}</ChipLabel>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-std-14N-170 text-solid-gray-700">
-                      {t('admin.users.quotaSummary', {
-                        uploadMb: row.max_video_upload_size_mb,
-                        storageGb:
-                          row.storage_limit_gb == null
-                            ? t('admin.users.unlimited')
-                            : row.storage_limit_gb,
-                      })}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex flex-wrap gap-2">
-                        <Button
-                          type="button"
-                          variant="text"
-                          onClick={() => openEditUser(row)}
-                        >
-                          {t('admin.users.edit')}
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="text"
-                          disabled={row.is_superuser || row.id === user.id}
-                          onClick={() => {
-                            setUserToDelete(row);
-                            setIsDeleteOpen(true);
-                          }}
-                        >
-                          {t('admin.users.delete')}
-                        </Button>
-                      </div>
-                    </TableCell>
+            <div className="overflow-x-auto">
+              <Table className="min-w-[560px]">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t('admin.users.columns.id')}</TableHead>
+                    <TableHead>{t('admin.users.columns.username')}</TableHead>
+                    <TableHead>{t('admin.users.columns.email')}</TableHead>
+                    <TableHead>{t('admin.users.columns.flags')}</TableHead>
+                    <TableHead>{t('admin.users.columns.quota')}</TableHead>
+                    <TableHead>{t('admin.users.columns.actions')}</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {visibleUsers.map((row) => (
+                    <TableRow key={row.id}>
+                      <TableCell>{row.id}</TableCell>
+                      <TableCell>{row.username}</TableCell>
+                      <TableCell>{row.email}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          {row.is_superuser && (
+                            <ChipLabel>{t('admin.users.flags.superuser')}</ChipLabel>
+                          )}
+                          {row.is_staff && <ChipLabel>{t('admin.users.flags.staff')}</ChipLabel>}
+                          {!row.is_active && (
+                            <ChipLabel color="red">{t('admin.users.flags.inactive')}</ChipLabel>
+                          )}
+                          {row.is_over_quota && (
+                            <ChipLabel color="orange">{t('admin.users.flags.overQuota')}</ChipLabel>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-std-14N-170 text-solid-gray-700">
+                        {t('admin.users.quotaSummary', {
+                          uploadMb: row.max_video_upload_size_mb,
+                          storageGb:
+                            row.storage_limit_gb == null
+                              ? t('admin.users.unlimited')
+                              : row.storage_limit_gb,
+                        })}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            type="button"
+                            variant="text"
+                            onClick={() => openEditUser(row)}
+                          >
+                            {t('admin.users.edit')}
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="text"
+                            disabled={row.is_superuser || row.id === user.id}
+                            onClick={() => {
+                              setUserToDelete(row);
+                              setIsDeleteOpen(true);
+                            }}
+                          >
+                            {t('admin.users.delete')}
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
 
             <div className="mt-4 flex gap-3">
               <Button

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -142,7 +142,7 @@ export default function SharePage() {
       </header>
 
       {/* ── Main ────────────────────────────────────────────────────────── */}
-      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-20 lg:pb-4 lg:h-[calc(100dvh-4rem)] lg:overflow-hidden">
+      <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-4 lg:h-[calc(100dvh-4rem)] lg:overflow-hidden">
         {group.description && (
           <div className="shrink-0 rounded-8 border border-solid-gray-300 bg-white px-4 py-3 text-std-16N-170 text-solid-gray-700">
             {group.description}
@@ -246,7 +246,7 @@ export default function SharePage() {
       </main>
 
       {/* ── Mobile bottom nav ───────────────────────────────────────────── */}
-      <nav className="fixed bottom-0 left-0 z-50 flex h-16 w-full items-center justify-around border-t border-solid-gray-420 bg-white px-4 lg:hidden">
+      <nav className="fixed bottom-0 left-0 z-50 flex min-h-16 w-full items-center justify-around border-t border-solid-gray-420 bg-white px-4 pb-[env(safe-area-inset-bottom)] lg:hidden">
         {(['videos', 'player'] as MobileTab[]).map((tab) => {
           const Icon = mobileTabIcon[tab];
           const isActive = mobileTab === tab;

--- a/frontend/src/pages/__tests__/AdminPage.test.tsx
+++ b/frontend/src/pages/__tests__/AdminPage.test.tsx
@@ -86,6 +86,15 @@ describe('AdminPage', () => {
     expect(apiClient.getAdminUsers).toHaveBeenCalled()
   })
 
+  it('keeps the users table in a horizontal scroll container on narrow viewports', async () => {
+    const { container } = render(<AdminPage />)
+    expect(await screen.findByText('bob')).toBeInTheDocument()
+    const table = container.querySelector('table')
+    expect(table).not.toBeNull()
+    expect(table?.parentElement).toHaveClass('overflow-x-auto')
+    expect(table).toHaveClass('min-w-[560px]')
+  })
+
   it('redirects non-superusers home', async () => {
     ;(useAuth as ReturnType<typeof vi.fn>).mockReturnValue({
       user: {


### PR DESCRIPTION
## Summary
- Stop Admin users table from causing page-wide horizontal scroll on narrow viewports
- Fix AppNav mega-menu backdrop so opening the menu no longer stretches document height
- Hide the learning graph on mobile transcript tab, and add safe-area padding for Share/Group bottom nav and toasts

## Test plan
- [ ] Open `/admin` at ~390px width and confirm only the table scrolls horizontally
- [ ] Open「すべてのメニュー」and confirm page height does not jump; backdrop covers content below the header
- [ ] On a completed video detail page, switch to「文字起こし」and confirm the learning graph is hidden
- [ ] On group detail / share pages, confirm chat input is not covered by the bottom nav (including iOS safe area)
- [ ] Trigger a toast on mobile and confirm it sits above the bottom nav


Made with [Cursor](https://cursor.com)