### PR TITLE
fix: 講座移行後もアカウント削除を完了する

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,15 @@ jobs:
               - '.github/workflows/cd.yml'
             worker:
               - 'apps/worker/**'
+              # A migration can rename objects used by the Python worker. If a
+              # coordinated deploy is blocked on migration and the follow-up
+              # only fixes SQL, redeploy the worker too so production cannot
+              # remain on the pre-migration schema contract.
+              - 'apps/api/drizzle/**'
+              - 'apps/api/src/db/**'
+              - 'apps/api/drizzle.config.ts'
+              - 'apps/api/scripts/db-migrate.sh'
+              - 'apps/api/scripts/stamp-baseline.mjs'
               - '.github/workflows/cd.yml'
             migrate:
               - 'apps/api/drizzle/**'

--- a/apps/worker/tests/test_account_deletion_retry.py
+++ b/apps/worker/tests/test_account_deletion_retry.py
@@ -36,3 +36,44 @@ def test_storage_delete_failure_propagates_for_sqs_retry(monkeypatch) -> None:
         account_deletion._delete_all_videos_for_user(conn, "u1")
 
     delete_video.assert_called_once_with(conn, 42, "u1")
+
+
+def test_account_deletion_uses_renamed_courses_table() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = {
+        "video_courses": "video_courses",
+        "video_groups": None,
+    }
+
+    account_deletion._delete_owned_courses_for_user(conn, "u1")
+
+    conn.execute.assert_any_call(
+        "DELETE FROM video_courses WHERE user_id = %s",
+        ("u1",),
+    )
+
+
+def test_account_deletion_remains_compatible_before_course_rename() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = {
+        "video_courses": None,
+        "video_groups": "video_groups",
+    }
+
+    account_deletion._delete_owned_courses_for_user(conn, "u1")
+
+    conn.execute.assert_any_call(
+        "DELETE FROM video_groups WHERE user_id = %s",
+        ("u1",),
+    )
+
+
+def test_account_deletion_fails_if_course_table_is_missing() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = {
+        "video_courses": None,
+        "video_groups": None,
+    }
+
+    with pytest.raises(RuntimeError, match="Neither video_courses nor video_groups exists"):
+        account_deletion._delete_owned_courses_for_user(conn, "u1")

--- a/apps/worker/worker_python/tasks/account_deletion.py
+++ b/apps/worker/worker_python/tasks/account_deletion.py
@@ -38,8 +38,21 @@ def _delete_chat_history_for_user(conn, user_id: str) -> None:
     conn.execute("DELETE FROM chat_logs WHERE user_id = %s", (user_id,))
 
 
-def _delete_video_courses_for_user(conn, user_id: str) -> None:
-    conn.execute("DELETE FROM video_courses WHERE user_id = %s", (user_id,))
+def _delete_owned_courses_for_user(conn, user_id: str) -> None:
+    """Delete owned courses across the video_groups -> video_courses rollout."""
+    tables = conn.execute(
+        """
+        SELECT to_regclass('video_courses') AS video_courses,
+               to_regclass('video_groups') AS video_groups
+        """
+    ).fetchone()
+    if tables and tables.get("video_courses") is not None:
+        conn.execute("DELETE FROM video_courses WHERE user_id = %s", (user_id,))
+        return
+    if tables and tables.get("video_groups") is not None:
+        conn.execute("DELETE FROM video_groups WHERE user_id = %s", (user_id,))
+        return
+    raise RuntimeError("Neither video_courses nor video_groups exists")
 
 
 def _delete_tags_for_user(conn, user_id: str) -> None:
@@ -60,7 +73,7 @@ def delete_account_data(user_id: str) -> None:
     steps = [
         ("delete_all_videos_for_user", _delete_all_videos_for_user),
         ("delete_chat_history_for_user", _delete_chat_history_for_user),
-        ("delete_video_courses_for_user", _delete_video_courses_for_user),
+        ("delete_owned_courses_for_user", _delete_owned_courses_for_user),
         ("delete_tags_for_user", _delete_tags_for_user),
         ("delete_remaining_vectors_for_user", _delete_remaining_vectors_for_user),
         ("delete_user_row", _delete_user_row),


### PR DESCRIPTION
## 概要
- 講座テーブルのリネーム前後どちらでもアカウント削除を実行できるようにする
- DB migrationを含む変更ではPython workerも再配備し、schema contractのずれを防ぐ
- 新旧テーブルと欠損時の回帰テストを追加する

## 確認
- apps/worker: 71 passed, 2 skipped