### PR TITLE
コネクターが参照する protected resource metadata を返す

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,3 +1,4 @@
+import type { Context } from "hono";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import type { AppEnv } from "./types/bindings";
 import { requestId } from "./middleware/request-id";
@@ -73,18 +74,22 @@ export function createApp() {
       return oauthProviderOpenIdConfigMetadata(auth as never)(c.req.raw);
     });
   });
-  app.get("/.well-known/oauth-protected-resource", (c) => {
+  const protectedResourceMetadata = (c: Context<AppEnv>) => {
     const origin = new URL(c.req.url).origin;
+    const issuer = (
+      c.env.BETTER_AUTH_URL?.trim() ||
+      c.env.OAUTH_ISSUER_URL?.trim() ||
+      c.env.FRONTEND_URL?.trim() ||
+      origin
+    ).replace(/\/+$/, "");
     return c.json({
-      resource: `${origin}/api/mcp`,
-      authorization_servers: [
-        c.env.BETTER_AUTH_URL?.trim() ||
-          c.env.OAUTH_ISSUER_URL?.trim() ||
-          c.env.FRONTEND_URL?.trim() ||
-          origin,
-      ],
+      resource: `${issuer}/api/mcp`,
+      authorization_servers: [issuer],
     });
-  });
+  };
+  app.get("/.well-known/oauth-protected-resource", protectedResourceMetadata);
+  // RFC 9728 path form. MCP 401 の resource_metadata が指す先。
+  app.get("/.well-known/oauth-protected-resource/api/mcp", protectedResourceMetadata);
 
   app.route("/api/account", accountRoutes);
   app.route("/api/billing", billingRoutes);

--- a/apps/api/test/oauth-discovery.test.ts
+++ b/apps/api/test/oauth-discovery.test.ts
@@ -36,6 +36,21 @@ describe("OAuth discovery", () => {
     });
   });
 
+  it("serves RFC 9728 metadata at both resource well-known URLs", async () => {
+    const expected = {
+      resource: "https://api.example.com/api/mcp",
+      authorization_servers: ["https://api.example.com"],
+    };
+    for (const path of [
+      "/.well-known/oauth-protected-resource",
+      "/.well-known/oauth-protected-resource/api/mcp",
+    ]) {
+      const res = await createApp().request(path, {}, ENV);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(expected);
+    }
+  });
+
   it("serves OpenID metadata below the issuer path", async () => {
     const res = await createApp().request(
       "/api/auth/.well-known/openid-configuration",


### PR DESCRIPTION
## Summary
- MCP コネクターは 401 の `WWW-Authenticate` から `/.well-known/oauth-protected-resource/api/mcp` を見に行くが、この経路が 404 だった。
- RFC 9728 の path 形式でも同じ metadata を返すようにし、Claude / ChatGPT からの VideoQ 接続が完了できるようにする。

## Test plan
- [ ] `https://videoq.jp/.well-known/oauth-protected-resource/api/mcp` が JSON を返す（デプロイ後）
- [ ] `/.well-known/oauth-protected-resource` も同じ内容を返す
- [ ] Claude / ChatGPT のカスタムコネクターで `https://videoq.jp/api/mcp` を追加し、同意画面まで進んで接続が完了する


Made with [Cursor](https://cursor.com)