### PR TITLE
Sync Digital Agency UI to v0.6.0

### DIFF
--- a/frontend/scripts/sync-digital-agency-ui.mjs
+++ b/frontend/scripts/sync-digital-agency-ui.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
-const registry = 'yukiharada1228/shadcn-digital-agency-jp'
+const registry = 'yukiharada1228/shadcn-digital-agency-jp' // last synced: v0.6.0
 
 // Keep this list aligned with imports from src/components/ui. Do not use the
 // registry's all-components block: it installs demo-only components and their

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -8,7 +8,7 @@ const solidStyle =
   "border-4 border-double border-transparent bg-key-900 text-white hover:bg-key-1000 hover:underline active:bg-key-1200 active:underline disabled:bg-solid-gray-300 disabled:text-solid-gray-50 aria-disabled:bg-solid-gray-300 aria-disabled:text-solid-gray-50"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap underline-offset-[calc(3/16*1rem)] focus-visible:outline focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:ring-yellow-300 disabled:pointer-events-none disabled:forced-colors:border-[GrayText] disabled:forced-colors:text-[GrayText] aria-disabled:pointer-events-none aria-disabled:forced-colors:border-[GrayText] aria-disabled:forced-colors:text-[GrayText]",
+  "inline-flex items-center justify-center gap-x-1 max-w-full underline-offset-[calc(3/16*1rem)] focus-visible:outline focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:ring-yellow-300 disabled:pointer-events-none disabled:forced-colors:border-[GrayText] disabled:forced-colors:text-[GrayText] aria-disabled:pointer-events-none aria-disabled:forced-colors:border-[GrayText] aria-disabled:forced-colors:text-[GrayText]",
   {
     variants: {
       variant: {

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -9,7 +9,7 @@ export type CheckboxSize = "sm" | "md" | "lg"
 // Outer hit area (matches upstream's wrapping <span>): sized size-6/8/11, with the
 // subtle gray hover backdrop. The visible box is the inner element at 75%.
 const checkboxVariants = cva(
-  "group/checkbox inline-flex shrink-0 items-center justify-center appearance-none rounded-[calc(1/8*100%)] bg-transparent outline-none hover:bg-solid-gray-420 focus-visible:bg-transparent aria-disabled:pointer-events-none aria-disabled:hover:bg-transparent data-[size=sm]:size-6 data-[size=md]:size-8 data-[size=lg]:size-11",
+  "group/checkbox inline-flex shrink-0 items-center justify-center appearance-none rounded-[calc(1/8*100%)] bg-transparent outline-none hover:bg-solid-gray-420 focus-visible:bg-transparent disabled:pointer-events-none disabled:hover:bg-transparent aria-disabled:pointer-events-none aria-disabled:hover:bg-transparent data-[size=sm]:size-6 data-[size=md]:size-8 data-[size=lg]:size-11",
   {
     variants: {
       size: {
@@ -47,7 +47,14 @@ const checkboxBoxClass = cn(
   "group-hover/checkbox:group-data-[state=checked]/checkbox:group-data-[error]/checkbox:bg-red-1000 group-hover/checkbox:group-data-[state=indeterminate]/checkbox:group-data-[error]/checkbox:bg-red-1000",
   "group-aria-disabled/checkbox:!border-solid-gray-300 group-aria-disabled/checkbox:!bg-solid-gray-50",
   "group-data-[state=checked]/checkbox:group-aria-disabled/checkbox:!bg-solid-gray-300 group-data-[state=indeterminate]/checkbox:group-aria-disabled/checkbox:!bg-solid-gray-300",
-  "forced-colors:!border-[ButtonText] group-data-[state=checked]/checkbox:forced-colors:!bg-[Highlight] group-data-[state=checked]/checkbox:forced-colors:!border-[Highlight] group-data-[state=indeterminate]/checkbox:forced-colors:!bg-[Highlight] group-data-[state=indeterminate]/checkbox:forced-colors:!border-[Highlight] group-aria-disabled/checkbox:forced-colors:!border-[GrayText] group-data-[state=checked]/checkbox:group-aria-disabled/checkbox:forced-colors:!bg-[GrayText]"
+  // native `disabled` gets the same treatment as `aria-disabled` (upstream 22cda0d)
+  "group-disabled/checkbox:!border-solid-gray-300 group-disabled/checkbox:!bg-solid-gray-50",
+  "group-data-[state=checked]/checkbox:group-disabled/checkbox:!bg-solid-gray-300 group-data-[state=indeterminate]/checkbox:group-disabled/checkbox:!bg-solid-gray-300",
+  "forced-colors:!border-[ButtonText] group-data-[state=checked]/checkbox:forced-colors:!bg-[Highlight] group-data-[state=checked]/checkbox:forced-colors:!border-[Highlight] group-data-[state=indeterminate]/checkbox:forced-colors:!bg-[Highlight] group-data-[state=indeterminate]/checkbox:forced-colors:!border-[Highlight] group-aria-disabled/checkbox:forced-colors:!border-[GrayText] group-data-[state=checked]/checkbox:group-aria-disabled/checkbox:forced-colors:!bg-[GrayText] group-disabled/checkbox:forced-colors:!border-[GrayText] group-data-[state=checked]/checkbox:group-disabled/checkbox:forced-colors:!bg-[GrayText]",
+  // Checked + disabled must use GrayText for the border too. Specificity matches
+  // the checked rule, so a combined selector is required or Highlight remains.
+  "group-data-[state=checked]/checkbox:group-disabled/checkbox:forced-colors:!border-[GrayText] group-data-[state=indeterminate]/checkbox:group-disabled/checkbox:forced-colors:!border-[GrayText]",
+  "group-data-[state=checked]/checkbox:group-aria-disabled/checkbox:forced-colors:!border-[GrayText] group-data-[state=indeterminate]/checkbox:group-aria-disabled/checkbox:forced-colors:!border-[GrayText]"
 )
 
 export type CheckboxProps = Omit<


### PR DESCRIPTION
## Summary
- Sync used Digital Agency UI components to [shadcn-digital-agency-jp v0.6.0](https://github.com/yukiharada1228/shadcn-digital-agency-jp/releases/tag/v0.6.0) (no breaking changes).
- Button now allows wrapping (`gap-x-1` / `max-w-full` instead of `whitespace-nowrap`).
- Checkbox applies disabled styles to native `disabled` and fixes forced-colors for checked + disabled.

## Test plan
- [ ] Confirm buttons with icons/long labels still look correct, including on narrow widths
- [ ] Confirm disabled checkboxes look disabled (native `disabled` and `aria-disabled`)
- [ ] `cd frontend && npm run typecheck && npm run lint && npm test`


Made with [Cursor](https://cursor.com)