### PR TITLE
fix: 動画アップロードの署名付き URL PUT を CSP で許可する

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -7,14 +7,16 @@
 #   fonts.gstatic.com     : 上記が参照するフォント本体
 #   www.youtube.com       : YouTube 埋め込み iframe（API が embed URL を生成）
 #   img.youtube.com       : YouTube サムネイル（VideoCard）
-#   *.r2.cloudflarestorage.com : R2 バインディング失敗時に /api/media が
-#                                署名付き URL へ 302 する際の最終取得先
-# API は本番では同一オリジン（videoq.jp/api）なので connect-src は 'self'。
+#   *.r2.cloudflarestorage.com : 署名付き URL の相手先。動画アップロードの
+#                                PUT（connect-src）と、/api/media が署名付き
+#                                URL へ 302 したあとの再生取得（media-src）。
+# API は本番では同一オリジン（videoq.jp/api）なので connect-src は 'self' と
+# 上記 R2 のみ。
 #
 # style-src の 'unsafe-inline' は Radix / Tailwind が実行時に差し込む
 # インラインスタイルに必要。外すとダイアログとポップオーバーが壊れる。
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://img.youtube.com; media-src 'self' blob: https://*.r2.cloudflarestorage.com; frame-src https://www.youtube.com; connect-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://img.youtube.com; media-src 'self' blob: https://*.r2.cloudflarestorage.com; frame-src https://www.youtube.com; connect-src 'self' https://*.r2.cloudflarestorage.com
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
## 概要

本番で動画をアップロードすると、ブラウザが CSP でリクエストをブロックし `Upload failed` で失敗する。`connect-src` に R2 の S3 互換エンドポイントを追加して直す。

```
Connecting to 'https://<account-id>.r2.cloudflarestorage.com/videoq-media-prod/media/videos/...'
violates the following Content Security Policy directive: "connect-src 'self'".
```

## 原因

999fe9e でリソース系 CSP を追加した際、`*.r2.cloudflarestorage.com` を「`/api/media` が署名付き URL へ 302 したあとの再生取得先」としてのみ捉え、`media-src` にだけ入れていた。

実際にはアップロードも R2 を直接叩く。`frontend/src/lib/api.ts` の `uploadToPresignedUrl` が署名付き URL へ XHR で PUT するため、これは `media-src` ではなく `connect-src` の管轄になる。`connect-src 'self'` のままだったので PUT がブロックされ、`xhr` の error イベント経由で `Upload failed` になっていた。

CSP を追加した際の動作確認は認証前のページ（login / signup / docs / group-invitations）に限られており、認証後のアップロード経路が確認範囲から漏れていた。

## 変更内容

- `frontend/public/_headers` の `connect-src` に `https://*.r2.cloudflarestorage.com` を追加
- 同ファイルのコメントを、R2 が再生（`media-src`）とアップロード（`connect-src`）の両方で使われる旨に修正

CSP の他のディレクティブは変更していない。

## 動作確認

- 変更は Pages の静的ヘッダーファイルのみ。反映には再デプロイが必要
- デプロイ後、動画アップロードで CSP 違反が出ないこと・アップロードが完了することを確認する

なお CSP を通した先には R2 バケット側の CORS（`https://videoq.jp` からの `PUT` と `content-type` ヘッダーの許可）があるが、999fe9e 以前はアップロードできていたため設定済みのはず。デプロイ後に `No 'Access-Control-Allow-Origin'` が出た場合は別途対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiRUGCtMdFQEd333aHjh9h