### PR TITLE
Sync Digital Agency UI to v0.7.0

### DIFF
--- a/frontend/scripts/sync-digital-agency-ui.mjs
+++ b/frontend/scripts/sync-digital-agency-ui.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
-const registry = 'yukiharada1228/shadcn-digital-agency-jp' // last synced: v0.6.0
+const registry = 'yukiharada1228/shadcn-digital-agency-jp' // last synced: v0.7.0
 
 // Keep this list aligned with imports from src/components/ui. Do not use the
 // registry's all-components block: it installs demo-only components and their

--- a/frontend/src/components/ui/breadcrumbs.tsx
+++ b/frontend/src/components/ui/breadcrumbs.tsx
@@ -33,32 +33,34 @@ const BreadcrumbsLabel = React.forwardRef<
 })
 BreadcrumbsLabel.displayName = "BreadcrumbsLabel"
 
+// The trail is a <p> of <span>s, not ol/li: upstream 2166f11 dropped the list
+// semantics so screen readers announce the trail as running text.
 const BreadcrumbList = React.forwardRef<
-  HTMLOListElement,
-  React.ComponentPropsWithoutRef<"ol">
+  HTMLParagraphElement,
+  React.ComponentPropsWithoutRef<"p">
 >(({ className, children, ...props }, ref) => {
   return (
-    <ol
+    <p
       ref={ref}
       data-slot="breadcrumb-list"
       className={cn("inline", className)}
       {...props}
     >
       {children}
-    </ol>
+    </p>
   )
 })
 BreadcrumbList.displayName = "BreadcrumbList"
 
