### PR TITLE
Let Google users change the email-derived username in Settings

### DIFF
--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -433,6 +433,23 @@
   "settings": {
     "title": "Settings",
     "subtitle": "Manage your account and integration settings",
+    "usernameChange": {
+      "title": "Username",
+      "description": "Google sign-in may set your username from your email address. You can change it to something you prefer.",
+      "currentUsernameLabel": "Current username",
+      "newUsernameLabel": "New username",
+      "help": "Use 3–150 characters: letters, numbers, underscores, and periods. Uppercase is stored as lowercase. Your username is also used to sign in.",
+      "submit": "Change username",
+      "submitting": "Saving...",
+      "success": "Username updated",
+      "errorEmpty": "Please enter a new username",
+      "errorUnchanged": "That is already your current username",
+      "errorTaken": "This username is already taken",
+      "errorTooShort": "Username is too short (minimum 3 characters)",
+      "errorTooLong": "Username is too long (maximum 150 characters)",
+      "errorInvalid": "Usernames can only include letters, numbers, underscores, and periods",
+      "errorSubmitting": "Failed to update username"
+    },
     "emailChange": {
       "title": "Email address",
       "description": "Change the email address associated with your account. The change is applied only after you confirm the new address.",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -433,6 +433,23 @@
   "settings": {
     "title": "設定",
     "subtitle": "アカウントと統合の設定を管理します",
+    "usernameChange": {
+      "title": "ユーザー名",
+      "description": "Googleログインではメールアドレスの一部がユーザー名になることがあります。あとから好きな名前に変更できます。",
+      "currentUsernameLabel": "現在のユーザー名",
+      "newUsernameLabel": "新しいユーザー名",
+      "help": "3〜150文字の英数字、アンダースコア、ピリオドが使えます。大文字は小文字として保存されます。ユーザー名はログインにも使われます。",
+      "submit": "ユーザー名を変更",
+      "submitting": "変更中...",
+      "success": "ユーザー名を変更しました",
+      "errorEmpty": "新しいユーザー名を入力してください",
+      "errorUnchanged": "現在と同じユーザー名です",
+      "errorTaken": "このユーザー名はすでに使われています",
+      "errorTooShort": "ユーザー名が短すぎます（3文字以上）",
+      "errorTooLong": "ユーザー名が長すぎます（150文字以内）",
+      "errorInvalid": "ユーザー名に使えるのは英数字、アンダースコア、ピリオドだけです",
+      "errorSubmitting": "ユーザー名の変更に失敗しました"
+    },
     "emailChange": {
       "title": "メールアドレス",
       "description": "アカウントに紐づくメールアドレスを変更します。新しいメールアドレスで確認が完了するまで、現在のメールアドレスが維持されます。",

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -26,6 +26,7 @@ const { authClientMock, fetchAuthSessionMock } = vi.hoisted(() => {
     requestPasswordReset: vi.fn(() => ok()),
     resetPassword: vi.fn(() => ok()),
     changeEmail: vi.fn(() => ok()),
+    updateUser: vi.fn(() => ok()),
     oauth2: {
       getConsents: vi.fn(() =>
         ok([
@@ -222,6 +223,25 @@ describe('ApiClient', () => {
       expect(authClientMock.changeEmail).toHaveBeenCalledWith({
         newEmail: 'new@example.com',
         callbackURL: 'http://frontend.example.com/change-email',
+      });
+    });
+
+    it('updateUsername should call Better Auth updateUser with displayUsername', async () => {
+      await apiClient.updateUsername({ username: ' new_name ' });
+      expect(authClientMock.updateUser).toHaveBeenCalledWith({
+        username: 'new_name',
+        displayUsername: 'new_name',
+      });
+    });
+
+    it('updateUsername should throw ApiError when Better Auth fails', async () => {
+      authClientMock.updateUser.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'Username is already taken', code: 'USERNAME_IS_ALREADY_TAKEN' },
+      });
+      await expect(apiClient.updateUsername({ username: 'taken' })).rejects.toMatchObject({
+        name: 'ApiError',
+        code: 'USERNAME_IS_ALREADY_TAKEN',
       });
     });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -169,6 +169,10 @@ export interface EmailChangeConfirmRequest {
   token: string;
 }
 
+export interface UsernameChangeRequest {
+  username: string;
+}
+
 export interface LoginRequest {
   username: string;
   password: string;
@@ -671,6 +675,22 @@ export class ApiClient {
       callbackURL: `${window.location.origin}/change-email`,
     });
     if (error) throw new ApiError(error.message || 'Email change failed', error.code || 'EMAIL_CHANGE_FAILED');
+  }
+
+  /**
+   * Updates username via Better Auth `/update-user`.
+   * Also sets `displayUsername` so Google-signup accounts stay in sync.
+   */
+  async updateUsername(data: UsernameChangeRequest): Promise<void> {
+    const { authClient } = await import('@/lib/auth-client');
+    const username = data.username.trim();
+    const { error } = await authClient.updateUser({
+      username,
+      displayUsername: username,
+    });
+    if (error) {
+      throw new ApiError(error.message || 'Username change failed', error.code || 'USERNAME_CHANGE_FAILED');
+    }
   }
 
   /**

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -44,6 +44,28 @@ const SETTINGS_CALLOUT_CLASS =
 
 type AccessLevel = 'all' | 'read_only';
 
+const USERNAME_CHANGE_ERROR_CODES: Record<string, string> = {
+  USERNAME_IS_ALREADY_TAKEN: 'settings.usernameChange.errorTaken',
+  USERNAME_TOO_SHORT: 'settings.usernameChange.errorTooShort',
+  USERNAME_TOO_LONG: 'settings.usernameChange.errorTooLong',
+  INVALID_USERNAME: 'settings.usernameChange.errorInvalid',
+};
+
+function errorCode(error: unknown): string {
+  if (typeof error === 'object' && error !== null && 'code' in error && typeof error.code === 'string') {
+    return error.code;
+  }
+  return '';
+}
+
+function usernameChangeErrorMessage(error: unknown, t: (key: string) => string): string {
+  const key = USERNAME_CHANGE_ERROR_CODES[errorCode(error)];
+  if (key) return t(key);
+  return error instanceof Error && error.message
+    ? error.message
+    : t('settings.usernameChange.errorSubmitting');
+}
+
 export default function SettingsPage() {
   const { user } = useAuth();
   const { t } = useTranslation();
@@ -73,6 +95,11 @@ export default function SettingsPage() {
   } | null>(null);
   const [emailChangeEmail, setEmailChangeEmail] = useState('');
   const [emailChangeStatusMessage, setEmailChangeStatusMessage] = useState<{
+    tone: 'success' | 'error';
+    text: string;
+  } | null>(null);
+  const [usernameChangeUsername, setUsernameChangeUsername] = useState('');
+  const [usernameChangeStatusMessage, setUsernameChangeStatusMessage] = useState<{
     tone: 'success' | 'error';
     text: string;
   } | null>(null);
@@ -109,6 +136,10 @@ export default function SettingsPage() {
   useEffect(() => {
     setEmailChangeEmail(user?.email ?? '');
   }, [user?.email]);
+
+  useEffect(() => {
+    setUsernameChangeUsername(user?.username ?? '');
+  }, [user?.username]);
 
   const apiKeysQuery = useQuery({
     queryKey: queryKeys.auth.apiKeys,
@@ -178,6 +209,23 @@ export default function SettingsPage() {
         text: error instanceof Error
           ? error.message
           : t('settings.emailChange.errorSubmitting'),
+      });
+    },
+  });
+
+  const updateUsernameMutation = useMutation({
+    mutationFn: async (username: string) => apiClient.updateUsername({ username }),
+    onSuccess: async () => {
+      setUsernameChangeStatusMessage({
+        tone: 'success',
+        text: t('settings.usernameChange.success'),
+      });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.auth.me });
+    },
+    onError: (error) => {
+      setUsernameChangeStatusMessage({
+        tone: 'error',
+        text: usernameChangeErrorMessage(error, t),
       });
     },
   });
@@ -298,6 +346,86 @@ export default function SettingsPage() {
       />
 
       <div className="flex flex-col gap-12">
+          <section className={SETTINGS_SECTION_CLASS}>
+            <div className="mb-5">
+              <Heading size="18" hasChip className="mb-2">
+                <HeadingTitle level="h2">{t('settings.usernameChange.title')}</HeadingTitle>
+              </Heading>
+              <p className="text-std-16N-170 text-solid-gray-600">
+                {t('settings.usernameChange.description')}
+              </p>
+            </div>
+
+            {usernameChangeStatusMessage && (
+              <div className="mb-5">
+                <MessageAlert
+                  type={usernameChangeStatusMessage.tone}
+                  message={usernameChangeStatusMessage.text}
+                />
+              </div>
+            )}
+
+            <form
+              className="space-y-4"
+              onSubmit={async (event) => {
+                event.preventDefault();
+                const trimmedUsername = usernameChangeUsername.trim();
+                if (!trimmedUsername) {
+                  setUsernameChangeStatusMessage({
+                    tone: 'error',
+                    text: t('settings.usernameChange.errorEmpty'),
+                  });
+                  return;
+                }
+                if (trimmedUsername.toLowerCase() === (user?.username ?? '').toLowerCase()) {
+                  setUsernameChangeStatusMessage({
+                    tone: 'error',
+                    text: t('settings.usernameChange.errorUnchanged'),
+                  });
+                  return;
+                }
+                setUsernameChangeStatusMessage(null);
+                try {
+                  await updateUsernameMutation.mutateAsync(trimmedUsername);
+                } catch {
+                  // onError renders the user-facing message.
+                }
+              }}
+            >
+              <div className={SETTINGS_CALLOUT_CLASS}>
+                <div className="font-bold text-solid-gray-800 mb-1">
+                  {t('settings.usernameChange.currentUsernameLabel')}
+                </div>
+                <p>{user?.username ?? t('common.notProvided')}</p>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="username-change-username">
+                  {t('settings.usernameChange.newUsernameLabel')}
+                </Label>
+                <Input
+                  id="username-change-username"
+                  type="text"
+                  autoComplete="username"
+                  value={usernameChangeUsername}
+                  onChange={(event) => setUsernameChangeUsername(event.target.value)}
+                />
+                <SupportText>{t('settings.usernameChange.help')}</SupportText>
+              </div>
+
+              <div className="flex justify-end">
+                <Button type="submit" disabled={updateUsernameMutation.isPending}>
+                  {updateUsernameMutation.isPending ? (
+                    <span className="flex items-center gap-2">
+                      <InlineSpinner className="w-4 h-4" />
+                      {t('settings.usernameChange.submitting')}
+                    </span>
+                  ) : t('settings.usernameChange.submit')}
+                </Button>
+              </div>
+            </form>
+          </section>
+
           <section className={SETTINGS_SECTION_CLASS}>
             <div className="mb-5">
               <Heading size="18" hasChip className="mb-2">

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/lib/api', () => {
       getIntegrationApiKeys: vi.fn(() => Promise.resolve([])),
       getSearchApiKeyStatus: vi.fn(() => Promise.resolve({ has_api_key: false })),
       requestEmailChange: vi.fn(() => Promise.resolve()),
+      updateUsername: vi.fn(() => Promise.resolve()),
       createIntegrationApiKey: vi.fn(),
       revokeIntegrationApiKey: vi.fn(),
       saveSearchApiKey: vi.fn(),
@@ -84,5 +85,71 @@ describe('SettingsPage email change', () => {
 
     expect(apiClient.requestEmailChange).not.toHaveBeenCalled()
     expect(screen.getByText('settings.emailChange.errorEmpty')).toBeInTheDocument()
+  })
+})
+
+describe('SettingsPage username change', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the current username and username change form', async () => {
+    render(<SettingsPage />)
+
+    expect(await screen.findByText('settings.usernameChange.title')).toBeInTheDocument()
+    expect(screen.getByText('alice')).toBeInTheDocument()
+    expect(screen.getByLabelText('settings.usernameChange.newUsernameLabel')).toBeInTheDocument()
+  })
+
+  it('updates the username from the settings form', async () => {
+    render(<SettingsPage />)
+
+    const input = await screen.findByLabelText('settings.usernameChange.newUsernameLabel')
+    fireEvent.change(input, { target: { value: 'alice_new' } })
+    fireEvent.click(screen.getByText('settings.usernameChange.submit'))
+
+    await waitFor(() => {
+      expect(apiClient.updateUsername).toHaveBeenCalledWith({ username: 'alice_new' })
+    })
+    expect(await screen.findByText('settings.usernameChange.success')).toBeInTheDocument()
+  })
+
+  it('does not call the API when the username is empty', async () => {
+    render(<SettingsPage />)
+
+    const input = await screen.findByLabelText('settings.usernameChange.newUsernameLabel')
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.click(screen.getByText('settings.usernameChange.submit'))
+
+    expect(apiClient.updateUsername).not.toHaveBeenCalled()
+    expect(screen.getByText('settings.usernameChange.errorEmpty')).toBeInTheDocument()
+  })
+
+  it('does not call the API when the username is unchanged', async () => {
+    render(<SettingsPage />)
+
+    const input = await screen.findByLabelText('settings.usernameChange.newUsernameLabel')
+    await waitFor(() => {
+      expect(input).toHaveValue('alice')
+    })
+    fireEvent.click(screen.getByText('settings.usernameChange.submit'))
+
+    expect(apiClient.updateUsername).not.toHaveBeenCalled()
+    expect(screen.getByText('settings.usernameChange.errorUnchanged')).toBeInTheDocument()
+  })
+
+  it('maps a taken username error to the settings copy', async () => {
+    vi.mocked(apiClient.updateUsername).mockRejectedValueOnce(
+      Object.assign(new Error('Username is already taken'), {
+        code: 'USERNAME_IS_ALREADY_TAKEN',
+      }),
+    )
+    render(<SettingsPage />)
+
+    const input = await screen.findByLabelText('settings.usernameChange.newUsernameLabel')
+    fireEvent.change(input, { target: { value: 'taken_name' } })
+    fireEvent.click(screen.getByText('settings.usernameChange.submit'))
+
+    expect(await screen.findByText('settings.usernameChange.errorTaken')).toBeInTheDocument()
   })
 })

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -290,6 +290,7 @@ vi.mock('@/lib/api', async (importOriginal) => {
     confirmPasswordReset: vi.fn(() => Promise.resolve()),
     requestEmailChange: vi.fn(() => Promise.resolve()),
     confirmEmailChange: vi.fn(() => Promise.resolve()),
+    updateUsername: vi.fn(() => Promise.resolve()),
     login: vi.fn(() => Promise.resolve()),
     getVideoGroups: vi.fn(() => Promise.resolve([])),
     getSharedVideoGroup: vi.fn(() => Promise.resolve(null)),


### PR DESCRIPTION
## Summary
- Google sign-in currently copies the email local-part into the username, so accounts look like `yukiharada1228softbank`.
- Settings now has a username form that updates Better Auth `username` and `displayUsername` via `/update-user`.
- Duplicate, length, and character-set errors are mapped to Japanese and English copy.

## Test plan
- [ ] Sign in with Google, open Settings, and confirm the current username is the email local-part
- [ ] Change it to a valid unused name (3–150 chars, letters/numbers/`_`/`.`) and confirm it saves
- [ ] Reload Settings and confirm the new username is shown
- [ ] Try an already-taken username and confirm the taken error
- [ ] Confirm Google sign-in still works after the rename; password login uses the new username


Made with [Cursor](https://cursor.com)