### PR TITLE
Align the transcript panel height with the video column

### DIFF
--- a/frontend/src/components/video/detail/VideoDetailView.tsx
+++ b/frontend/src/components/video/detail/VideoDetailView.tsx
@@ -442,138 +442,136 @@ function TranscriptPanel({
 
   return (
     <div
-      className={`lg:col-span-4 flex flex-col border border-solid-gray-420 bg-white ${
-        isMobile
-          ? 'min-h-[500px]'
-          : 'sticky top-[var(--app-header-offset,8.5rem)] h-[calc(100vh-var(--app-header-offset,8.5rem))]'
-      } ${isMobile && mobileTab !== 'transcript' ? 'hidden' : ''}`}
+      className={`lg:col-span-4 lg:relative ${isMobile && mobileTab !== 'transcript' ? 'hidden' : ''}`}
     >
-      <div className="p-4 border-b border-solid-gray-200 flex flex-col gap-3 shrink-0">
-        <div className="flex justify-between items-center">
-          <Heading size="18">
-            <HeadingTitle level="h2">{t('videos.detail.transcriptSection')}</HeadingTitle>
-          </Heading>
-          {!isTranscriptEditing && (
-            <Button
-              type="button"
-              variant="outline"
-              size="xs"
-              onClick={onStartTranscriptEditing}
-              disabled={!video.transcript}
-            >
-              <Pencil className="h-3.5 w-3.5 mr-1.5" />
-              {t('videos.detail.editTranscriptButton')}
-            </Button>
-          )}
-        </div>
-        {!isTranscriptEditing && (
-          <div className="relative w-full">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-solid-gray-600 w-3.5 h-3.5 z-10" />
-            <Input
-              type="search"
-              blockSize="sm"
-              value={transcriptSearch}
-              onChange={(event) => onTranscriptSearchChange(event.target.value)}
-              aria-label={t('videos.detail.transcriptSearchPlaceholder')}
-              className="pl-9"
-            />
-          </div>
-        )}
-      </div>
-
-      {isTranscriptEditing ? (
-        <div className="flex-1 overflow-hidden flex flex-col">
-          <div className="flex shrink-0 flex-col gap-3 border-b border-solid-gray-200 bg-solid-gray-50 p-3 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex shrink-0 gap-2">
+      <div className="flex min-h-[31.25rem] flex-col border border-solid-gray-420 bg-white lg:absolute lg:inset-0 lg:min-h-0">
+        <div className="p-4 border-b border-solid-gray-200 flex flex-col gap-3 shrink-0">
+          <div className="flex justify-between items-center">
+            <Heading size="18">
+              <HeadingTitle level="h2">{t('videos.detail.transcriptSection')}</HeadingTitle>
+            </Heading>
+            {!isTranscriptEditing && (
               <Button
                 type="button"
                 variant="outline"
                 size="xs"
-                onClick={onCancelTranscriptEditing}
-                disabled={isTranscriptSaving}
+                onClick={onStartTranscriptEditing}
+                disabled={!video.transcript}
               >
-                {t('videos.detail.cancel')}
+                <Pencil className="h-3.5 w-3.5 mr-1.5" />
+                {t('videos.detail.editTranscriptButton')}
               </Button>
-              <Button
-                type="button"
-                variant="solid"
-                size="xs"
-                onClick={onSaveTranscript}
-                disabled={isTranscriptSaving}
-              >
-                {isTranscriptSaving ? <InlineSpinner className="h-3 w-3 mr-1.5" /> : <Save className="h-3 w-3 mr-1.5" />}
-                {isTranscriptSaving ? t('videos.detail.saving') : t('videos.detail.saveTranscriptButton')}
-              </Button>
-            </div>
+            )}
           </div>
-          {transcriptSaveError && (
-            <div className="shrink-0 p-3 border-b border-solid-gray-200">
-              <ErrorMessage message={transcriptSaveError} />
+          {!isTranscriptEditing && (
+            <div className="relative w-full">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-solid-gray-600 w-3.5 h-3.5 z-10" />
+              <Input
+                type="search"
+                blockSize="sm"
+                value={transcriptSearch}
+                onChange={(event) => onTranscriptSearchChange(event.target.value)}
+                aria-label={t('videos.detail.transcriptSearchPlaceholder')}
+                className="pl-9"
+              />
             </div>
           )}
-          <Textarea
-            value={editedTranscript}
-            onChange={(event) => onEditedTranscriptChange(event.target.value)}
-            disabled={isTranscriptSaving}
-            spellCheck={false}
-            className="min-h-0 flex-1 resize-none rounded-none border-0 font-mono text-dns-14N-130 leading-relaxed focus:outline-none focus:ring-0"
-          />
         </div>
-      ) : (
-        <div className="flex-1 overflow-y-auto p-2 flex flex-col gap-1">
-          {filteredSegments.length > 0 ? (
-            filteredSegments.map((segment, index) => (
-              <div
-                key={index}
-                onClick={() => onSeek(segment.seconds, index)}
-                className={`flex cursor-pointer gap-4 rounded-8 p-3 transition-colors group ${
-                  activeSegmentIdx === index
-                    ? 'border-l-4 border-key-900 bg-blue-50'
-                    : 'hover:bg-solid-gray-50'
-                }`}
-              >
-                <span className="mt-0.5 h-fit shrink-0 whitespace-nowrap rounded-8 bg-blue-50 px-2 py-0.5 font-mono text-dns-14B-120 text-key-900">
-                  {segment.timestamp}
-                </span>
-                <p
-                  className={`text-std-16N-170 leading-relaxed ${
+
+        {isTranscriptEditing ? (
+          <div className="flex-1 overflow-hidden flex flex-col">
+            <div className="flex shrink-0 flex-col gap-3 border-b border-solid-gray-200 bg-solid-gray-50 p-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex shrink-0 gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  onClick={onCancelTranscriptEditing}
+                  disabled={isTranscriptSaving}
+                >
+                  {t('videos.detail.cancel')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="solid"
+                  size="xs"
+                  onClick={onSaveTranscript}
+                  disabled={isTranscriptSaving}
+                >
+                  {isTranscriptSaving ? <InlineSpinner className="h-3 w-3 mr-1.5" /> : <Save className="h-3 w-3 mr-1.5" />}
+                  {isTranscriptSaving ? t('videos.detail.saving') : t('videos.detail.saveTranscriptButton')}
+                </Button>
+              </div>
+            </div>
+            {transcriptSaveError && (
+              <div className="shrink-0 p-3 border-b border-solid-gray-200">
+                <ErrorMessage message={transcriptSaveError} />
+              </div>
+            )}
+            <Textarea
+              value={editedTranscript}
+              onChange={(event) => onEditedTranscriptChange(event.target.value)}
+              disabled={isTranscriptSaving}
+              spellCheck={false}
+              className="min-h-0 flex-1 resize-none rounded-none border-0 font-mono text-dns-14N-130 leading-relaxed focus:outline-none focus:ring-0"
+            />
+          </div>
+        ) : (
+          <div className="flex-1 overflow-y-auto p-2 flex flex-col gap-1">
+            {filteredSegments.length > 0 ? (
+              filteredSegments.map((segment, index) => (
+                <div
+                  key={index}
+                  onClick={() => onSeek(segment.seconds, index)}
+                  className={`flex cursor-pointer gap-4 rounded-8 p-3 transition-colors group ${
                     activeSegmentIdx === index
-                      ? 'text-solid-gray-800 font-medium'
-                      : 'text-solid-gray-700 group-hover:text-solid-gray-800'
+                      ? 'border-l-4 border-key-900 bg-blue-50'
+                      : 'hover:bg-solid-gray-50'
                   }`}
                 >
-                  {segment.text}
+                  <span className="mt-0.5 h-fit shrink-0 whitespace-nowrap rounded-8 bg-blue-50 px-2 py-0.5 font-mono text-dns-14B-120 text-key-900">
+                    {segment.timestamp}
+                  </span>
+                  <p
+                    className={`text-std-16N-170 leading-relaxed ${
+                      activeSegmentIdx === index
+                        ? 'text-solid-gray-800 font-medium'
+                        : 'text-solid-gray-700 group-hover:text-solid-gray-800'
+                    }`}
+                  >
+                    {segment.text}
+                  </p>
+                </div>
+              ))
+            ) : isPlainTextTranscript ? (
+              <div className="p-4 bg-white rounded-8">
+                <p className="text-std-16N-170 text-solid-gray-700 whitespace-pre-wrap leading-relaxed">
+                  {video.transcript}
                 </p>
               </div>
-            ))
-          ) : isPlainTextTranscript ? (
-            <div className="p-4 bg-white rounded-8">
-              <p className="text-std-16N-170 text-solid-gray-700 whitespace-pre-wrap leading-relaxed">
-                {video.transcript}
-              </p>
-            </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center py-16 text-solid-gray-600">
-              <div className="w-16 h-16 bg-solid-gray-50 border border-solid-gray-200 rounded-full flex items-center justify-center mb-4">
-                <Search className="w-8 h-8 text-solid-gray-420" />
+            ) : (
+              <div className="flex flex-col items-center justify-center py-16 text-solid-gray-600">
+                <div className="w-16 h-16 bg-solid-gray-50 border border-solid-gray-200 rounded-full flex items-center justify-center mb-4">
+                  <Search className="w-8 h-8 text-solid-gray-420" />
+                </div>
+                <p className="text-std-16N-170 font-medium text-center px-4">
+                  {transcriptSearch
+                    ? t('videos.detail.transcriptNotFound')
+                    : (() => {
+                        const statusMsgs: Partial<Record<Video['status'], string>> = {
+                          pending: t('videos.detail.transcriptStatus.pending'),
+                          processing: t('videos.detail.transcriptStatus.processing'),
+                          indexing: t('videos.detail.transcriptStatus.indexing'),
+                          error: t('videos.detail.transcriptStatus.error'),
+                        };
+                        return statusMsgs[video.status] ?? t('videos.detail.transcriptStatus.unavailable');
+                      })()}
+                </p>
               </div>
-              <p className="text-std-16N-170 font-medium text-center px-4">
-                {transcriptSearch
-                  ? t('videos.detail.transcriptNotFound')
-                  : (() => {
-                      const statusMsgs: Partial<Record<Video['status'], string>> = {
-                        pending: t('videos.detail.transcriptStatus.pending'),
-                        processing: t('videos.detail.transcriptStatus.processing'),
-                        indexing: t('videos.detail.transcriptStatus.indexing'),
-                        error: t('videos.detail.transcriptStatus.error'),
-                      };
-                      return statusMsgs[video.status] ?? t('videos.detail.transcriptStatus.unavailable');
-                    })()}
-              </p>
-            </div>
-          )}
-        </div>
-      )}
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 問題

動画詳細画面で、文字起こしパネルの高さが左カラム（動画プレイヤー + メタ情報）と揃っておらず、下端がズレて見える。

## 原因

左右のカラムが別々の基準で高さを決めていた。

| カラム | 高さの決まり方 |
| --- | --- |
| 左（動画 + メタ情報） | コンテンツ基準（`aspect-video` + メタパネルの中身） |
| 右（文字起こし） | ビューポート基準 `sticky top-[var(--app-header-offset,8.5rem)] h-[calc(100vh-var(--app-header-offset,8.5rem))]` |

片方は中身の量、もう片方は画面の高さで決まるため、揃うのは偶然一致したときだけ。加えて `--app-header-offset` のフォールバックが `8.5rem` になっており、`AppNav.tsx` の `HEADER_OFFSET_FALLBACK`（`5rem`）と食い違っていた。`sticky` により下の `PlogPanel` までスクロールすると文字起こしだけが張り付いて残る点も、ズレを助長していた。

## 修正

高さの決定権を grid の行に一本化した。

- `sticky` + `100vh` 計算を削除し、カラムのラッパー（`lg:col-span-4 lg:relative`）が grid 行のストレッチで左カラムと同じ高さになるようにした
- パネル本体を `lg:absolute lg:inset-0 lg:min-h-0` で流し込み、文字起こしの分量が行の高さに寄与しないようにした（これがないと「中身が長い → 行が伸びる」の循環になる）
- スクロールするのはパネル内部（`flex-1 overflow-y-auto`）のみ
- モバイル（`< lg`）は従来どおり静的配置 + 最低高さ。`isMobile` の JS フラグはタブの出し分けだけに使い、高さは CSS 側に寄せた

差分 113/115 行のうち、実質的な変更は上記のみで、残りはラップに伴うインデント（`git diff -w` で確認可能）。

## 確認

- 同じ構造を切り出した最小 HTML を Playwright で計測し、動画 top と パネル top、メタ bottom と パネル bottom がそれぞれ一致することを確認。セグメント 200 件を流し込んでもページ高さは変わらず、パネル内部のみがスクロールする
- `npx tsc -p tsconfig.app.json --noEmit`: エラーなし
- `npx eslint src/components/video/detail/VideoDetailView.tsx`: 指摘なし
- `npx vitest run src/pages/__tests__/VideoDetailPage.test.tsx`: 23 passed

実アプリ（実データ）での目視確認は未実施。

## 補足

左カラムと高さを揃える以上、スクロール追従（`sticky`）とは両立しないため、今回は「揃える」方を優先している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPKhc88yLpdkcd9cUTawWU
