### PR TITLE
fix: 公開ポリシーの連絡先を一時的な個人メールにする

### DIFF
--- a/docs/billing/stripe-dashboard.md
+++ b/docs/billing/stripe-dashboard.md
@@ -47,7 +47,7 @@ Checkout / Customer Portal に利用規約とプライバシーを出すには�
 |---|---|
 | Terms of service | `https://videoq.jp/terms` |
 | Privacy policy | `https://videoq.jp/privacy` |
-| Support email | `support@videoq.jp` |
+| Support email | `yukiharada1228@gmail.com` |
 | Support website | `https://videoq.jp` |
 
 [Checkout settings](https://dashboard.stripe.com/acct_1Re0SMJ2c6Th1a6w/settings/checkout) で Legal policies と Refund policy を有効にし、返金ポリシー全文は `https://videoq.jp/refund` を指す。日本の通信販売として [特商法表記](https://videoq.jp/legal) もサイトに置く。

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -587,7 +587,7 @@
         },
         "contact": {
           "title": "10. Contact",
-          "body": "Questions about these terms: support@videoq.jp. Seller details are listed on the Specified Commercial Transactions notice."
+          "body": "Questions about these terms: yukiharada1228@gmail.com. Seller details are listed on the Specified Commercial Transactions notice."
         }
       }
     },
@@ -597,7 +597,7 @@
       "sections": {
         "controller": {
           "title": "1. Controller",
-          "body": "VideoQ (https://videoq.jp) handles personal data collected through the service under this policy. Contact: support@videoq.jp."
+          "body": "VideoQ (https://videoq.jp) handles personal data collected through the service under this policy. Contact: yukiharada1228@gmail.com."
         },
         "collect": {
           "title": "2. Data we collect",
@@ -621,7 +621,7 @@
         },
         "rights": {
           "title": "7. Your rights",
-          "body": "You may request access, correction, suspension, or deletion of your personal data by emailing support@videoq.jp. We will verify your identity and respond as required by law."
+          "body": "You may request access, correction, suspension, or deletion of your personal data by emailing yukiharada1228@gmail.com. We will verify your identity and respond as required by law."
         },
         "cookies": {
           "title": "8. Cookies",
@@ -629,7 +629,7 @@
         },
         "contact": {
           "title": "9. Contact",
-          "body": "Privacy questions: support@videoq.jp."
+          "body": "Privacy questions: yukiharada1228@gmail.com."
         }
       }
     },
@@ -655,11 +655,11 @@
         },
         "howto": {
           "title": "If you want a refund",
-          "body": "For duplicate charges, payment errors, or cases where the law requires a refund, email support@videoq.jp with the account and what happened. We will review it. For card chargebacks, contact us first."
+          "body": "For duplicate charges, payment errors, or cases where the law requires a refund, email yukiharada1228@gmail.com with the account and what happened. We will review it. For card chargebacks, contact us first."
         },
         "contact": {
           "title": "Contact",
-          "body": "Refunds and cancellations: support@videoq.jp"
+          "body": "Refunds and cancellations: yukiharada1228@gmail.com"
         }
       }
     },
@@ -686,7 +686,7 @@
         },
         "email": {
           "label": "Email",
-          "value": "support@videoq.jp"
+          "value": "yukiharada1228@gmail.com"
         },
         "url": {
           "label": "Website",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -587,7 +587,7 @@
         },
         "contact": {
           "title": "10. 連絡先",
-          "body": "本規約に関する問い合わせは support@videoq.jp までお願いします。事業者情報は特定商取引法に基づく表記を参照してください。"
+          "body": "本規約に関する問い合わせは yukiharada1228@gmail.com までお願いします。事業者情報は特定商取引法に基づく表記を参照してください。"
         }
       }
     },
@@ -597,7 +597,7 @@
       "sections": {
         "controller": {
           "title": "1. 事業者",
-          "body": "VideoQ（https://videoq.jp）は、本サービスの提供に伴い取得する個人情報を、このポリシーに従って取り扱います。問い合わせ先は support@videoq.jp です。"
+          "body": "VideoQ（https://videoq.jp）は、本サービスの提供に伴い取得する個人情報を、このポリシーに従って取り扱います。問い合わせ先は yukiharada1228@gmail.com です。"
         },
         "collect": {
           "title": "2. 取得する情報",
@@ -621,7 +621,7 @@
         },
         "rights": {
           "title": "7. 開示・訂正・削除",
-          "body": "利用者は、自己の個人情報について開示、訂正、利用停止、削除を求められます。support@videoq.jp まで連絡してください。本人確認のうえ、法令の範囲で対応します。"
+          "body": "利用者は、自己の個人情報について開示、訂正、利用停止、削除を求められます。yukiharada1228@gmail.com まで連絡してください。本人確認のうえ、法令の範囲で対応します。"
         },
         "cookies": {
           "title": "8. Cookie",
@@ -629,7 +629,7 @@
         },
         "contact": {
           "title": "9. 問い合わせ",
-          "body": "プライバシーに関する問い合わせは support@videoq.jp までお願いします。"
+          "body": "プライバシーに関する問い合わせは yukiharada1228@gmail.com までお願いします。"
         }
       }
     },
@@ -655,11 +655,11 @@
         },
         "howto": {
           "title": "返金を希望する場合",
-          "body": "重複課金、決済エラー、法令で返金が必要な場合は support@videoq.jp へ、対象アカウントと経緯を書いて連絡してください。内容を確認のうえ対応します。カード会社経由のチャージバックは、まず上記窓口へ連絡してください。"
+          "body": "重複課金、決済エラー、法令で返金が必要な場合は yukiharada1228@gmail.com へ、対象アカウントと経緯を書いて連絡してください。内容を確認のうえ対応します。カード会社経由のチャージバックは、まず上記窓口へ連絡してください。"
         },
         "contact": {
           "title": "連絡先",
-          "body": "返金・解約の問い合わせ: support@videoq.jp"
+          "body": "返金・解約の問い合わせ: yukiharada1228@gmail.com"
         }
       }
     },
@@ -686,7 +686,7 @@
         },
         "email": {
           "label": "メールアドレス",
-          "value": "support@videoq.jp"
+          "value": "yukiharada1228@gmail.com"
         },
         "url": {
           "label": "サイト",


### PR DESCRIPTION
## Summary
- 利用規約・プライバシー・返金・特商法の連絡先を `yukiharada1228@gmail.com` にする

## Test plan
- [ ] `/legal` のメールが gmail になっている
- [ ] Stripe Public details の support email も同じ値にする


Made with [Cursor](https://cursor.com)