-export type BreadcrumbItemProps = React.ComponentPropsWithoutRef<"li"> & {
+export type BreadcrumbItemProps = React.ComponentPropsWithoutRef<"span"> & {
   isCurrent?: boolean
 }
 
-const BreadcrumbItem = React.forwardRef<HTMLLIElement, BreadcrumbItemProps>(
+const BreadcrumbItem = React.forwardRef<HTMLSpanElement, BreadcrumbItemProps>(
   ({ isCurrent = false, className, children, ...props }, ref) => {
     if (isCurrent) {
       return (
-        <li
+        <span
           ref={ref}
           data-slot="breadcrumb-item"
           aria-current="page"
@@ -66,12 +68,12 @@ const BreadcrumbItem = React.forwardRef<HTMLLIElement, BreadcrumbItemProps>(
           {...props}
         >
           {children}
-        </li>
+        </span>
       )
     }
 
     return (
-      <li
+      <span
         ref={ref}
         data-slot="breadcrumb-item"
         className={cn("inline break-words", className)}
@@ -91,7 +93,7 @@ const BreadcrumbItem = React.forwardRef<HTMLLIElement, BreadcrumbItemProps>(
             fill="currentColor"
           />
         </svg>
-      </li>
+      </span>
     )
   }
 )

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -51,8 +51,8 @@ const checkboxBoxClass = cn(
   "group-disabled/checkbox:!border-solid-gray-300 group-disabled/checkbox:!bg-solid-gray-50",
   "group-data-[state=checked]/checkbox:group-disabled/checkbox:!bg-solid-gray-300 group-data-[state=indeterminate]/checkbox:group-disabled/checkbox:!bg-solid-gray-300",
   "forced-colors:!border-[ButtonText] group-data-[state=checked]/checkbox:forced-colors:!bg-[Highlight] group-data-[state=checked]/checkbox:forced-colors:!border-[Highlight] group-data-[state=indeterminate]/checkbox:forced-colors:!bg-[Highlight] group-data-[state=indeterminate]/checkbox:forced-colors:!border-[Highlight] group-aria-disabled/checkbox:forced-colors:!border-[GrayText] group-data-[state=checked]/checkbox:group-aria-disabled/checkbox:forced-colors:!bg-[GrayText] group-disabled/checkbox:forced-colors:!border-[GrayText] group-data-[state=checked]/checkbox:group-disabled/checkbox:forced-colors:!bg-[GrayText]",
-  // Checked + disabled must use GrayText for the border too. Specificity matches
-  // the checked rule, so a combined selector is required or Highlight remains.
+  // 選択済み + 無効では枠線も GrayText にする。checked 側のルールと詳細度が並ぶため、
+  // 組み合わせたセレクタで明示的に上書きしないと Highlight が残る。
   "group-data-[state=checked]/checkbox:group-disabled/checkbox:forced-colors:!border-[GrayText] group-data-[state=indeterminate]/checkbox:group-disabled/checkbox:forced-colors:!border-[GrayText]",
   "group-data-[state=checked]/checkbox:group-aria-disabled/checkbox:forced-colors:!border-[GrayText] group-data-[state=indeterminate]/checkbox:group-aria-disabled/checkbox:forced-colors:!border-[GrayText]"
 )

--- a/frontend/src/components/ui/chip-label.tsx
+++ b/frontend/src/components/ui/chip-label.tsx
@@ -16,7 +16,7 @@ type ChipLabelColor =
   | "magenta"
   | "purple"
 
-// Define only color-specific styles; chipLabelVariants applies shared styles.
+// 色に関するスタイルのみ定義（共通スタイルは chipLabelVariants で適用）
 const colorClasses: Record<
   NonNullable<VariantProps<typeof chipLabelVariants>["variant"]>,
   Record<ChipLabelColor, string>

--- a/frontend/src/components/ui/progress-indicator.tsx
+++ b/frontend/src/components/ui/progress-indicator.tsx
@@ -370,8 +370,8 @@ const format = (template: string, variables: Record<string, string | number>) =>
   )
 
 /**
- * Hook that manages announcement text for screen readers.
- * Render the returned value in a visually hidden element with `role="status"`.
+ * スクリーンリーダーへの通知テキストを管理する hook。
+ * 戻り値を `role="status"` のビジュアル上隠した要素に差し込んで使用する。
  */
 const useProgressIndicatorAnnouncer = (
   props: UseProgressIndicatorAnnouncerProps


### PR DESCRIPTION
## 概要

[shadcn-digital-agency-jp v0.7.0](https://github.com/yukiharada1228/shadcn-digital-agency-jp/releases/tag/v0.7.0) に追従（`npm run ui:sync`）。upstream の `digital-go-jp/design-system-example-components-react@2166f11` 追従による**破壊的変更を含む**リリース。

## 変更

- **`breadcrumbs`（破壊的変更）**: `BreadcrumbList` が `<ol>` → `<p>`、`BreadcrumbItem` が `<li>` → `<span>` を描画。upstream がリストのセマンティクスを廃し、スクリーンリーダーに地の文として読ませる方針に変更したことへの追従。型も `HTMLOListElement`/`HTMLLIElement` → `HTMLParagraphElement`/`HTMLSpanElement` に変わる
- **`checkbox` / `chip-label` / `progress-indicator`**: upstream 側のコメント和訳のみ（挙動の変更なし）
- `scripts/sync-digital-agency-ui.mjs` の `last synced` を v0.7.0 に更新

`list` はこのリポジトリでは未インストールのため、リリースノートのもう一つの破壊的変更（`--spacing` → `--list-spacing`）の影響はなし（`--spacing` の参照も `src` に存在しないことを確認済み）。

## 呼び出し側への影響

`Breadcrumb*` の利用箇所は 3 つ（`VideoDetailView` / `VideoGroupDetailView` / `DeveloperDocsSectionPage`）で、いずれも `BreadcrumbItem` の中身は `BreadcrumbLink asChild` → `<a>` と文字列のみ。`<p>` の中に block 要素が入る構造にはならず、`ol`/`li` を前提としたスタイルや DOM クエリ（`role="listitem"` など）も存在しないため、追加の修正は不要。

## 確認

- `npm run typecheck`: エラーなし
- `npm run lint`: 指摘なし
- `npm test`: 64 files / 616 tests passed

実ブラウザでの目視確認は未実施。

## Test plan

- [ ] 動画詳細 / グループ詳細 / 開発者ドキュメントの各ページでパンくずの見た目が変わっていないこと
- [ ] スクリーンリーダーでパンくずが地の文として読まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvdMejYb4LZnsS83wUqUtz
