### PR TITLE
Update developer docs for current API endpoints

### DIFF
--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -62,9 +62,20 @@ VideoQはMCPサーバーとして動作し、Claude DesktopなどのAIエージ�
 
 VideoQ acts as an MCP server, allowing AI agent clients such as Claude Desktop to access video content directly via the Model Context Protocol.
 
+- Endpoint: `POST /api/mcp` (Streamable HTTP)
+- Authentication: OAuth bearer token or API key
+
 ## Documentation
 
 - [Authentication API](https://videoq.jp/docs/auth)
 - [Video API](https://videoq.jp/docs/videos)
+- [Group and Membership API](https://videoq.jp/docs/groups)
+- [Tag API](https://videoq.jp/docs/tags)
 - [Chat API](https://videoq.jp/docs/chat)
 - [OpenAI-Compatible API](https://videoq.jp/docs/openai)
+- [Plog API](https://videoq.jp/docs/plog)
+- [Evaluation API](https://videoq.jp/docs/evaluation)
+- [Admin API](https://videoq.jp/docs/admin)
+- [Interactive API Reference](https://videoq.jp/api/docs)
+- [ReDoc API Reference](https://videoq.jp/api/redoc)
+- [OpenAPI Schema](https://videoq.jp/api/openapi.json)

--- a/frontend/src/__tests__/llms.test.ts
+++ b/frontend/src/__tests__/llms.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { describe, it, expect, beforeAll } from 'vitest'
+import { docsSectionIds } from '@/lib/docs/sections'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -75,12 +76,8 @@ describe('llms.txt', () => {
 
   // ── Documentation links ──────────────────────────────────────────────────────
 
-  const REQUIRED_DOC_LINKS = [
-    `${BASE}/docs/auth`,
-    `${BASE}/docs/videos`,
-    `${BASE}/docs/chat`,
-    `${BASE}/docs/openai`,
-  ]
+  // Every docs section the app renders must be discoverable from llms.txt.
+  const REQUIRED_DOC_LINKS = docsSectionIds.map((id) => `${BASE}/docs/${id}`)
 
   it.each(REQUIRED_DOC_LINKS)('contains link to %s', (url) => {
     expect(content).toContain(url)

--- a/frontend/src/components/docs/ApiEndpointList.tsx
+++ b/frontend/src/components/docs/ApiEndpointList.tsx
@@ -1,55 +1,23 @@
-import { useEffect, useMemo, useState } from 'react';
-import { API_URL, apiClient } from '@/lib/api';
+import { useMemo } from 'react';
+import { getApiOrigin } from '@/lib/api';
+import { useOpenApiSchema } from '@/hooks/useOpenApiSchema';
+import {
+  listOperations,
+  type HttpMethod,
+  type OpenApiOperation,
+  type OpenApiSchemaObject,
+} from '@/lib/docs/openapi';
+import {
+  getDocsAuthMode,
+  matchesDocsSection,
+  type DocsAuthMode,
+  type DocsSectionId,
+} from '@/lib/docs/sections';
 import { ChipLabel } from '@/components/ui/chip-label';
 import { Disclosure, DisclosureSummary } from '@/components/ui/disclosure';
 import { Heading, HeadingTitle } from '@/components/ui/heading';
 import { Tab, TabItem, TabList, TabPanel, useTabAria } from '@/components/ui/tabs';
 import { useTranslation } from 'react-i18next';
-
-type DocsSection = 'auth' | 'videos' | 'chat' | 'openai';
-type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
-
-type OpenApiSchema = {
-  paths?: Record<string, Record<string, OpenApiOperation>>;
-  components?: {
-    schemas?: Record<string, OpenApiSchemaObject>;
-  };
-};
-
-type OpenApiOperation = {
-  summary?: string;
-  description?: string;
-  tags?: string[];
-  parameters?: OpenApiParameter[];
-  requestBody?: {
-    content?: {
-      'application/json'?: {
-        schema?: OpenApiSchemaObject;
-      };
-    };
-  };
-};
-
-type OpenApiSchemaObject = {
-  type?: string;
-  format?: string;
-  enum?: string[];
-  properties?: Record<string, OpenApiSchemaObject>;
-  required?: string[];
-  items?: OpenApiSchemaObject;
-  oneOf?: OpenApiSchemaObject[];
-  anyOf?: OpenApiSchemaObject[];
-  allOf?: OpenApiSchemaObject[];
-  additionalProperties?: OpenApiSchemaObject | boolean;
-  $ref?: string;
-};
-
-type OpenApiParameter = {
-  in?: 'path' | 'query' | 'header' | 'cookie';
-  name?: string;
-  required?: boolean;
-  schema?: OpenApiSchemaObject;
-};
 
 type EndpointItem = {
   method: HttpMethod;
@@ -59,15 +27,20 @@ type EndpointItem = {
   snippets: Record<SnippetTab, string>;
 };
 
-const supportedMethods: HttpMethod[] = ['get', 'post', 'put', 'patch', 'delete'];
 const snippetTabs = ['curl', 'javascript', 'typescript', 'python', 'go', 'java', 'csharp', 'php', 'ruby'] as const;
 type SnippetTab = (typeof snippetTabs)[number];
 
-function sectionMatchesPath(path: string, section: DocsSection): boolean {
-  if (section === 'auth') return path.includes('/auth/');
-  if (section === 'videos') return path.includes('/videos/');
-  if (section === 'openai') return path.startsWith('/v1/');
-  return path.includes('/chat/');
+function authenticationHeader(authMode: DocsAuthMode): [string, string] | null {
+  if (authMode === 'session') {
+    return ['Cookie', '<session-cookie-name>=<session-cookie-value>'];
+  }
+  if (authMode === 'bearerApiKey') {
+    return ['Authorization', 'Bearer vq_your_key_here'];
+  }
+  if (authMode === 'apiKey') {
+    return ['X-API-Key', 'vq_your_key_here'];
+  }
+  return null;
 }
 
 function resolveSchemaRef(
@@ -133,13 +106,14 @@ function generateJsonExample(
 function buildCurlExample(
   method: HttpMethod,
   url: string,
-  includeApiKeyHeader: boolean,
+  authMode: DocsAuthMode,
   body: unknown | null,
 ): string {
   const lines: string[] = [`curl -X ${method.toUpperCase()} \\`, '  -H "Accept: application/json" \\'];
 
-  if (includeApiKeyHeader) {
-    lines.push('  -H "X-API-Key: vq_your_key_here" \\');
+  const authHeader = authenticationHeader(authMode);
+  if (authHeader) {
+    lines.push(`  -H "${authHeader[0]}: ${authHeader[1]}" \\`);
   }
 
   if (body !== null) {
@@ -154,11 +128,13 @@ function buildCurlExample(
 function buildJavaScriptExample(
   method: HttpMethod,
   url: string,
-  includeApiKeyHeader: boolean,
+  authMode: DocsAuthMode,
   body: unknown | null,
 ): string {
   const headers: Record<string, string> = { Accept: 'application/json' };
-  if (includeApiKeyHeader) headers['X-API-Key'] = 'vq_your_key_here';
+  const authHeader = authenticationHeader(authMode);
+  // Browsers attach the HttpOnly account-session cookie themselves.
+  if (authHeader && authMode !== 'session') headers[authHeader[0]] = authHeader[1];
   if (body !== null) headers['Content-Type'] = 'application/json';
 
   const lines: string[] = [
@@ -166,6 +142,7 @@ function buildJavaScriptExample(
     `  method: "${method.toUpperCase()}",`,
     `  headers: ${JSON.stringify(headers, null, 2).replace(/\n/g, '\n  ')},`,
   ];
+  if (authMode === 'session') lines.push('  credentials: "include",');
   if (body !== null) {
     lines.push(`  body: JSON.stringify(${JSON.stringify(body, null, 2).replace(/\n/g, '\n  ')}),`);
   }
@@ -179,13 +156,14 @@ function buildJavaScriptExample(
 function buildPythonExample(
   method: HttpMethod,
   url: string,
-  includeApiKeyHeader: boolean,
+  authMode: DocsAuthMode,
   body: unknown | null,
 ): string {
   const headers: Record<string, string> = {
     Accept: 'application/json',
   };
-  if (includeApiKeyHeader) headers['X-API-Key'] = 'vq_your_key_here';
+  const authHeader = authenticationHeader(authMode);
+  if (authHeader) headers[authHeader[0]] = authHeader[1];
   if (body !== null) headers['Content-Type'] = 'application/json';
 
   const lines: string[] = [
@@ -212,16 +190,16 @@ function buildPythonExample(
 function buildTypescriptExample(
   method: HttpMethod,
   url: string,
-  includeApiKeyHeader: boolean,
+  authMode: DocsAuthMode,
   body: unknown | null,
 ): string {
-  return buildJavaScriptExample(method, url, includeApiKeyHeader, body);
+  return buildJavaScriptExample(method, url, authMode, body);
 }
 
 function buildGoExample(
   method: HttpMethod,
   url: string,
-  includeApiKeyHeader: boolean,
+  authMode: DocsAuthMode,
   body: unknown | null,
 ): string {
   const bodyLiteral = body !== null ? JSON.stringify(body, null, 2).replace(/`/g, '\\`') : '';
@@ -238,7 +216,8 @@ function buildGoExample(
   lines.push('  log.Fatal(err)');
   lines.push('}');
   lines.push('req.Header.Set("Accept", "application/json")');
-  if (includeApiKeyHeader) lines.push('req.Header.Set("X-API-Key", "vq_your_key_here")');
+  const authHeader = authenticationHeader(authMode);
+  if (authHeader) lines.push(`req.Header.Set("${authHeader[0]}", "${authHeader[1]}")`);
   if (body !== null) lines.push('req.Header.Set("Content-Type", "application/json")');
   lines.push('resp, err := client.Do(req)');
   lines.push('if err != nil {');
@@ -253,7 +232,7 @@ function buildGoExample(
 function buildJavaExample(
   method: HttpMethod,
   url: string,
-  includeApiKeyHeader: boolean,
+  authMode: DocsAuthMode,
   body: unknown | null,
 ): string {
   const bodyLiteral = body !== null ? JSON.stringify(body, null, 2).replace(/"/g, '\\"') : '';
@@ -262,7 +241,8 @@ function buildJavaExample(
     `HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create("${url}"))`,
     '    .header("Accept", "application/json")',
   ];
-  if (includeApiKeyHeader) lines.push('    .header("X-API-Key", "vq_your_key_here")');
+  const authHeader = authenticationHeader(authMode);
+  if (authHeader) lines.push(`    .header("${authHeader[0]}", "${authHeader[1]}")`);
   if (body !== null) lines.push('    .header("Content-Type", "application/json")');
   if (body !== null) {
     lines.push(`    .method("${method.toUpperCase()}", HttpRequest.BodyPublishers.ofString("${bodyLiteral}"));`);
@@ -278,7 +258,7 @@ function buildJavaExample(
 function buildCSharpExample(
   method: HttpMethod,
   url: string,
-  includeApiKeyHeader: boolean,
+  authMode: DocsAuthMode,
   body: unknown | null,
 ): string {
   const bodyLiteral = body !== null ? JSON.stringify(body, null, 2).replace(/"/g, '\\"') : '';
@@ -287,7 +267,8 @@ function buildCSharpExample(
     'using var request = new HttpRequestMessage(new HttpMethod("' + method.toUpperCase() + '"), "' + url + '");',
     'request.Headers.Add("Accept", "application/json");',
   ];
-  if (includeApiKeyHeader) lines.push('request.Headers.Add("X-API-Key", "vq_your_key_here");');
+  const authHeader = authenticationHeader(authMode);
+  if (authHeader) lines.push(`request.Headers.Add("${authHeader[0]}", "${authHeader[1]}");`);
   if (body !== null) {
     lines.push('request.Content = new StringContent("' + bodyLiteral + '", Encoding.UTF8, "application/json");');
   }
@@ -301,11 +282,12 @@ function buildCSharpExample(
 function buildPhpExample(
   method: HttpMethod,
   url: string,
-  includeApiKeyHeader: boolean,
+  authMode: DocsAuthMode,
   body: unknown | null,
 ): string {
   const headerLines = ['"Accept: application/json"'];
-  if (includeApiKeyHeader) headerLines.push('"X-API-Key: vq_your_key_here"');
+  const authHeader = authenticationHeader(authMode);
+  if (authHeader) headerLines.push(`"${authHeader[0]}: ${authHeader[1]}"`);
   if (body !== null) headerLines.push('"Content-Type: application/json"');
   const bodyLiteral = body !== null ? JSON.stringify(body, null, 2).replace(/'/g, "\\'") : '';
   const lines: string[] = [
@@ -327,11 +309,12 @@ function buildPhpExample(
 function buildRubyExample(
   method: HttpMethod,
   url: string,
-  includeApiKeyHeader: boolean,
+  authMode: DocsAuthMode,
   body: unknown | null,
 ): string {
   const headers: Record<string, string> = { 'Accept' : 'application/json' };
-  if (includeApiKeyHeader) headers['X-API-Key'] = 'vq_your_key_here';
+  const authHeader = authenticationHeader(authMode);
+  if (authHeader) headers[authHeader[0]] = authHeader[1];
   if (body !== null) headers['Content-Type'] = 'application/json';
   const lines: string[] = [
     'uri = URI("' + url + '")',
@@ -369,94 +352,45 @@ function buildEndpointSnippets(
     .map((parameter) => `${parameter.name}=${encodeURIComponent(String(primitiveExample(parameter.schema)))}`);
 
   const queryString = queryPairs.length > 0 ? `?${queryPairs.join('&')}` : '';
-  const apiOrigin = new URL(API_URL, window.location.origin).origin;
-  const url = `${apiOrigin}${resolvedPath}${queryString}`;
-  const includeApiKeyHeader = !path.includes('/schema/');
+  const url = `${getApiOrigin()}${resolvedPath}${queryString}`;
+  const authMode = getDocsAuthMode(path);
   const bodySchema = operation.requestBody?.content?.['application/json']?.schema;
   const body = bodySchema ? generateJsonExample(bodySchema, components) : null;
 
   return {
-    curl: buildCurlExample(method, url, includeApiKeyHeader, body),
-    javascript: buildJavaScriptExample(method, url, includeApiKeyHeader, body),
-    typescript: buildTypescriptExample(method, url, includeApiKeyHeader, body),
-    python: buildPythonExample(method, url, includeApiKeyHeader, body),
-    go: buildGoExample(method, url, includeApiKeyHeader, body),
-    java: buildJavaExample(method, url, includeApiKeyHeader, body),
-    csharp: buildCSharpExample(method, url, includeApiKeyHeader, body),
-    php: buildPhpExample(method, url, includeApiKeyHeader, body),
-    ruby: buildRubyExample(method, url, includeApiKeyHeader, body),
+    curl: buildCurlExample(method, url, authMode, body),
+    javascript: buildJavaScriptExample(method, url, authMode, body),
+    typescript: buildTypescriptExample(method, url, authMode, body),
+    python: buildPythonExample(method, url, authMode, body),
+    go: buildGoExample(method, url, authMode, body),
+    java: buildJavaExample(method, url, authMode, body),
+    csharp: buildCSharpExample(method, url, authMode, body),
+    php: buildPhpExample(method, url, authMode, body),
+    ruby: buildRubyExample(method, url, authMode, body),
   };
 }
 
 interface ApiEndpointListProps {
-  section: DocsSection;
+  section: DocsSectionId;
 }
 
 export function ApiEndpointList({ section }: ApiEndpointListProps) {
   const { t } = useTranslation();
-  const [schema, setSchema] = useState<OpenApiSchema | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [activeSnippetTab, setActiveSnippetTab] = useState<SnippetTab>('curl');
-  const tabs = useTabAria({
-    defaultSelectedIndex: 0,
-    onTabChange: ({ selectedIndex }) => {
-      setActiveSnippetTab(snippetTabs[selectedIndex] ?? 'curl');
-    },
-  });
-
-  useEffect(() => {
-    const abortController = new AbortController();
-
-    const loadSchema = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await apiClient.getSchema<OpenApiSchema>(abortController.signal);
-        setSchema(data);
-      } catch (caughtError) {
-        if ((caughtError as Error).name === 'AbortError') return;
-        setError(caughtError instanceof Error ? caughtError.message : 'Failed to load schema');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadSchema();
-    return () => abortController.abort();
-  }, []);
+  const { schema, error, loading } = useOpenApiSchema();
+  const tabs = useTabAria({ defaultSelectedIndex: 0 });
 
   const endpoints = useMemo<EndpointItem[]>(() => {
-    if (!schema?.paths) return [];
+    const components = schema?.components?.schemas || {};
 
-    const components = schema.components?.schemas || {};
-    const items: EndpointItem[] = [];
-
-    Object.entries(schema.paths).forEach(([path, methods]) => {
-      if (!sectionMatchesPath(path, section)) return;
-
-      supportedMethods.forEach((method) => {
-        const operation = methods[method];
-        if (!operation) return;
-
-        const summary = operation.summary || `${method.toUpperCase()} ${path}`;
-        items.push({
-          method,
-          path,
-          summary,
-          description: operation.description,
-          snippets: buildEndpointSnippets(method, path, operation, components),
-        });
-      });
-    });
-
-    const sorted = items.sort((left, right) => {
-      const pathCompare = left.path.localeCompare(right.path);
-      if (pathCompare !== 0) return pathCompare;
-      return left.method.localeCompare(right.method);
-    });
-
-    return sorted;
+    return listOperations(schema)
+      .filter(({ path, operation }) => matchesDocsSection(section, path, operation))
+      .map(({ method, path, operation }) => ({
+        method,
+        path,
+        summary: operation.summary || `${method.toUpperCase()} ${path}`,
+        description: operation.description,
+        snippets: buildEndpointSnippets(method, path, operation, components),
+      }));
   }, [schema, section]);
 
   if (loading) {
@@ -511,7 +445,7 @@ export function ApiEndpointList({ section }: ApiEndpointListProps) {
                   <p className="text-std-16N-170 text-solid-gray-700">{endpoint.description}</p>
                 ) : null}
                 <pre className="overflow-x-auto border border-solid-gray-420 bg-solid-gray-800 p-4 text-dns-14N-130 text-white">
-                  <code>{endpoint.snippets[activeSnippetTab]}</code>
+                  <code>{endpoint.snippets[tab]}</code>
                 </pre>
               </div>
             </Disclosure>

--- a/frontend/src/components/docs/OpenAiSdkExampleList.tsx
+++ b/frontend/src/components/docs/OpenAiSdkExampleList.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getApiOrigin } from '@/lib/api';
 import { Disclosure, DisclosureSummary } from '@/components/ui/disclosure';
 import { Heading, HeadingTitle } from '@/components/ui/heading';
 import { Tab, TabItem, TabList, TabPanel, useTabAria } from '@/components/ui/tabs';
@@ -119,15 +119,9 @@ const tabLabels: Record<TabId, string> = {
 
 export function OpenAiSdkExampleList() {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState<TabId>('python');
-  const tabAria = useTabAria({
-    defaultSelectedIndex: 0,
-    onTabChange: ({ selectedIndex }) => {
-      setActiveTab(tabs[selectedIndex] ?? 'python');
-    },
-  });
+  const tabAria = useTabAria({ defaultSelectedIndex: 0 });
 
-  const baseUrl = `${window.location.origin}/api/v1/`;
+  const baseUrl = `${getApiOrigin()}/api/v1/`;
 
   const codeStrings: CodeStrings = {
     ragComment: t('docs.openai.code.ragComment'),
@@ -165,7 +159,7 @@ export function OpenAiSdkExampleList() {
                   {t(example.descriptionKey)}
                 </p>
                 <pre className="overflow-x-auto border border-solid-gray-420 bg-solid-gray-800 p-4 text-dns-14N-130 text-white">
-                  <code>{example.snippets[activeTab]}</code>
+                  <code>{example.snippets[tab]}</code>
                 </pre>
               </div>
             </Disclosure>

--- a/frontend/src/hooks/useOpenApiSchema.ts
+++ b/frontend/src/hooks/useOpenApiSchema.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api';
+import type { OpenApiSchema } from '@/lib/docs/openapi';
+
+/** Loads the live OpenAPI document that the docs pages are generated from. */
+export function useOpenApiSchema() {
+  const [schema, setSchema] = useState<OpenApiSchema | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    const loadSchema = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await apiClient.getSchema<OpenApiSchema>(abortController.signal);
+        setSchema(data);
+      } catch (caughtError) {
+        if ((caughtError as Error).name === 'AbortError') return;
+        setError(caughtError instanceof Error ? caughtError.message : 'Failed to load schema');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadSchema();
+    return () => abortController.abort();
+  }, []);
+
+  return { schema, error, loading };
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -614,52 +614,117 @@
     "home": {
       "title": "VideoQ Developer Docs",
       "subtitle": "Reference docs for integrating with VideoQ APIs and automations.",
-      "quickLinksTitle": "Quick links",
-      "quickLinksDescription": "Review the official API docs and issue an integration API key from Settings.",
+      "quickLinksTitle": "API sections",
+      "quickLinksDescription": "Integration endpoints from the live OpenAPI schema (/api/schema), grouped by feature. Health checks are listed under References and tools.",
+      "endpointCount_one": "{{count}} endpoint",
+      "endpointCount_other": "{{count}} endpoints",
+      "referencesTitle": "References and tools",
+      "referencesDescription": "Links to the schema itself, MCP, and the liveness endpoints.",
+      "references": {
+        "reference": "API reference (Scalar)",
+        "openapi": "OpenAPI document (JSON)",
+        "redoc": "API reference (ReDoc)",
+        "health": "Health checks",
+        "mcp": "MCP endpoint (Streamable HTTP)"
+      },
       "createApiKey": "Create API key in Settings"
     },
     "section": {
       "checklistTitle": "Implementation checklist",
       "checklistDescription": "Validate these points before coding your integration.",
-      "autoExampleTitle": "Auto-generated endpoint samples",
-      "autoExampleDescription": "These cURL examples are generated from /api/schema.",
+      "autoExampleTitle": "Endpoints",
+      "autoExampleDescription": "These request samples are generated from /api/schema. Switch languages with the tabs.",
       "autoLabel": "Auto-generated"
     },
     "sections": {
       "auth": {
-        "title": "Authentication",
-        "description": "How to issue and use integration API keys.",
+        "title": "Authentication and account",
+        "description": "How to issue API keys, and how to manage account and third-party keys.",
         "bullets": [
-          "Create a key in Settings and store it securely",
-          "Use X-API-Key header in server-to-server calls",
-          "Verify with GET /api/auth/me before full integration"
+          "Create an API key (it starts with vq_) in Settings and store it securely; key-management endpoints are provided by Better Auth and are not in the OpenAPI schema",
+          "For integration endpoints, send the key as X-API-Key; the OpenAI-compatible endpoint uses Authorization: Bearer vq_...",
+          "Verify API-key connectivity with GET /api/videos?limit=1",
+          "Writes (POST / PUT / PATCH / DELETE) need a key with the write scope",
+          "/api/account/* uses the signed-in browser session; Better Auth issues that session through /api/auth/*"
         ]
       },
       "videos": {
         "title": "Videos API",
-        "description": "Upload videos and manage video groups for retrieval.",
+        "description": "Upload videos, register YouTube URLs, and track processing status.",
         "bullets": [
-          "Create a group first and keep group_id for later calls",
-          "Upload videos with supported MIME types",
-          "Poll list/detail endpoints to track processing/indexing status"
+          "For large files, request a presigned URL with POST /api/videos/uploads and confirm with PATCH /api/videos/{id} after uploading",
+          "For small files, post multipart/form-data straight to POST /api/videos",
+          "Register YouTube videos by passing the URL to POST /api/videos/youtube",
+          "Track transcription and indexing through status on GET /api/videos/{id} (processing → indexing → completed)",
+          "GET /api/videos accepts q / status / ordering / tags plus limit / offset"
+        ]
+      },
+      "groups": {
+        "title": "Groups / Membership API",
+        "description": "Create video groups, manage their members, and issue share links.",
+        "bullets": [
+          "Create a group with POST /api/videos/groups and reuse the returned id as group_id in the Chat API",
+          "Add videos in bulk with POST /api/videos/groups/{groupId}/videos",
+          "Reorder them with PATCH /api/videos/groups/{groupId}/videos/order",
+          "POST /api/videos/groups/{id}/share issues a share link, after which GET /api/videos/groups/share/{slug} is readable without authentication"
+        ]
+      },
+      "tags": {
+        "title": "Tags API",
+        "description": "Create tags and attach them to videos.",
+        "bullets": [
+          "Create tags with POST /api/videos/tags",
+          "Attach with POST /api/videos/{videoId}/tags and detach with DELETE /api/videos/{videoId}/tags/{tagId}",
+          "Filter the video list with the tags parameter on GET /api/videos"
         ]
       },
       "chat": {
         "title": "Chat API",
-        "description": "Run RAG chat and collect analytics for each group.",
+        "description": "Run RAG chat and pull history and analytics.",
         "bullets": [
-          "Send messages with group_id to target indexed videos",
-          "Use Accept-Language when you need response language control",
-          "Store chat_log_id and analytics outputs for downstream systems"
+          "POST /api/chat/messages with messages and group_id (set mode to study for study mode)",
+          "Use POST /api/chat/messages/stream (SSE) when you want token-by-token output",
+          "Control the response language with the Accept-Language header",
+          "GET /api/chat/groups/{groupId}/history returns history (?download=csv for CSV) and GET /api/chat/groups/{groupId}/analytics returns volume and feedback totals",
+          "Record ratings by sending good / bad / null to PATCH /api/chat/logs/{logId}/feedback"
         ]
       },
       "openai": {
         "title": "OpenAI-Compatible API",
         "description": "Access VideoQ RAG chat using the OpenAI SDK with no code changes.",
         "bullets": [
-          "Authenticate with Authorization: Bearer <vq_...>",
-          "Pass language to control response language (defaults to English if omitted)",
+          "Set base_url to /api/v1 and api_key to vq_... (sent as Authorization: Bearer)",
+          "Use model videoq and select the target group with group_id (extra_body in the Python SDK)",
+          "Pass language to control the response language (falls back to Accept-Language, then English)",
           "citations and chat_log_id are returned as extension fields on choices[0].message (access via msg.model_extra in Python SDK)"
+        ]
+      },
+      "plog": {
+        "title": "Plog API",
+        "description": "Read and edit the concept graph (Plog) generated from a video.",
+        "bullets": [
+          "GET /api/videos/{videoId}/plog returns concepts and edges",
+          "POST /api/videos/{videoId}/plog/rebuild enqueues a rebuild (processed asynchronously)",
+          "Concepts and edges can be created, updated, and deleted, and merged with POST /api/videos/{videoId}/plog/concepts/{conceptId}/merge",
+          "Read or reset learner state with GET / DELETE /api/videos/{videoId}/plog/learner-state"
+        ]
+      },
+      "evaluation": {
+        "title": "Evaluation API",
+        "description": "Per-group answer evaluation logs and summaries.",
+        "bullets": [
+          "GET /api/evaluation/groups/{groupId}/summary returns aggregated evaluation results",
+          "GET /api/evaluation/groups/{groupId}/logs returns individual evaluation logs"
+        ]
+      },
+      "admin": {
+        "title": "Admin API",
+        "description": "Superuser-only user management and reindexing.",
+        "bullets": [
+          "Requires a session or API key authenticated as a superuser",
+          "List users with GET /api/admin/users, then update permissions, quota, and usage with PATCH /api/admin/users/{id}/flags, /quota, and /usage",
+          "DELETE /api/admin/users/{id} deactivates the user and hands the data deletion to the worker",
+          "POST /api/admin/embeddings/reindex-all enqueues an embedding rebuild for every video"
         ]
       }
     }

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -614,52 +614,117 @@
     "home": {
       "title": "VideoQ Developer Docs",
       "subtitle": "VideoQ API 連携と自動化のための開発者向けリファレンス。",
-      "quickLinksTitle": "クイックリンク",
-      "quickLinksDescription": "公式 API ドキュメントを確認したり、設定画面で連携用 API キーを発行したりできます。",
+      "quickLinksTitle": "API セクション",
+      "quickLinksDescription": "OpenAPI スキーマ（/api/schema）から連携用エンドポイントを機能ごとに分類しています。ヘルスチェックは「リファレンスとツール」から確認できます。",
+      "endpointCount_one": "{{count}} エンドポイント",
+      "endpointCount_other": "{{count}} エンドポイント",
+      "referencesTitle": "リファレンスとツール",
+      "referencesDescription": "スキーマ本体、MCP、稼働確認用エンドポイントへのリンクです。",
+      "references": {
+        "reference": "API リファレンス（Scalar）",
+        "openapi": "OpenAPI ドキュメント（JSON）",
+        "redoc": "API リファレンス（ReDoc）",
+        "health": "ヘルスチェック",
+        "mcp": "MCP エンドポイント（Streamable HTTP）"
+      },
       "createApiKey": "設定で API キーを発行"
     },
     "section": {
       "checklistTitle": "実装チェックリスト",
       "checklistDescription": "連携実装前に確認しておくべき項目です。",
-      "autoExampleTitle": "自動生成エンドポイント例",
-      "autoExampleDescription": "以下の cURL は /api/schema から自動生成しています。",
+      "autoExampleTitle": "エンドポイント一覧",
+      "autoExampleDescription": "以下のリクエスト例は /api/schema から自動生成しています。タブで言語を切り替えられます。",
       "autoLabel": "自動生成"
     },
     "sections": {
       "auth": {
-        "title": "認証",
-        "description": "連携用 API キーの発行と利用方法。",
+        "title": "認証とアカウント",
+        "description": "API キーの発行方法と、アカウント情報・外部サービスキーの管理。",
         "bullets": [
-          "設定画面でキーを作成し、安全に保管する",
-          "サーバー間通信は X-API-Key ヘッダーを利用する",
-          "本実装前に GET /api/auth/me で認証確認する"
+          "設定画面で API キー（vq_ で始まる文字列）を発行し、安全に保管する。キー管理 API は Better Auth が提供するため OpenAPI スキーマ対象外",
+          "連携用エンドポイントでは X-API-Key を使い、OpenAI 互換エンドポイントでは Authorization: Bearer vq_... を使う",
+          "API キーの疎通確認は GET /api/videos?limit=1 で行う",
+          "更新系（POST / PUT / PATCH / DELETE）には write スコープを持つキーが必要",
+          "/api/account/* はログイン中のブラウザセッションで認証し、セッション自体は Better Auth の /api/auth/* が発行する"
         ]
       },
       "videos": {
         "title": "Videos API",
-        "description": "動画アップロードとグループ管理の連携手順。",
+        "description": "動画のアップロードと YouTube 登録、処理状況の確認。",
         "bullets": [
-          "最初にグループを作成し group_id を保持する",
-          "対応 MIME type で動画をアップロードする",
-          "一覧/詳細 API で処理状態を監視する"
+          "大きいファイルは POST /api/videos/uploads で署名付き URL を取得し、アップロード後に PATCH /api/videos/{id} で確定する",
+          "小さいファイルは POST /api/videos に multipart/form-data で直接送れる",
+          "YouTube 動画は POST /api/videos/youtube に URL を渡して登録する",
+          "GET /api/videos/{id} の status（processing → indexing → completed）で文字起こしとインデックスの進捗を確認する",
+          "GET /api/videos は q / status / ordering / tags と limit / offset で絞り込める"
+        ]
+      },
+      "groups": {
+        "title": "Groups / Membership API",
+        "description": "動画グループの作成、所属動画の管理、共有リンクの発行。",
+        "bullets": [
+          "POST /api/videos/groups でグループを作成し、返却された id を Chat API の group_id に使う",
+          "POST /api/videos/groups/{groupId}/videos で動画をまとめて追加する",
+          "PATCH /api/videos/groups/{groupId}/videos/order で並び順を更新する",
+          "POST /api/videos/groups/{id}/share で共有リンクを発行すると、GET /api/videos/groups/share/{slug} が認証なしで参照できる"
+        ]
+      },
+      "tags": {
+        "title": "Tags API",
+        "description": "タグの作成と、動画へのタグ付け。",
+        "bullets": [
+          "POST /api/videos/tags でタグを作成する",
+          "POST /api/videos/{videoId}/tags で動画にタグを付け、DELETE /api/videos/{videoId}/tags/{tagId} で外す",
+          "作成したタグは GET /api/videos の tags パラメータで絞り込みに使える"
         ]
       },
       "chat": {
         "title": "Chat API",
-        "description": "RAG チャット実行と分析データ取得。",
+        "description": "RAG チャットの実行と、履歴・分析データの取得。",
         "bullets": [
-          "group_id を指定して対象動画群に質問する",
-          "回答言語を固定したい場合は Accept-Language を指定する",
-          "chat_log_id と分析結果を外部システムに保存する"
+          "POST /api/chat/messages に messages と group_id を渡して質問する（mode に study を指定すると学習モード）",
+          "逐次表示したい場合は POST /api/chat/messages/stream（SSE）を使う",
+          "回答言語は Accept-Language ヘッダーで切り替える",
+          "GET /api/chat/groups/{groupId}/history で履歴（?download=csv で CSV）、GET /api/chat/groups/{groupId}/analytics で件数と評価の集計を取得する",
+          "PATCH /api/chat/logs/{logId}/feedback に good / bad / null を送って評価を記録する"
         ]
       },
       "openai": {
         "title": "OpenAI 互換 API",
         "description": "OpenAI SDK をそのまま使って VideoQ の RAG チャットにアクセス。",
         "bullets": [
-          "Authorization: Bearer <vq_...> で認証する",
-          "language フィールドで応答言語を指定する（省略すると英語）",
+          "base_url に /api/v1、api_key に vq_... を設定する（Authorization: Bearer で送信される）",
+          "model は videoq、対象グループは group_id で指定する（Python SDK では extra_body）",
+          "language フィールドで応答言語を指定する（省略時は Accept-Language、それも無ければ英語）",
           "citations と chat_log_id は choices[0].message の拡張フィールドとして返される（Python SDK では msg.model_extra で取得）"
+        ]
+      },
+      "plog": {
+        "title": "Plog API",
+        "description": "動画から生成した概念グラフ（Plog）の取得と編集。",
+        "bullets": [
+          "GET /api/videos/{videoId}/plog で概念（concepts）と関連（edges）を取得する",
+          "POST /api/videos/{videoId}/plog/rebuild で再生成をキューに積む（処理は非同期）",
+          "概念と関連は作成・更新・削除でき、POST /api/videos/{videoId}/plog/concepts/{conceptId}/merge で統合できる",
+          "学習状態は GET / DELETE /api/videos/{videoId}/plog/learner-state で取得・リセットする"
+        ]
+      },
+      "evaluation": {
+        "title": "Evaluation API",
+        "description": "グループ単位の回答評価ログとサマリー。",
+        "bullets": [
+          "GET /api/evaluation/groups/{groupId}/summary で評価の集計を取得する",
+          "GET /api/evaluation/groups/{groupId}/logs で個別の評価ログを取得する"
+        ]
+      },
+      "admin": {
+        "title": "Admin API",
+        "description": "スーパーユーザー限定のユーザー管理と再インデックス。",
+        "bullets": [
+          "スーパーユーザーとして認証したセッションまたは API キーが必要",
+          "GET /api/admin/users で一覧し、PATCH /api/admin/users/{id}/flags・/quota・/usage で権限・上限・使用量を更新する",
+          "DELETE /api/admin/users/{id} は該当ユーザーを無効化し、関連データの削除をワーカーに委譲する",
+          "POST /api/admin/embeddings/reindex-all は全動画の埋め込み再生成をキューに積む"
         ]
       }
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -23,6 +23,14 @@ export interface PaginatedResponse<T> {
   };
 }
 
+/**
+ * Origin the API is served from. `VITE_API_URL` is a same-origin path (`/api`)
+ * in Docker and production, but an absolute URL in local development.
+ */
+export function getApiOrigin(): string {
+  return new URL(API_URL, window.location.origin).origin;
+}
+
 /** Strip trailing slashes from API paths (except root). Preserves query strings. */
 export function apiPath(path: string): string {
   if (!path || path === '/') return path;

--- a/frontend/src/lib/docs/openapi.ts
+++ b/frontend/src/lib/docs/openapi.ts
@@ -1,0 +1,75 @@
+export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+export const supportedMethods: HttpMethod[] = ['get', 'post', 'put', 'patch', 'delete'];
+
+export type OpenApiSchemaObject = {
+  type?: string;
+  format?: string;
+  enum?: string[];
+  properties?: Record<string, OpenApiSchemaObject>;
+  required?: string[];
+  items?: OpenApiSchemaObject;
+  oneOf?: OpenApiSchemaObject[];
+  anyOf?: OpenApiSchemaObject[];
+  allOf?: OpenApiSchemaObject[];
+  additionalProperties?: OpenApiSchemaObject | boolean;
+  $ref?: string;
+};
+
+export type OpenApiParameter = {
+  in?: 'path' | 'query' | 'header' | 'cookie';
+  name?: string;
+  required?: boolean;
+  schema?: OpenApiSchemaObject;
+};
+
+export type OpenApiOperation = {
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: OpenApiParameter[];
+  requestBody?: {
+    content?: {
+      'application/json'?: {
+        schema?: OpenApiSchemaObject;
+      };
+      'multipart/form-data'?: {
+        schema?: OpenApiSchemaObject;
+      };
+    };
+  };
+};
+
+export type OpenApiSchema = {
+  paths?: Record<string, Record<string, OpenApiOperation>>;
+  components?: {
+    schemas?: Record<string, OpenApiSchemaObject>;
+  };
+};
+
+export type OpenApiOperationEntry = {
+  method: HttpMethod;
+  path: string;
+  operation: OpenApiOperation;
+};
+
+/** Flattens `paths` into one entry per method, sorted by path then method. */
+export function listOperations(schema: OpenApiSchema | null): OpenApiOperationEntry[] {
+  if (!schema?.paths) return [];
+
+  const entries: OpenApiOperationEntry[] = [];
+
+  Object.entries(schema.paths).forEach(([path, methods]) => {
+    supportedMethods.forEach((method) => {
+      const operation = methods[method];
+      if (!operation) return;
+      entries.push({ method, path, operation });
+    });
+  });
+
+  return entries.sort((left, right) => {
+    const pathCompare = left.path.localeCompare(right.path);
+    if (pathCompare !== 0) return pathCompare;
+    return left.method.localeCompare(right.method);
+  });
+}

--- a/frontend/src/lib/docs/sections.ts
+++ b/frontend/src/lib/docs/sections.ts
@@ -1,0 +1,87 @@
+import { listOperations, type OpenApiOperation, type OpenApiSchema } from '@/lib/docs/openapi';
+
+export const docsSectionIds = [
+  'auth',
+  'videos',
+  'groups',
+  'tags',
+  'chat',
+  'openai',
+  'plog',
+  'evaluation',
+  'admin',
+] as const;
+
+export type DocsSectionId = (typeof docsSectionIds)[number];
+
+export function isDocsSectionId(value: string): value is DocsSectionId {
+  return (docsSectionIds as readonly string[]).includes(value);
+}
+
+type SectionFilter = {
+  /** OpenAPI tags declared by apps/api features. */
+  tags?: string[];
+  /** Used where the API does not tag the operations (account) or tags overlap (OpenAI). */
+  pathPrefixes?: string[];
+  excludePathPrefixes?: string[];
+};
+
+// Every integration operation in the schema belongs to exactly one section.
+// /health and /ready are deliberately linked from the reference list instead.
+// Membership operations are split by path because their shared OpenAPI tag
+// covers both group-video and video-tag relationships.
+const sectionFilters: Record<DocsSectionId, SectionFilter> = {
+  auth: { pathPrefixes: ['/api/account'] },
+  videos: { tags: ['Videos'] },
+  groups: { tags: ['Groups'], pathPrefixes: ['/api/videos/groups/'] },
+  tags: { tags: ['Tags'], pathPrefixes: ['/api/videos/{videoId}/tags'] },
+  chat: { tags: ['Chat'], excludePathPrefixes: ['/api/v1/'] },
+  openai: { pathPrefixes: ['/api/v1/'] },
+  plog: { tags: ['Plog'] },
+  evaluation: { tags: ['Evaluation'] },
+  admin: { tags: ['Admin'] },
+};
+
+/** Endpoints that authenticate through neither an API key nor a session. */
+const publicPathPrefixes = ['/health', '/ready', '/api/videos/groups/share/'];
+
+export type DocsAuthMode = 'public' | 'session' | 'apiKey' | 'bearerApiKey';
+
+/** Authentication style to show in generated request examples. */
+export function getDocsAuthMode(path: string): DocsAuthMode {
+  if (publicPathPrefixes.some((prefix) => path.startsWith(prefix))) return 'public';
+  if (path.startsWith('/api/account/')) return 'session';
+  if (path.startsWith('/api/v1/')) return 'bearerApiKey';
+  return 'apiKey';
+}
+
+export function matchesDocsSection(
+  section: DocsSectionId,
+  path: string,
+  operation: OpenApiOperation,
+): boolean {
+  const filter = sectionFilters[section];
+
+  if (filter.excludePathPrefixes?.some((prefix) => path.startsWith(prefix))) {
+    return false;
+  }
+  if (filter.pathPrefixes?.some((prefix) => path.startsWith(prefix))) {
+    return true;
+  }
+  return Boolean(filter.tags?.some((tag) => operation.tags?.includes(tag)));
+}
+
+export function countEndpointsBySection(
+  schema: OpenApiSchema | null,
+): Record<DocsSectionId, number> {
+  const counts = Object.fromEntries(
+    docsSectionIds.map((id) => [id, 0]),
+  ) as Record<DocsSectionId, number>;
+
+  listOperations(schema).forEach(({ path, operation }) => {
+    const section = docsSectionIds.find((id) => matchesDocsSection(id, path, operation));
+    if (section) counts[section] += 1;
+  });
+
+  return counts;
+}

--- a/frontend/src/pages/DeveloperDocsPage.tsx
+++ b/frontend/src/pages/DeveloperDocsPage.tsx
@@ -1,5 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from '@/lib/i18n';
+import { getApiOrigin } from '@/lib/api';
+import { useOpenApiSchema } from '@/hooks/useOpenApiSchema';
+import { countEndpointsBySection, docsSectionIds } from '@/lib/docs/sections';
 import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
 import { Heading, HeadingTitle } from '@/components/ui/heading';
@@ -11,17 +14,46 @@ import {
 import { UtilityLink } from '@/components/ui/utility-link';
 import { cn } from '@/lib/digital-agency/cn';
 
-const sectionIds = ['auth', 'videos', 'chat', 'openai'] as const;
-
 export default function DeveloperDocsPage() {
   const { t } = useTranslation();
+  const { schema } = useOpenApiSchema();
+  const endpointCounts = countEndpointsBySection(schema);
+  const apiOrigin = getApiOrigin();
 
-  const sections = sectionIds.map((id) => ({
+  const sections = docsSectionIds.map((id) => ({
     id,
     href: `/docs/${id}`,
     title: t(`docs.sections.${id}.title`),
     description: t(`docs.sections.${id}.description`),
+    endpointCount: endpointCounts[id],
   }));
+
+  const references = [
+    {
+      key: 'reference',
+      href: `${apiOrigin}/api/docs`,
+      label: t('docs.home.references.reference'),
+      hint: '/api/docs',
+    },
+    {
+      key: 'openapi',
+      href: `${apiOrigin}/api/openapi.json`,
+      label: t('docs.home.references.openapi'),
+      hint: '/api/openapi.json · /api/schema',
+    },
+    {
+      key: 'redoc',
+      href: `${apiOrigin}/api/redoc`,
+      label: t('docs.home.references.redoc'),
+      hint: '/api/redoc',
+    },
+    {
+      key: 'health',
+      href: `${apiOrigin}/health`,
+      label: t('docs.home.references.health'),
+      hint: '/health · /ready',
+    },
+  ];
 
   return (
     <AppPageShell activePage="docs">
@@ -39,7 +71,7 @@ export default function DeveloperDocsPage() {
           {t('docs.home.quickLinksDescription')}
         </p>
         <MenuList className="border-t border-solid-gray-420">
-          {sections.map(({ id, href, title, description }) => (
+          {sections.map(({ id, href, title, description, endpointCount }) => (
             <MenuListItem key={id} className="border-b border-solid-gray-200">
               <Link
                 href={href}
@@ -47,7 +79,14 @@ export default function DeveloperDocsPage() {
                 data-type="box"
                 data-size="regular"
               >
-                <span className="text-std-16B-170 text-solid-gray-800">{title}</span>
+                <span className="flex w-full flex-wrap items-baseline gap-x-3 gap-y-1">
+                  <span className="text-std-16B-170 text-solid-gray-800">{title}</span>
+                  {endpointCount > 0 && (
+                    <span className="font-mono text-dns-14N-130 font-normal text-solid-gray-600">
+                      {t('docs.home.endpointCount', { count: endpointCount })}
+                    </span>
+                  )}
+                </span>
                 <span className="text-std-16N-170 font-normal text-solid-gray-700">
                   {description}
                 </span>
@@ -59,18 +98,27 @@ export default function DeveloperDocsPage() {
 
       <section className="mb-8">
         <Heading size="18" hasChip className="mb-4">
-          <HeadingTitle level="h2">API</HeadingTitle>
+          <HeadingTitle level="h2">{t('docs.home.referencesTitle')}</HeadingTitle>
         </Heading>
+        <p className="mb-4 text-std-16N-170 text-solid-gray-700">
+          {t('docs.home.referencesDescription')}
+        </p>
         <ul className="space-y-3 border-t border-solid-gray-420 pt-4">
-          <li>
-            <UtilityLink href="/api/docs" target="_blank" rel="noreferrer">
-              OpenAPI (Swagger UI)
-            </UtilityLink>
-          </li>
-          <li>
-            <UtilityLink href="/api/redoc" target="_blank" rel="noreferrer">
-              ReDoc
-            </UtilityLink>
+          {references.map(({ key, href, label, hint }) => (
+            <li key={key} className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <UtilityLink href={href} target="_blank" rel="noreferrer">
+                {label}
+              </UtilityLink>
+              <span className="font-mono text-dns-14N-130 text-solid-gray-600">{hint}</span>
+            </li>
+          ))}
+          <li className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+            <span className="text-std-16N-170 text-solid-gray-800">
+              {t('docs.home.references.mcp')}
+            </span>
+            <span className="font-mono text-dns-14N-130 text-solid-gray-600">
+              {`${apiOrigin}/api/mcp`}
+            </span>
           </li>
           <li>
             <UtilityLink asChild>

--- a/frontend/src/pages/DeveloperDocsSectionPage.tsx
+++ b/frontend/src/pages/DeveloperDocsSectionPage.tsx
@@ -5,6 +5,7 @@ import { AppPageShell } from '@/components/layout/AppPageShell';
 import { AppPageHeader } from '@/components/layout/AppPageHeader';
 import { ApiEndpointList } from '@/components/docs/ApiEndpointList';
 import { OpenAiSdkExampleList } from '@/components/docs/OpenAiSdkExampleList';
+import { isDocsSectionId } from '@/lib/docs/sections';
 import {
   BreadcrumbItem,
   BreadcrumbLink,
@@ -14,18 +15,11 @@ import {
 } from '@/components/ui/breadcrumbs';
 import { Heading, HeadingTitle } from '@/components/ui/heading';
 
-const sectionIds = ['auth', 'videos', 'chat', 'openai'] as const;
-type SectionId = (typeof sectionIds)[number];
-
-function isSectionId(value: string): value is SectionId {
-  return sectionIds.includes(value as SectionId);
-}
-
 export default function DeveloperDocsSectionPage() {
   const { t } = useTranslation();
   const { section } = useParams<{ section: string }>();
 
-  if (!section || !isSectionId(section)) {
+  if (!section || !isDocsSectionId(section)) {
     return <Navigate to="/docs" replace />;
   }
 
@@ -71,20 +65,26 @@ export default function DeveloperDocsSectionPage() {
         </ul>
       </section>
 
+      {isOpenAi && (
+        <section className="mb-12">
+          <Heading size="18" hasChip className="mb-4">
+            <HeadingTitle level="h2">{t('docs.openai.exampleTitle')}</HeadingTitle>
+          </Heading>
+          <p className="mb-6 text-std-16N-170 text-solid-gray-700">
+            {t('docs.openai.exampleDescription')}
+          </p>
+          <OpenAiSdkExampleList />
+        </section>
+      )}
+
       <section className="mb-8">
         <Heading size="18" hasChip className="mb-4">
-          <HeadingTitle level="h2">
-            {t(isOpenAi ? 'docs.openai.exampleTitle' : 'docs.section.autoExampleTitle')}
-          </HeadingTitle>
+          <HeadingTitle level="h2">{t('docs.section.autoExampleTitle')}</HeadingTitle>
         </Heading>
         <p className="mb-6 text-std-16N-170 text-solid-gray-700">
-          {t(
-            isOpenAi
-              ? 'docs.openai.exampleDescription'
-              : 'docs.section.autoExampleDescription',
-          )}
+          {t('docs.section.autoExampleDescription')}
         </p>
-        {isOpenAi ? <OpenAiSdkExampleList /> : <ApiEndpointList section={section} />}
+        <ApiEndpointList section={section} />
       </section>
     </AppPageShell>
   );

--- a/frontend/src/pages/__tests__/DeveloperDocsPage.test.tsx
+++ b/frontend/src/pages/__tests__/DeveloperDocsPage.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import DeveloperDocsPage from '../DeveloperDocsPage'
+import { docsSectionIds } from '@/lib/docs/sections'
+
+const schema = {
+  paths: {
+    '/api/account/me': { get: { summary: 'Current user profile (app fields)' } },
+    '/api/videos': {
+      get: { summary: 'List videos', tags: ['Videos'] },
+      post: { summary: 'Upload a video', tags: ['Videos'] },
+    },
+    '/api/videos/groups': { get: { summary: 'List groups', tags: ['Groups'] } },
+    '/api/chat/messages': { post: { summary: 'Send chat message', tags: ['Chat'] } },
+    '/api/v1/chat/completions': {
+      post: { summary: 'OpenAI-compatible chat completions', tags: ['Chat'] },
+    },
+    '/health': { get: { summary: 'Liveness probe', tags: ['Health'] } },
+  },
+}
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    apiClient: { getSchema: vi.fn(() => Promise.resolve(schema)) },
+  }
+})
+
+describe('DeveloperDocsPage', () => {
+  it('links to every docs section', async () => {
+    render(<DeveloperDocsPage />)
+
+    for (const id of docsSectionIds) {
+      const link = await screen.findByRole('link', { name: new RegExp(`docs\\.sections\\.${id}\\.title`) })
+      expect(link).toHaveAttribute('href', `/docs/${id}`)
+    }
+  })
+
+  it('shows the endpoint count each section resolves to in the live schema', async () => {
+    render(<DeveloperDocsPage />)
+
+    // /api/videos GET + POST land in videos; the OpenAI path is not counted as chat.
+    await waitFor(() => {
+      expect(screen.getByText('docs.home.endpointCount {"count":2}')).toBeInTheDocument()
+    })
+    expect(screen.getAllByText('docs.home.endpointCount {"count":1}')).toHaveLength(4)
+  })
+
+  it('points at the endpoints the API actually serves', async () => {
+    render(<DeveloperDocsPage />)
+
+    const reference = await screen.findByRole('link', { name: /docs\.home\.references\.reference/ })
+    expect(reference.getAttribute('href')).toMatch(/\/api\/docs$/)
+
+    const openapi = screen.getByRole('link', { name: /docs\.home\.references\.openapi/ })
+    expect(openapi.getAttribute('href')).toMatch(/\/api\/openapi\.json$/)
+
+    const redoc = screen.getByRole('link', { name: /docs\.home\.references\.redoc/ })
+    expect(redoc.getAttribute('href')).toMatch(/\/api\/redoc$/)
+  })
+})

--- a/frontend/src/pages/__tests__/DeveloperDocsSectionPage.test.tsx
+++ b/frontend/src/pages/__tests__/DeveloperDocsSectionPage.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import DeveloperDocsSectionPage from '../DeveloperDocsSectionPage'
+
+const schema = {
+  paths: {
+    '/api/account/me': { get: { summary: 'Current user profile (app fields)' } },
+    '/api/videos': {
+      get: { summary: 'List videos', tags: ['Videos'] },
+    },
+    '/api/videos/groups': { get: { summary: 'List groups', tags: ['Groups'] } },
+    '/api/videos/groups/{groupId}/videos': {
+      post: { summary: 'Add videos to a group', tags: ['Membership'] },
+    },
+    '/api/videos/{videoId}/tags': {
+      post: { summary: 'Attach tags to a video', tags: ['Membership'] },
+    },
+    '/api/chat/messages': { post: { summary: 'Send chat message', tags: ['Chat'] } },
+    '/api/v1/chat/completions': {
+      post: { summary: 'OpenAI-compatible chat completions', tags: ['Chat'] },
+    },
+  },
+}
+
+const params = { section: 'videos' }
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => params,
+    Navigate: ({ to }: { to: string }) => React.createElement('div', {}, `navigate:${to}`),
+  }
+})
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    apiClient: { getSchema: vi.fn(() => Promise.resolve(schema)) },
+  }
+})
+
+describe('DeveloperDocsSectionPage', () => {
+  it('lists the endpoints tagged for the section, including collection paths', async () => {
+    params.section = 'videos'
+    render(<DeveloperDocsSectionPage />)
+
+    expect(await screen.findAllByText('/api/videos')).not.toHaveLength(0)
+    expect(screen.queryByText('/api/videos/groups')).not.toBeInTheDocument()
+  })
+
+  it('keeps the OpenAI-compatible endpoint out of the chat section', async () => {
+    params.section = 'chat'
+    render(<DeveloperDocsSectionPage />)
+
+    expect(await screen.findAllByText('/api/chat/messages')).not.toHaveLength(0)
+    expect(screen.queryByText('/api/v1/chat/completions')).not.toBeInTheDocument()
+  })
+
+  it('splits membership endpoints between the groups and tags sections', async () => {
+    params.section = 'groups'
+    const { unmount } = render(<DeveloperDocsSectionPage />)
+
+    expect(await screen.findAllByText('/api/videos/groups/{groupId}/videos')).not.toHaveLength(0)
+    expect(screen.queryByText('/api/videos/{videoId}/tags')).not.toBeInTheDocument()
+
+    unmount()
+    params.section = 'tags'
+    render(<DeveloperDocsSectionPage />)
+
+    expect(await screen.findAllByText('/api/videos/{videoId}/tags')).not.toHaveLength(0)
+    expect(screen.queryByText('/api/videos/groups/{groupId}/videos')).not.toBeInTheDocument()
+  })
+
+  it('shows SDK examples and the raw endpoint for the OpenAI section', async () => {
+    params.section = 'openai'
+    const { container } = render(<DeveloperDocsSectionPage />)
+
+    expect(await screen.findAllByText('/api/v1/chat/completions')).not.toHaveLength(0)
+    expect(screen.getByText('docs.openai.exampleTitle')).toBeInTheDocument()
+    expect(container.textContent).toContain('Authorization: Bearer vq_your_key_here')
+    expect(container.textContent).not.toContain('X-API-Key: vq_your_key_here')
+  })
+
+  it('uses the browser session for account endpoint examples', async () => {
+    params.section = 'auth'
+    const { container } = render(<DeveloperDocsSectionPage />)
+
+    expect(await screen.findAllByText('/api/account/me')).not.toHaveLength(0)
+    expect(container.textContent).toContain('Cookie: <session-cookie-name>=<session-cookie-value>')
+    expect(container.textContent).toContain('credentials: "include"')
+    expect(container.textContent).not.toContain('X-API-Key: vq_your_key_here')
+  })
+
+  it('redirects unknown sections back to the docs index', () => {
+    params.section = 'nope'
+    render(<DeveloperDocsSectionPage />)
+
+    expect(screen.getByText('navigate:/docs')).toBeInTheDocument()
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import path from 'path'
 
+const apiProxyTarget = process.env.VITE_API_PROXY_TARGET || 'http://127.0.0.1:8787'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
@@ -17,7 +19,16 @@ export default defineConfig({
     proxy: {
       // Local Hono (wrangler). Client should use VITE_API_URL=/api so cookies stay same-origin.
       '/api': {
-        target: process.env.VITE_API_PROXY_TARGET || 'http://127.0.0.1:8787',
+        target: apiProxyTarget,
+        changeOrigin: true,
+      },
+      // Health endpoints live at the API origin root rather than below /api.
+      '/health': {
+        target: apiProxyTarget,
+        changeOrigin: true,
+      },
+      '/ready': {
+        target: apiProxyTarget,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- generate the developer docs index and endpoint lists from the live OpenAPI schema
- add Groups, Tags, Plog, Evaluation, and Admin sections with current endpoint guidance and counts
- align authentication examples and reference links with the current Scalar, ReDoc, OpenAPI, MCP, and health endpoints
- keep `llms.txt`, Japanese/English translations, local health proxies, and regression tests in sync

## Testing

- `npm test` — 66 files / 630 tests passed
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Dependency

- stacked on #836; this PR targets `chore/sync-digital-agency-ui-v0.7.0` so the diff contains only the developer docs update