### PR TITLE
fix: グループ詳細と共有ページの見出しまわりを揃える

### DIFF
--- a/frontend/src/components/video/group-detail/VideoGroupDetailView.tsx
+++ b/frontend/src/components/video/group-detail/VideoGroupDetailView.tsx
@@ -60,7 +60,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { SupportText } from '@/components/ui/support-text';
 import { ChipLabel } from '@/components/ui/chip-label';
-import { Heading, HeadingShoulder, HeadingTitle } from '@/components/ui/heading';
+import { Heading, HeadingTitle } from '@/components/ui/heading';
 import { UtilityLink } from '@/components/ui/utility-link';
 import { GroupParticipantsDialog } from './GroupParticipantsDialog';
 import {
@@ -998,30 +998,9 @@ export function VideoGroupDetailView({
                 </BreadcrumbList>
               </Breadcrumbs>
 
-              <header className="flex flex-col justify-between gap-3 lg:flex-row lg:items-end">
-                <div className="min-w-0 space-y-1">
-                  <Heading size="24" rule="4" hasChip={!!shareLink || !canManage}>
-                    {shareLink && canManage ? (
-                      <HeadingShoulder>
-                        <ChipLabel variant="filled-1" color="blue" className="min-h-0 text-oln-14N-100">
-                          {t('videos.groupDetail.sharingBadge')}
-                        </ChipLabel>
-                      </HeadingShoulder>
-                    ) : !canManage ? (
-                      <HeadingShoulder>
-                        <ChipLabel variant="filled-1" color="gray" className="min-h-0 text-oln-14N-100">
-                          {t('videos.groupDetail.memberBadge')}
-                        </ChipLabel>
-                      </HeadingShoulder>
-                    ) : null}
-                    <HeadingTitle level="h1">{group.name}</HeadingTitle>
-                  </Heading>
-                  {group.description ? (
-                    <p className="line-clamp-2 max-w-3xl text-std-16N-170 text-solid-gray-700">
-                      {group.description}
-                    </p>
-                  ) : null}
-                </div>
+              <header className="flex flex-wrap items-center justify-end gap-3">
+                {/* 見出しは非表示にしたが、ページの h1 として構造には残す。 */}
+                <h1 className="sr-only">{group.name}</h1>
                 {canManage ? <div className="flex shrink-0 flex-wrap items-center gap-3">
                   <Button
                     type="button"

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -239,7 +239,6 @@
         "disabled": "Generate a share link to allow access without signing in."
       },
       "shareOpen": "Share",
-      "sharingBadge": "Sharing",
       "generating": "Generating...",
       "copied": "Copied ✓",
       "disable": "Disable",
@@ -284,7 +283,6 @@
       "copyButton": "Copy",
       "removeFromGroup": "Remove from group",
       "deleteError": "Failed to delete the chat group",
-      "memberBadge": "Member",
       "leave": "Leave group",
       "leaveError": "Failed to leave the group"
     },

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -239,7 +239,6 @@
         "disabled": "共有リンクを生成すると、ログインなしで閲覧できるようになります。"
       },
       "shareOpen": "共有",
-      "sharingBadge": "共有中",
       "generating": "生成中...",
       "copied": "コピー済み ✓",
       "disable": "無効化",
@@ -284,7 +283,6 @@
       "copyButton": "コピー",
       "removeFromGroup": "グループから削除",
       "deleteError": "チャットグループの削除に失敗しました",
-      "memberBadge": "参加メンバー",
       "leave": "グループから退出",
       "leaveError": "グループから退出できませんでした"
     },

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -6,6 +6,13 @@ import { Link } from '@/lib/i18n';
 import { apiClient, type VideoInGroup } from '@/lib/api';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { StatusBadge } from '@/components/common/StatusBadge';
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  Breadcrumbs,
+  BreadcrumbsLabel,
+} from '@/components/ui/breadcrumbs';
 import { Button } from '@/components/ui/button';
 import { ChipLabel } from '@/components/ui/chip-label';
 import { ChatPanel } from '@/components/chat/ChatPanel';
