### PR TITLE
Finish admin user deletion after UUID user ids

### DIFF
--- a/apps/worker/tests/test_lambda_handler.py
+++ b/apps/worker/tests/test_lambda_handler.py
@@ -6,7 +6,7 @@ import base64
 import json
 from unittest.mock import patch
 
-from worker_python.contracts import JOB_TRANSCRIBE_VIDEO
+from worker_python.contracts import JOB_DELETE_ACCOUNT_DATA, JOB_TRANSCRIBE_VIDEO
 from worker_python.lambda_handler import _execute_task
 
 
@@ -36,3 +36,19 @@ def test_execute_task_decodes_outer_base64() -> None:
         fn = get_task.return_value
         _execute_task(outer)
         fn.assert_called_once_with(7)
+
+
+def test_execute_task_passes_uuid_user_id_for_account_deletion() -> None:
+    user_id = "00000000-0000-4000-8000-000000000009"
+    body = json.dumps(
+        {
+            "type": JOB_DELETE_ACCOUNT_DATA,
+            "job_id": "job-del",
+            "payload": {"user_id": user_id},
+        }
+    )
+    with patch("worker_python.lambda_handler.get_task") as get_task:
+        fn = get_task.return_value
+        _execute_task(body)
+        get_task.assert_called_once_with(JOB_DELETE_ACCOUNT_DATA)
+        fn.assert_called_once_with(user_id)

--- a/apps/worker/worker_python/lambda_handler.py
+++ b/apps/worker/worker_python/lambda_handler.py
@@ -68,7 +68,9 @@ def _dispatch(task_fn, job_type: str, body: dict) -> None:
         task_fn(int(body["chat_log_id"]))
         return
     if job_type == "delete_account_data":
-        task_fn(int(body["user_id"]))
+        # users.id is a UUID text PK (migration 0006). int() would fail and
+        # leave the admin-locked (is_active=false) row undeleted.
+        task_fn(str(body["user_id"]))
         return
     # video_id jobs
     task_fn(int(body["video_id"]))

--- a/apps/worker/worker_python/pipeline/vector_index.py
+++ b/apps/worker/worker_python/pipeline/vector_index.py
@@ -66,7 +66,7 @@ def _vector_store() -> Iterator[PGVectorStore]:
         engine.close()
 
 
-def _count_vectors(metadata_key: str | None = None, value: int | None = None) -> int:
+def _count_vectors(metadata_key: str | None = None, value: int | str | None = None) -> int:
     table = _table_name()
     with db_connection() as conn:
         if metadata_key is None:
@@ -89,11 +89,11 @@ def delete_video_vectors(video_id: int) -> int:
     return deleted
 
 
-def delete_user_vectors(user_id: int) -> int:
+def delete_user_vectors(user_id: str) -> int:
     deleted = _count_vectors("user_id", user_id)
     with _vector_store() as store:
         store.delete(filter={"user_id": user_id})
-    logger.info("Deleted %d vector rows for user %d", deleted, user_id)
+    logger.info("Deleted %d vector rows for user %s", deleted, user_id)
     return deleted
 
 

--- a/apps/worker/worker_python/tasks/account_deletion.py
+++ b/apps/worker/worker_python/tasks/account_deletion.py
@@ -12,7 +12,7 @@ from worker_python.video_sql import delete_video_cascade
 logger = logging.getLogger(__name__)
 
 
-def _delete_all_videos_for_user(conn, user_id: int) -> None:
+def _delete_all_videos_for_user(conn, user_id: str) -> None:
     rows = conn.execute(
         "SELECT id, file FROM videos WHERE user_id = %s ORDER BY id",
         (user_id,),
@@ -35,27 +35,27 @@ def _delete_all_videos_for_user(conn, user_id: int) -> None:
                 )
 
 
-def _delete_chat_history_for_user(conn, user_id: int) -> None:
+def _delete_chat_history_for_user(conn, user_id: str) -> None:
     conn.execute("DELETE FROM chat_logs WHERE user_id = %s", (user_id,))
 
 
-def _delete_video_groups_for_user(conn, user_id: int) -> None:
+def _delete_video_groups_for_user(conn, user_id: str) -> None:
     conn.execute("DELETE FROM video_groups WHERE user_id = %s", (user_id,))
 
 
-def _delete_tags_for_user(conn, user_id: int) -> None:
+def _delete_tags_for_user(conn, user_id: str) -> None:
     conn.execute("DELETE FROM tags WHERE user_id = %s", (user_id,))
 
 
-def _delete_remaining_vectors_for_user(_conn, user_id: int) -> None:
+def _delete_remaining_vectors_for_user(_conn, user_id: str) -> None:
     vector_index.delete_user_vectors(user_id)
 
 
-def _delete_user_row(conn, user_id: int) -> None:
+def _delete_user_row(conn, user_id: str) -> None:
     conn.execute("DELETE FROM users WHERE id = %s", (user_id,))
 
 
-def delete_account_data(user_id: int) -> None:
+def delete_account_data(user_id: str) -> None:
     logger.info("Account deletion task started for user %s", user_id)
 
     steps = [

--- a/apps/worker/worker_python/video_sql.py
+++ b/apps/worker/worker_python/video_sql.py
@@ -102,7 +102,7 @@ def list_completed_videos_with_transcript(
 
 
 def delete_video_cascade(
-    conn: psycopg.Connection[Any], video_id: int, user_id: int
+    conn: psycopg.Connection[Any], video_id: int, user_id: str
 ) -> None:
     """
     Hard-delete a video and related rows from the modern VideoQ schema.
@@ -134,5 +134,5 @@ def delete_video_cascade(
         "DELETE FROM videos WHERE id = %s AND user_id = %s",
         (video_id, user_id),
     )
-    logger.info("Deleted video %d (user %d) and related rows", video_id, user_id)
+    logger.info("Deleted video %d (user %s) and related rows", video_id, user_id)
 


### PR DESCRIPTION
## Summary
- Admin delete immediately locks the user (`is_active=false`), then the worker is supposed to hard-delete videos, history, and the user row.
- After the UUID user-id migration the worker still did `int(user_id)`, so the job failed and the locked row stayed forever.
- Pass the UUID through as a string and treat `user_id` as text in the deletion path.

## Test plan
- [ ] Deploy the worker, then Admin → delete a non-superuser
- [ ] Confirm the user is inactive immediately, then disappears after the `delete_account_data` job succeeds
- [ ] Re-click Delete on users that were stuck inactive from earlier failed jobs
- [ ] Confirm video/chat/tag rows and the `users` row are gone


Made with [Cursor](https://cursor.com)