### PR TITLE
Pass UUID user ids through video rows instead of int()

### DIFF
--- a/apps/worker/tests/test_video_sql.py
+++ b/apps/worker/tests/test_video_sql.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from worker_python.video_sql import _row_to_video
+
+
+def _row(**overrides) -> dict:
+    row = {
+        "id": 109,
+        # users.id became a UUID text PK in migration 0006_user_id_uuid.
+        "user_id": "1f0c6a5e-6d3c-4a1b-9f2e-8c7d5b4a3e21",
+        "title": "sample",
+        "transcript": None,
+        "status": "uploaded",
+        "source_type": "uploaded",
+        "file": "videos/109.mp4",
+        "youtube_video_id": None,
+        "error_message": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_row_to_video_keeps_uuid_user_id_as_text() -> None:
+    video = _row_to_video(_row())
+
+    assert video.user_id == "1f0c6a5e-6d3c-4a1b-9f2e-8c7d5b4a3e21"
+    assert video.id == 109
+
+
+def test_row_to_video_normalises_optional_columns() -> None:
+    video = _row_to_video(_row(file="", transcript="", error_message=None))
+
+    assert video.file_key is None
+    assert video.transcript is None
+    assert video.error_message == ""

--- a/apps/worker/worker_python/tasks/transcription.py
+++ b/apps/worker/worker_python/tasks/transcription.py
@@ -36,7 +36,7 @@ class FileSizeExceededError(Exception):
     pass
 
 
-def _load_searchapi_key(user_id: int) -> str | None:
+def _load_searchapi_key(user_id: str) -> str | None:
     from worker_python.env import env_str
 
     override = env_str("SEARCHAPI_API_KEY")

--- a/apps/worker/worker_python/video_sql.py
+++ b/apps/worker/worker_python/video_sql.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class VideoRow:
     id: int
-    user_id: int
+    user_id: str
     title: str
     transcript: str | None
     status: str
@@ -30,7 +30,8 @@ def _row_to_video(row: dict[str, Any]) -> VideoRow:
     file_val = row.get("file")
     return VideoRow(
         id=int(row["id"]),
-        user_id=int(row["user_id"]),
+        # users.id is a UUID text PK (migration 0006); int() would raise ValueError.
+        user_id=str(row["user_id"]),
         title=row["title"],
         transcript=row.get("transcript") or None,
         status=row["status"],


### PR DESCRIPTION
## 問題

本番で動画をアップロードしても文字起こしが始まらない。`videoq-worker-prod` の全 `transcribe_video` ジョブが約1秒で例外終了していた。

```
File "worker_python/tasks/transcription.py", line 71, in transcribe_video
  video = get_video_for_task(conn, video_id)
File "worker_python/video_sql.py", line 33, in _row_to_video
  user_id=int(row["user_id"]),
```

`videoq-worker-dlq-prod` に 4 件滞留（`video_id=109`, `110` を確認）。

## 原因

migration `0006_user_id_uuid.sql` で `users.id` / `videos.user_id` が bigint → UUID text になったが、`_row_to_video()` が `int()` のまま残っていた。

失敗はステータス遷移より**前**の `get_video_for_task()` で起きるため、DB 上の動画ステータスは変わらず「処理が始まらない」状態になる。`index_video_transcript` / `reindex_all_videos_embeddings` も `list_completed_videos_with_transcript()` 経由で同様に壊れていた。

#832 (c77cb60) でアカウント削除パスの同種バグを直したが、動画パスが漏れていた。

## 修正

- `VideoRow.user_id: int` → `str`、`int(row["user_id"])` → `str(...)`
- `_load_searchapi_key(user_id: int)` → `str`（型注釈の追従）
- `_row_to_video` の回帰テストを追加

`VideoRow.user_id` の利用箇所は 2 つのみで、どちらも既に text 前提（`vector_index` のメタデータ列 `scene_embeddings.user_id` は同 migration で text に remap 済み、`_load_searchapi_key` は `users.id` と突き合わせ）。

## 確認

- `pytest`: 40 passed
- `ruff` / `mypy`: 変更ファイルは指摘なし（既存の指摘は無関係のファイル）

## マージ後

CD で Lambda を更新後、DLQ の滞留分を redrive する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKFDna5GHTYLZ1agyAPkRz