@@ -122,16 +129,9 @@ export default function SharePage() {
       {/* ── Fixed Header ────────────────────────────────────────────────── */}
       <header className="fixed top-0 z-50 w-full border-b border-solid-gray-420 bg-white">
         <div className="mx-auto flex w-full max-w-screen-xl items-center justify-between gap-4 px-6 py-4 lg:px-8">
-          <div className="flex min-w-0 items-center gap-6">
-            <Link href="/" className="shrink-0 text-std-20B-150 text-solid-gray-800">
-              VideoQ
-            </Link>
-            <div className="hidden min-w-0 items-center gap-1 text-std-16N-170 font-medium text-solid-gray-600 lg:flex">
-              <span className="max-w-[200px] truncate font-bold text-key-900">
-                {group.name}
-              </span>
-            </div>
-          </div>
+          <Link href="/" className="shrink-0 text-std-20B-150 text-solid-gray-800">
+            VideoQ
+          </Link>
 
           <div className="flex shrink-0 items-center gap-2">
             <ChipLabel variant="filled-1" color="blue" className="min-h-0 text-oln-14N-100">
@@ -143,11 +143,23 @@ export default function SharePage() {
 
       {/* ── Main ────────────────────────────────────────────────────────── */}
       <main className="mt-16 flex flex-col px-6 pt-4 gap-4 max-w-[1600px] mx-auto w-full overflow-y-auto pb-[calc(5rem+env(safe-area-inset-bottom))] lg:pb-4 lg:h-[calc(100dvh-4rem)] lg:overflow-hidden">
-        {group.description && (
-          <div className="shrink-0 rounded-8 border border-solid-gray-300 bg-white px-4 py-3 text-std-16N-170 text-solid-gray-700">
-            {group.description}
-          </div>
-        )}
+        {/* グループ名はバーではなくパンくずで示す（グループ詳細と同じ並び）。 */}
+        <Breadcrumbs aria-label={t('common.actions.backToHome')} className="shrink-0">
+          <BreadcrumbsLabel className="sr-only">
+            {t('common.actions.backToHome')}
+          </BreadcrumbsLabel>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link href="/">{t('navigation.home')}</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbItem isCurrent>{group.name}</BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumbs>
+
+        {/* 見出しは非表示にしたが、ページの h1 として構造には残す。 */}
+        <h1 className="sr-only">{group.name}</h1>
 
         {/* 3-column grid */}
         <div className="flex flex-col lg:grid lg:grid-cols-4 gap-6 lg:flex-1 lg:min-h-0 lg:items-stretch">

--- a/frontend/src/pages/__tests__/SharePage.test.tsx
+++ b/frontend/src/pages/__tests__/SharePage.test.tsx
@@ -46,15 +46,7 @@ describe('SharePage', () => {
     render(<SharePage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Shared Group')).toBeInTheDocument()
-    })
-  })
-
-  it('should render group description', async () => {
-    render(<SharePage />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Shared Description')).toBeInTheDocument()
+      expect(screen.getAllByText('Shared Group').length).toBeGreaterThan(0)
     })
   })
 

--- a/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/VideoGroupDetailPage.test.tsx
@@ -199,7 +199,7 @@ describe('VideoGroupDetailPage', () => {
 
     render(<VideoGroupDetailPage />)
 
-    expect(await screen.findByText('videos.groupDetail.memberBadge')).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: 'videos.groupDetail.leave' })).toBeInTheDocument()
     expect(screen.queryByText('videos.groupDetail.shareOpen')).not.toBeInTheDocument()
     expect(screen.queryByTitle('videos.groupDetail.editTitle')).not.toBeInTheDocument()
     expect(screen.queryByTitle('videos.groupDetail.delete')).not.toBeInTheDocument()
@@ -326,7 +326,6 @@ describe('VideoGroupDetailPage - Share Link', () => {
     render(<VideoGroupDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('videos.groupDetail.sharingBadge')).toBeInTheDocument()
       expect(screen.getByText('videos.groupDetail.shareOpen')).toBeInTheDocument()
     })
     fireEvent.click(screen.getByText('videos.groupDetail.shareOpen'))


### PR DESCRIPTION
## 概要

グループ詳細のヘッダーから、バッジ・グループ名の見出し・説明文のブロックを削除する。あわせて共有ページも同じ並びに揃える。

グループ名はすぐ上のパンくずにも出ているため、同じ情報が上下に二重で並んでいた。

## 変更内容

### グループ詳細（`VideoGroupDetailView.tsx`）

見出しブロック（`共有中` / `参加メンバー` バッジ、`<h1>` のグループ名、説明文）を削除し、`<header>` は操作ボタン（メンバー管理・共有・グループを編集・削除、メンバーの場合は退出）だけを右寄せで並べる形にした。

パンくず（`グループ › グループ名`）はそのまま残るので、どのグループを見ているかは引き続き分かる。

### 共有ページ（`SharePage.tsx`）

グループ詳細と並びが違ったので合わせた。

- 固定バーに載っていたグループ名を削除。左は VideoQ ロゴのみ、右は「公開共有リンク」バッジという、`AppNav` と同じ構成にした
- 代わりにグループ詳細と同じ `Breadcrumbs` を本文の先頭に追加（`ホーム › グループ名`）。共有ページは未ログインの閲覧者が見るため、リンク先はグループ一覧ではなくホームにしている
- 説明文のカードを削除

### 見出し階層

見出しを消すとページから `h1` がなくなり、見出しが `h2`（動画一覧・動画タイトル）から始まってしまう。両ページとも `sr-only` の `h1` としてグループ名を残し、表示は消しつつ文書構造は保っている。

### 翻訳キー

使われなくなった `videos.groupDetail.sharingBadge` と `videos.groupDetail.memberBadge` を ja / en から削除。`videos.groups.memberBadge` はグループ一覧で使用中なので残している。

## 動作確認

ローカルの dev サーバーで共有ページ（`/ja/share/<slug>`）を開き、「バー → パンくず → 3カラムグリッド」の並びになり、グループ詳細と同じ見え方になることを確認した。

- `npm test` — 69 files / 659 tests passed
- `npm run lint`
- `npm run typecheck`

削除した要素を参照していたテストは差し替えた。

- `VideoGroupDetailPage.test.tsx` — メンバー表示の確認を `参加メンバー` バッジから退出ボタンの存在に、共有リンクの確認を `共有中` バッジから共有ボタンの存在に変更
- `SharePage.test.tsx` — 説明文の表示テストを削除。グループ名は sr-only の `h1` とパンくずの2箇所にマッチするため `getAllByText` に変更

## 補足

共有ページでロゴがパンくずより少し内側に見えるが、これはバーが `max-w-screen-xl`、本文が `max-w-[1600px]` という既存のレイアウト差によるもので、グループ詳細でも同じ。両ページ共通の話になるため今回は触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ME5gvfsBjc16NNjyx86m7w
