### PR TITLE
fix: 講座リネームの 0016 が本番 migrate で落ちないようにする

### DIFF
--- a/apps/api/drizzle/0016_rename_groups_to_courses.sql
+++ b/apps/api/drizzle/0016_rename_groups_to_courses.sql
@@ -1,4 +1,5 @@
 -- Rename video groups to courses (講座). Data-preserving RENAME only.
+-- Objects below were created by 0001 / 0008. Snapshot-only indexes are created at the end.
 ALTER TABLE "video_groups" RENAME TO "video_courses";--> statement-breakpoint
 ALTER TABLE "video_group_members" RENAME TO "video_course_members";--> statement-breakpoint
 ALTER TABLE "video_group_invitations" RENAME TO "video_course_invitations";--> statement-breakpoint
@@ -15,19 +16,13 @@ ALTER TABLE "video_course_memberships" RENAME COLUMN "group_id" TO "course_id";-
 ALTER TABLE "chat_logs" RENAME COLUMN "group_id" TO "course_id";--> statement-breakpoint
 ALTER TABLE "course_evaluation_snapshots" RENAME COLUMN "group_id" TO "course_id";--> statement-breakpoint
 ALTER INDEX "video_groups_user_id_idx" RENAME TO "video_courses_user_id_idx";--> statement-breakpoint
-ALTER INDEX "video_groups_share_slug_idx" RENAME TO "video_courses_share_slug_idx";--> statement-breakpoint
-ALTER INDEX "video_groups_share_slug_ci_uniq" RENAME TO "video_courses_share_slug_ci_uniq";--> statement-breakpoint
 ALTER INDEX "video_group_members_group_id_idx" RENAME TO "video_course_members_course_id_idx";--> statement-breakpoint
-ALTER INDEX "video_group_members_video_id_idx" RENAME TO "video_course_members_video_id_idx";--> statement-breakpoint
-ALTER INDEX "video_group_members_group_order_idx" RENAME TO "video_course_members_course_order_idx";--> statement-breakpoint
 ALTER INDEX "video_group_invitations_group_status_idx" RENAME TO "video_course_invitations_course_status_idx";--> statement-breakpoint
 ALTER INDEX "video_group_invitations_email_idx" RENAME TO "video_course_invitations_email_idx";--> statement-breakpoint
 ALTER INDEX "video_group_invitations_pending_email_uniq" RENAME TO "video_course_invitations_pending_email_uniq";--> statement-breakpoint
 ALTER INDEX "video_group_memberships_group_id_idx" RENAME TO "video_course_memberships_course_id_idx";--> statement-breakpoint
 ALTER INDEX "video_group_memberships_user_id_idx" RENAME TO "video_course_memberships_user_id_idx";--> statement-breakpoint
 ALTER INDEX "chat_logs_group_id_idx" RENAME TO "chat_logs_course_id_idx";--> statement-breakpoint
-ALTER INDEX "chat_logs_group_created_idx" RENAME TO "chat_logs_course_created_idx";--> statement-breakpoint
-ALTER INDEX "group_evaluation_snapshots_user_id_idx" RENAME TO "course_evaluation_snapshots_user_id_idx";--> statement-breakpoint
 ALTER TABLE "video_courses" RENAME CONSTRAINT "video_groups_user_id_fkey" TO "video_courses_user_id_fkey";--> statement-breakpoint
 ALTER TABLE "video_course_members" RENAME CONSTRAINT "video_group_members_group_id_fkey" TO "video_course_members_course_id_fkey";--> statement-breakpoint
 ALTER TABLE "video_course_members" RENAME CONSTRAINT "video_group_members_video_id_fkey" TO "video_course_members_video_id_fkey";--> statement-breakpoint
@@ -47,4 +42,11 @@ ALTER TABLE "video_course_memberships" RENAME CONSTRAINT "video_group_membership
 ALTER TABLE "chat_logs" RENAME CONSTRAINT "chat_logs_group_id_fkey" TO "chat_logs_course_id_fkey";--> statement-breakpoint
 ALTER TABLE "course_evaluation_snapshots" RENAME CONSTRAINT "group_evaluation_snapshots_group_id_fkey" TO "course_evaluation_snapshots_course_id_fkey";--> statement-breakpoint
 ALTER TABLE "course_evaluation_snapshots" RENAME CONSTRAINT "group_evaluation_snapshots_user_id_fkey" TO "course_evaluation_snapshots_user_id_fkey";--> statement-breakpoint
-ALTER TABLE "course_evaluation_snapshots" RENAME CONSTRAINT "group_evaluation_snapshots_group_id_key" TO "course_evaluation_snapshots_course_id_key";
+ALTER TABLE "course_evaluation_snapshots" RENAME CONSTRAINT "group_evaluation_snapshots_group_id_key" TO "course_evaluation_snapshots_course_id_key";--> statement-breakpoint
+-- These indexes are in the Drizzle schema but were never created by a SQL migration.
+CREATE INDEX "video_courses_share_slug_idx" ON "video_courses" USING btree ("share_slug") WHERE (share_slug IS NOT NULL);--> statement-breakpoint
+CREATE UNIQUE INDEX "video_courses_share_slug_ci_uniq" ON "video_courses" USING btree (lower((share_slug)::text)) WHERE (share_slug IS NOT NULL);--> statement-breakpoint
+CREATE INDEX "video_course_members_video_id_idx" ON "video_course_members" USING btree ("video_id");--> statement-breakpoint
+CREATE INDEX "video_course_members_course_order_idx" ON "video_course_members" USING btree ("course_id", "order");--> statement-breakpoint
+CREATE INDEX "chat_logs_course_created_idx" ON "chat_logs" USING btree ("course_id", "created_at" DESC);--> statement-breakpoint
+CREATE INDEX "course_evaluation_snapshots_user_id_idx" ON "course_evaluation_snapshots" USING btree ("user_id");

--- a/apps/api/scripts/db-migrate.sh
+++ b/apps/api/scripts/db-migrate.sh
@@ -3,4 +3,10 @@
 set -eu
 cd "$(dirname "$0")/.."
 node scripts/stamp-baseline.mjs
-exec npx drizzle-kit migrate
+# drizzle-kit's spinner uses ANSI erase-line and hides the SQL error in CI logs.
+set +e
+migrate_output=$(npx drizzle-kit migrate 2>&1)
+migrate_status=$?
+set -e
+printf '%s\n' "$migrate_output" | sed 's/\x1B\[[0-9;]*[A-Za-z]//g'
+exit "$migrate_status"


### PR DESCRIPTION
## Summary
- 本番 CD の Drizzle migrate が `0016_rename_groups_to_courses` で失敗していた。0001 を stamp した DB には Drizzle schema 上のインデックス（`share_slug` など）が無く、存在しないオブジェクトを `ALTER INDEX ... RENAME` していた。
- 0016 は 0001 / 0008 が作ったテーブル・シーケンス・カラム・インデックス・制約だけをリネームし、欠けていたインデックスは新名で `CREATE INDEX` する。
- `db-migrate.sh` は drizzle-kit のスピナーが SQL エラーを消さないよう、ANSI を剥がしてからログに出す。

失敗ジョブ: https://github.com/yukiharada1228/videoq/actions/runs/32732242775/job/97446903368

## Test plan
- [ ] CI が通ること
- [ ] マージ後の CD で Drizzle DB Migrate が成功すること
- [ ] 本番で `video_courses` が存在し、`video_groups` が残っていないこと
- [ ] レガシー `app_videogroup` とそのシーケンスが残っていること
- [ ] 講座一覧・詳細・招待が動くこと


Made with [Cursor](https://cursor.com)