### PR TITLE
未ログインのトップを製品LPにし、日本語を公開のデフォルトにする

### DIFF
--- a/frontend/src/components/ui/__tests__/select.test.tsx
+++ b/frontend/src/components/ui/__tests__/select.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Dialog, useDialog } from '../dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../select'
+
+function DialogSelectHarness() {
+  const dialog = useDialog({ open: true, onOpenChange: () => {} })
+
+  return (
+    <Dialog {...dialog.dialogProps}>
+      <Select defaultValue="uploaded_at_desc">
+        <SelectTrigger aria-label="ordering">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="uploaded_at_desc">新しい順</SelectItem>
+          <SelectItem value="uploaded_at_asc">古い順</SelectItem>
+          <SelectItem value="title_asc">タイトル順</SelectItem>
+        </SelectContent>
+      </Select>
+    </Dialog>
+  )
+}
+
+describe('Select', () => {
+  beforeEach(() => {
+    if (!Element.prototype.hasPointerCapture) {
+      Element.prototype.hasPointerCapture = () => false
+    }
+    if (!Element.prototype.setPointerCapture) {
+      Element.prototype.setPointerCapture = () => {}
+    }
+    if (!Element.prototype.releasePointerCapture) {
+      Element.prototype.releasePointerCapture = () => {}
+    }
+    if (!Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = () => {}
+    }
+  })
+
+  it('shows every option when opened', async () => {
+    const user = userEvent.setup()
+    render(
+      <Select defaultValue="uploaded_at_desc">
+        <SelectTrigger aria-label="ordering">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="uploaded_at_desc">新しい順</SelectItem>
+          <SelectItem value="uploaded_at_asc">古い順</SelectItem>
+          <SelectItem value="title_asc">タイトル順</SelectItem>
+        </SelectContent>
+      </Select>,
+    )
+
+    await user.click(screen.getByRole('combobox', { name: 'ordering' }))
+
+    expect(await screen.findByRole('option', { name: '新しい順' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '古い順' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'タイトル順' })).toBeInTheDocument()
+  })
+
+  it('portals options into the open native dialog', async () => {
+    const user = userEvent.setup()
+    render(<DialogSelectHarness />)
+
+    const dialog = document.querySelector('dialog')
+    expect(dialog).toBeTruthy()
+
+    await user.click(screen.getByRole('combobox', { name: 'ordering' }))
+
+    const older = await screen.findByRole('option', { name: '古い順' })
+    expect(dialog?.contains(older)).toBe(true)
+    expect(screen.getByRole('option', { name: 'タイトル順' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -3,6 +3,22 @@ import { cva } from "class-variance-authority"
 
 import { cn } from "@/lib/digital-agency/cn"
 
+/**
+ * Native <dialog showModal()> renders in the top layer. Portaled overlays
+ * (Select, etc.) must mount inside this element or they appear behind it.
+ */
+export const DialogPortalContext = React.createContext<HTMLElement | null>(null)
+
+function assignRef<T>(ref: React.ForwardedRef<T> | undefined, value: T | null) {
+  if (typeof ref === "function") {
+    ref(value)
+    return
+  }
+  if (ref) {
+    ref.current = value
+  }
+}
+
 export const dialogVariants = cva(
   "group/modal-dialog inset-0 w-auto h-auto max-w-none max-h-none border-0 bg-transparent px-4 [container-type:inline-size] [color-scheme:dark] break-words text-std-16N-170 [&:modal]:flex [&:modal]:flex-col [&:modal]:items-center backdrop:bg-opacity-gray-600 forced-colors:backdrop:bg-[#000b] [scrollbar-gutter:stable] data-[scroll=inner]:[scrollbar-gutter:auto]"
 )
@@ -20,19 +36,31 @@ const Dialog = React.forwardRef<HTMLDialogElement, DialogProps>(
       ...style,
       ["--modal-dialog-width" as string]: width ?? "fit-content",
     }
+    const [portalContainer, setPortalContainer] =
+      React.useState<HTMLElement | null>(null)
+
+    const setDialogRef = React.useCallback(
+      (node: HTMLDialogElement | null) => {
+        setPortalContainer(node)
+        assignRef(ref, node)
+      },
+      [ref],
+    )
 
     return (
       <dialog
-        ref={ref}
+        ref={setDialogRef}
         data-slot="dialog"
         data-scroll={scroll}
         style={mergedStyle}
         className={cn(dialogVariants(), className)}
         {...props}
       >
-        <div className="shrink-[9999] w-px h-[calc(120/16*1rem)] min-h-4" />
-        {children}
-        <div className="shrink-[9999] w-px h-[calc(120/16*1rem)] min-h-4" />
+        <DialogPortalContext.Provider value={portalContainer}>
+          <div className="shrink-[9999] w-px h-[calc(120/16*1rem)] min-h-4" />
+          {children}
+          <div className="shrink-[9999] w-px h-[calc(120/16*1rem)] min-h-4" />
+        </DialogPortalContext.Provider>
       </dialog>
     )
   }

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -4,6 +4,7 @@ import { Check, ChevronDown, ChevronUp } from "lucide-react"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/digital-agency/cn"
+import { DialogPortalContext } from "./dialog"
 
 export type SelectBlockSize = "lg" | "md" | "sm"
 
@@ -99,34 +100,38 @@ SelectScrollDownButton.displayName =
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      data-slot="select-content"
-      className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-8 border border-solid-gray-600 bg-white text-solid-gray-800 shadow-md",
-        position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-        className
-      )}
-      position={position}
-      {...props}
-    >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
+>(({ className, children, position = "popper", ...props }, ref) => {
+  const dialogContainer = React.useContext(DialogPortalContext)
+
+  return (
+    <SelectPrimitive.Portal container={dialogContainer ?? undefined}>
+      <SelectPrimitive.Content
+        ref={ref}
+        data-slot="select-content"
         className={cn(
-          "p-1",
+          "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-8 border border-solid-gray-600 bg-white text-solid-gray-800 shadow-md",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
         )}
+        position={position}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-))
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "w-full min-w-[var(--radix-select-trigger-width)]"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+})
 SelectContent.displayName = SelectPrimitive.Content.displayName
 
 const SelectLabel = React.forwardRef<


### PR DESCRIPTION
## Summary
- 未ログインのトップを製品 LP にし、公開面のデフォルト言語を日本語にする。検索に載せる面は講義動画の検索・文字起こしに揃え、アプリ画面と共有リンクは noindex のままにする。
- 料金は据え置きで、Free / Basic / Pro の文字起こしと AI 回答の利用枠を広げる。
- グループへの動画追加ダイアログで、並び順・ステータスの Select 候補がネイティブ dialog の裏に隠れて見えない問題を直す。
- MCP コネクター向けに protected resource metadata を返し、Docs / 料金ページの末尾スラッシュや初回 HTML、LP デモのチャット高さなども合わせて直す。

## Test plan
- [ ] 未ログインで `/` を開き、製品 LP と日本語の meta / 初回 HTML になっている
- [ ] `/docs/`・`/pricing/`・`/docs/...` が LP の title に戻らず、言語切り替えで hash が残る
- [ ] LP デモのチャットにメッセージを重ねても入力欄が無限に伸びない
- [ ] 料金ページでプラン枠が新件数になり、読み込み中はプラン一覧だけスピナーになる
- [ ] `/.well-known/oauth-protected-resource` が 200 で `resource` を返す
- [ ] グループ詳細 → 動画を追加 で「新しい順」などを開き、候補がダイアログの前面に出る


Made with [Cursor](https://cursor.com)