### PR TITLE
Fix integration API keys header layout on narrow screens

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -464,8 +464,8 @@ export default function SettingsPage() {
 
           {/* ── Integration API Keys ─────────────────────────────────── */}
           <section className={SETTINGS_SECTION_CLASS}>
-            <div className="mb-5 flex items-start justify-between gap-4">
-              <div>
+            <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0">
                 <Heading size="18" hasChip className="mb-2">
                   <HeadingTitle level="h2">{t('settings.integrationApiKeys.title')}</HeadingTitle>
                 </Heading>
@@ -477,7 +477,7 @@ export default function SettingsPage() {
                 type="button"
                 variant="solid"
                 size="sm"
-                className="shrink-0"
+                className="w-full shrink-0 sm:w-auto"
                 onClick={() => {
                   setStatusMessage(null);
                   setApiKeyDialogError(null);

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -45,6 +45,23 @@ describe('SettingsPage email change', () => {
     expect(screen.getByLabelText('settings.emailChange.newEmailLabel')).toBeInTheDocument()
   })
 
+  it('stacks the integration API keys header on narrow layouts', async () => {
+    render(<SettingsPage />)
+
+    const title = await screen.findByRole('heading', {
+      name: 'settings.integrationApiKeys.title',
+    })
+    const header = title.closest('.mb-5')
+    expect(header).toHaveClass('flex-col')
+    expect(header).toHaveClass('sm:flex-row')
+
+    const createButton = screen.getByRole('button', {
+      name: 'settings.integrationApiKeys.create',
+    })
+    expect(createButton).toHaveClass('w-full')
+    expect(createButton).toHaveClass('sm:w-auto')
+  })
+
   it('requests an email change from the settings form', async () => {
     render(<SettingsPage />)
 


### PR DESCRIPTION
## Summary
- Stack the Settings「連携用APIキー」header on narrow viewports so the long create button no longer crushes the title
- Keep the create button full-width on mobile and side-by-side from `sm` up

## Test plan
- [ ] Open `/settings` at ~390px width and confirm「連携用APIキー」title/description are readable
- [ ] Confirm「新しいシークレットキーを作成」is full-width below the description on mobile
- [ ] At `sm+` widths, confirm title and button sit side-by-side again
- [ ] `npm test -- --run src/pages/__tests__/SettingsPage.test.tsx`


Made with [Cursor](https://cursor.com)