### PR TITLE
fix: 講座リネーム migration で所有者インデックスを再作成する

### DIFF
--- a/apps/api/drizzle/0016_rename_groups_to_courses.sql
+++ b/apps/api/drizzle/0016_rename_groups_to_courses.sql
@@ -1,5 +1,5 @@
 -- Rename video groups to courses (講座). Data-preserving RENAME only.
--- Objects below were created by 0001 / 0008. Snapshot-only indexes are created at the end.
+-- Objects below still exist after 0006 / 0008. Missing indexes are created at the end.
 ALTER TABLE "video_groups" RENAME TO "video_courses";--> statement-breakpoint
 ALTER TABLE "video_group_members" RENAME TO "video_course_members";--> statement-breakpoint
 ALTER TABLE "video_group_invitations" RENAME TO "video_course_invitations";--> statement-breakpoint
@@ -15,7 +15,6 @@ ALTER TABLE "video_course_invitations" RENAME COLUMN "group_id" TO "course_id";-
 ALTER TABLE "video_course_memberships" RENAME COLUMN "group_id" TO "course_id";--> statement-breakpoint
 ALTER TABLE "chat_logs" RENAME COLUMN "group_id" TO "course_id";--> statement-breakpoint
 ALTER TABLE "course_evaluation_snapshots" RENAME COLUMN "group_id" TO "course_id";--> statement-breakpoint
-ALTER INDEX "video_groups_user_id_idx" RENAME TO "video_courses_user_id_idx";--> statement-breakpoint
 ALTER INDEX "video_group_members_group_id_idx" RENAME TO "video_course_members_course_id_idx";--> statement-breakpoint
 ALTER INDEX "video_group_invitations_group_status_idx" RENAME TO "video_course_invitations_course_status_idx";--> statement-breakpoint
 ALTER INDEX "video_group_invitations_email_idx" RENAME TO "video_course_invitations_email_idx";--> statement-breakpoint
@@ -43,7 +42,10 @@ ALTER TABLE "chat_logs" RENAME CONSTRAINT "chat_logs_group_id_fkey" TO "chat_log
 ALTER TABLE "course_evaluation_snapshots" RENAME CONSTRAINT "group_evaluation_snapshots_group_id_fkey" TO "course_evaluation_snapshots_course_id_fkey";--> statement-breakpoint
 ALTER TABLE "course_evaluation_snapshots" RENAME CONSTRAINT "group_evaluation_snapshots_user_id_fkey" TO "course_evaluation_snapshots_user_id_fkey";--> statement-breakpoint
 ALTER TABLE "course_evaluation_snapshots" RENAME CONSTRAINT "group_evaluation_snapshots_group_id_key" TO "course_evaluation_snapshots_course_id_key";--> statement-breakpoint
--- These indexes are in the Drizzle schema but were never created by a SQL migration.
+-- Create indexes that are absent at this point in the migration history.
+-- video_groups_user_id_idx was created by 0001, then dropped implicitly when
+-- 0006 replaced video_groups.user_id with a text column.
+CREATE INDEX "video_courses_user_id_idx" ON "video_courses" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX "video_courses_share_slug_idx" ON "video_courses" USING btree ("share_slug") WHERE (share_slug IS NOT NULL);--> statement-breakpoint
 CREATE UNIQUE INDEX "video_courses_share_slug_ci_uniq" ON "video_courses" USING btree (lower((share_slug)::text)) WHERE (share_slug IS NOT NULL);--> statement-breakpoint
 CREATE INDEX "video_course_members_video_id_idx" ON "video_course_members" USING btree ("video_id");--> statement-breakpoint

--- a/apps/api/test/course-rename-migration.test.ts
+++ b/apps/api/test/course-rename-migration.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const userIdMigration = readFileSync(
+  new URL("../drizzle/0006_user_id_uuid.sql", import.meta.url),
+  "utf8",
+);
+const courseRenameMigration = readFileSync(
+  new URL("../drizzle/0016_rename_groups_to_courses.sql", import.meta.url),
+  "utf8",
+);
+
+describe("course rename migration", () => {
+  it("recreates the course owner index dropped by the user-id migration", () => {
+    expect(userIdMigration).toContain(
+      'ALTER TABLE "video_groups" DROP COLUMN "user_id"',
+    );
+    expect(courseRenameMigration).not.toContain(
+      'ALTER INDEX "video_groups_user_id_idx"',
+    );
+    expect(courseRenameMigration).toContain(
+      'CREATE INDEX "video_courses_user_id_idx" ON "video_courses"',
+    );
+  });
+});


### PR DESCRIPTION
## 概要

CD の Drizzle DB Migrate ジョブで、講座リネーム migration が存在しない index を rename しようとして失敗する問題を修正します。

## 原因

0001 で作成された video_groups_user_id_idx は、0006 が video_groups.user_id を bigint から text へ置換する際、元カラムの DROP とともに PostgreSQL によって削除されます。

その後の 0016 が video_groups_user_id_idx を video_courses_user_id_idx へ rename しようとしていたため、relation does not exist で migration が失敗していました。

## 変更内容

- 存在しない video_groups_user_id_idx の rename を削除
- テーブルとカラムのリネーム後、video_courses_user_id_idx を新規作成
- 0006 と 0016 の関係を検証する回帰テストを追加

## 検証

- npm test: 314 passed / 7 skipped
- npm run db:check: 成功
- PostgreSQL 17 + pgvector の新規 DB で 0000〜0016 の全 migration: 成功
- 0015 適用済み DB への 0016 単体適用: 成功
- migration 適用後の再実行: 成功

## 関連する失敗

https://github.com/yukiharada1228/videoq/actions/runs/32733884372/job/97452134153