### PR TITLE
fix: LPデモのチャット欄がメッセージで無限に伸びないようにする

### DIFF
--- a/frontend/src/components/chat/ChatMessagesView.tsx
+++ b/frontend/src/components/chat/ChatMessagesView.tsx
@@ -20,7 +20,7 @@ export function ChatMessagesView({
   onFeedback,
 }: ChatMessagesViewProps) {
   return (
-    <div ref={messagesContainerRef} className="flex-1 overflow-y-auto p-4 space-y-4">
+    <div ref={messagesContainerRef} className="min-h-0 flex-1 overflow-y-auto p-4 space-y-4">
       {messages.map((message, index) => (
         <ChatMessageBubble
           key={index}

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -92,7 +92,7 @@ export function ChatPanel({
   const showTabs = !!groupId && !shareToken && showHistory;
 
   const containerClass = cn(
-    'flex flex-col overflow-hidden border border-solid-gray-420 bg-white',
+    'flex min-h-0 flex-col overflow-hidden border border-solid-gray-420 bg-white',
     className ?? 'h-[500px] lg:h-[600px]',
   );
 
@@ -177,7 +177,7 @@ export function ChatPanel({
           />
           {suggestedQuestions && suggestedQuestions.length > 0 ? (
             <div
-              className="flex flex-wrap gap-2 px-4 pb-3"
+              className="flex shrink-0 flex-wrap gap-2 px-4 pb-3"
               role="group"
               aria-label={t('chat.suggestedQuestions')}
             >

--- a/frontend/src/components/landing/LandingTryDemo.tsx
+++ b/frontend/src/components/landing/LandingTryDemo.tsx
@@ -162,7 +162,7 @@ export function LandingTryDemo() {
               </div>
             </div>
 
-            <div className="lg:col-span-5">
+            <div className="relative min-h-[32rem] lg:col-span-5">
               <ChatPanel
                 key={sample.slug}
                 groupId={group.id}
@@ -170,7 +170,7 @@ export function LandingTryDemo() {
                 showHistory={false}
                 suggestedQuestions={suggestedQuestions}
                 onVideoPlay={handleVideoPlayFromTime}
-                className="h-[32rem] border-0 lg:h-full lg:min-h-[32rem]"
+                className="h-[32rem] border-0 lg:absolute lg:inset-0 lg:h-full"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- LP デモのチャットが `lg:h-full` とグリッド行高の循環で、メッセージ増分だけページを伸ばしていた
- 左列で行高を決め、チャットは絶対配置でその高さに合わせる。メッセージは `min-h-0` でパネル内スクロールにする

## Test plan
- [ ] 未ログインの `/` で公開サンプルを開き、質問を重ねてもページが下に伸びずチャット内だけスクロールすること（デスクトップ幅）
- [ ] モバイル幅ではチャットが固定高さ (`32rem`) のままであること
- [ ] `/share/...` とグループ詳細のチャットが従来どおりパネル内でスクロールすること
- [ ] `frontend` の ChatPanel / LandingTryDemo テストが通ること


Made with [Cursor](https://cursor.com)