### PR TITLE
Render TeX in chat answers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "i18next": "^24.2.0",
+        "katex": "^0.18.4",
         "lucide-react": "^0.560.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -4823,6 +4824,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6348,6 +6358,22 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.4.tgz",
+      "integrity": "sha512-IMPntbRLOU+eu88XDiFKqQ8Akhr9Tv7jDMXqPhjG9SI1JMA4DIgXk4x9k4skJz2NZJXBRbC+2pYBLj9olqcZow==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "i18next": "^24.2.0",
+    "katex": "^0.18.4",
     "lucide-react": "^0.560.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/components/chat/MessageBody.tsx
+++ b/frontend/src/components/chat/MessageBody.tsx
@@ -1,7 +1,10 @@
 import { Fragment } from 'react';
+import katex from 'katex';
 import type { Citation } from '@/lib/api';
+import { parseMessageContent } from '@/lib/chat/parseMessageContent';
 import { linkVariants } from '@/components/ui/link';
 import { cn } from '@/lib/digital-agency/cn';
+import 'katex/dist/katex.min.css';
 
 interface MessageBodyProps {
   content: string;
@@ -22,38 +25,36 @@ function formatTimeRange(startTime: string | undefined, endTime: string | undefi
   return start || end;
 }
 
+function renderMath(tex: string, display: boolean): string {
+  return katex.renderToString(tex, {
+    displayMode: display,
+    throwOnError: false,
+    trust: false,
+  });
+}
+
 export function MessageBody({ content, citations, onVideoNavigate }: MessageBodyProps) {
-  const tagPattern = /\[(\d+)\]/g;
-  const nodes: Array<
-    | { type: 'text'; value: string }
-    | { type: 'ref'; id: number }
-  > = [];
-  let lastIndex = 0;
-
-  for (const match of content.matchAll(tagPattern)) {
-    const id = Number(match[1]);
-    const start = match.index ?? 0;
-
-    if (start > lastIndex) {
-      nodes.push({ type: 'text', value: content.slice(lastIndex, start) });
-    }
-
-    nodes.push({ type: 'ref', id });
-    lastIndex = start + match[0].length;
-  }
-
-  if (lastIndex < content.length) {
-    nodes.push({ type: 'text', value: content.slice(lastIndex) });
-  }
-
-  const normalizedNodes = nodes.length > 0 ? nodes : [{ type: 'text' as const, value: content }];
+  const nodes = parseMessageContent(content);
   const citationMap = new Map((citations ?? []).map((citation) => [citation.id, citation]));
 
   return (
     <div className="text-solid-gray-700 leading-relaxed whitespace-pre-wrap">
-      {normalizedNodes.map((node, i) => {
+      {nodes.map((node, i) => {
         if (node.type === 'text') {
           return <Fragment key={`text-${i}`}>{node.value}</Fragment>;
+        }
+
+        if (node.type === 'math') {
+          return (
+            <span
+              key={`math-${i}`}
+              className={cn(
+                'whitespace-normal',
+                node.display && 'my-3 block overflow-x-auto text-center',
+              )}
+              dangerouslySetInnerHTML={{ __html: renderMath(node.value, node.display) }}
+            />
+          );
         }
 
         const video = citationMap.get(node.id);

--- a/frontend/src/components/chat/__tests__/MessageBody.test.tsx
+++ b/frontend/src/components/chat/__tests__/MessageBody.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { MessageBody } from '../MessageBody'
+
+const ROTATION_MATRIX = String.raw`\begin{pmatrix}
+\cos\theta & -\sin\theta \\
+\sin\theta & \cos\theta
+\end{pmatrix}`
+
+describe('MessageBody', () => {
+  it('renders display TeX instead of the raw delimiters', () => {
+    const content = `回転行列は次の形になります。\n\n\\[\n${ROTATION_MATRIX}\n\\]\n\nこの行列を使います。[1]`
+
+    const { container } = render(
+      <MessageBody
+        content={content}
+        citations={[{ id: 1, video_id: 7, title: '線形代数', start_time: '00:21:37', end_time: '00:22:20' }]}
+        onVideoNavigate={vi.fn()}
+      />,
+    )
+
+    expect(container.querySelector('.katex-display')).toBeInTheDocument()
+    expect(container.querySelector('.katex-html')?.textContent).toContain('cos')
+    expect(container.querySelector('annotation')?.textContent).toContain('pmatrix')
+    expect(container.querySelector('.katex-html')?.textContent).not.toContain('\\[')
+    expect(screen.getByRole('button', { name: '線形代数 00:21:37' })).toHaveTextContent('(21:37-22:20)')
+    expect(screen.getByText(/回転行列は次の形になります/)).toBeInTheDocument()
+  })
+
+  it('renders inline TeX in the surrounding sentence', () => {
+    const { container } = render(
+      <MessageBody content={'辺の長さは \\(a\\) です。'} onVideoNavigate={vi.fn()} />,
+    )
+
+    expect(container.querySelector('.katex')).toBeInTheDocument()
+    expect(container.textContent).toContain('辺の長さは')
+    expect(container.textContent).toContain('です。')
+    expect(container.textContent).not.toContain('\\(a\\)')
+  })
+})

--- a/frontend/src/lib/chat/__tests__/parseMessageContent.test.ts
+++ b/frontend/src/lib/chat/__tests__/parseMessageContent.test.ts
@@ -47,4 +47,23 @@ describe('parseMessageContent', () => {
       { type: 'text', value: '途中まで \\[ a^2' },
     ])
   })
+
+  it('keeps later TeX when a lone $ is not a closed formula', () => {
+    expect(parseMessageContent('PATH は $PATH です。\n\n\\[ x = 1 \\]')).toEqual([
+      { type: 'text', value: 'PATH は $PATH です。\n\n' },
+      { type: 'math', value: ' x = 1 ', display: true },
+    ])
+    expect(parseMessageContent('コストは $ 程度。そのあと \\(a\\) です。')).toEqual([
+      { type: 'text', value: 'コストは $ 程度。そのあと ' },
+      { type: 'math', value: 'a', display: false },
+      { type: 'text', value: ' です。' },
+    ])
+  })
+
+  it('does not let a stray $ consume a later $$ block', () => {
+    expect(parseMessageContent('Let $ and then $$a^2$$')).toEqual([
+      { type: 'text', value: 'Let $ and then ' },
+      { type: 'math', value: 'a^2', display: true },
+    ])
+  })
 })

--- a/frontend/src/lib/chat/__tests__/parseMessageContent.test.ts
+++ b/frontend/src/lib/chat/__tests__/parseMessageContent.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { parseMessageContent } from '../parseMessageContent'
+
+const ROTATION_MATRIX = String.raw`\begin{pmatrix}
+\cos\theta & -\sin\theta \\
+\sin\theta & \cos\theta
+\end{pmatrix}`
+
+describe('parseMessageContent', () => {
+  it('keeps plain text unchanged', () => {
+    expect(parseMessageContent('回転行列の説明です。')).toEqual([
+      { type: 'text', value: '回転行列の説明です。' },
+    ])
+  })
+
+  it('extracts display math wrapped in \\[ \\]', () => {
+    const content = `回転行列は次の形になります。\n\n\\[\n${ROTATION_MATRIX}\n\\]\n\nこの行列を使います。[1]`
+
+    expect(parseMessageContent(content)).toEqual([
+      { type: 'text', value: '回転行列は次の形になります。\n\n' },
+      { type: 'math', value: `\n${ROTATION_MATRIX}\n`, display: true },
+      { type: 'text', value: '\n\nこの行列を使います。' },
+      { type: 'ref', id: 1 },
+    ])
+  })
+
+  it('extracts $$ display math and \\( \\) inline math', () => {
+    expect(parseMessageContent('面積は $$a^{2}$$ で、辺は \\(a\\) です。')).toEqual([
+      { type: 'text', value: '面積は ' },
+      { type: 'math', value: 'a^{2}', display: true },
+      { type: 'text', value: ' で、辺は ' },
+      { type: 'math', value: 'a', display: false },
+      { type: 'text', value: ' です。' },
+    ])
+  })
+
+  it('extracts $inline$ math without treating currency as math', () => {
+    expect(parseMessageContent('コストは $100 で、$x$ を求めます。')).toEqual([
+      { type: 'text', value: 'コストは $100 で、' },
+      { type: 'math', value: 'x', display: false },
+      { type: 'text', value: ' を求めます。' },
+    ])
+  })
+
+  it('leaves unclosed math as text so streaming replies stay readable', () => {
+    expect(parseMessageContent('途中まで \\[ a^2')).toEqual([
+      { type: 'text', value: '途中まで \\[ a^2' },
+    ])
+  })
+})

--- a/frontend/src/lib/chat/parseMessageContent.ts
+++ b/frontend/src/lib/chat/parseMessageContent.ts
@@ -1,0 +1,152 @@
+export type MessageContentNode =
+  | { type: 'text'; value: string }
+  | { type: 'ref'; id: number }
+  | { type: 'math'; value: string; display: boolean };
+
+type MathDelimiter = {
+  left: string;
+  right: string;
+  display: boolean;
+};
+
+const MATH_DELIMITERS: MathDelimiter[] = [
+  { left: '$$', right: '$$', display: true },
+  { left: '\\[', right: '\\]', display: true },
+  { left: '\\(', right: '\\)', display: false },
+];
+
+const REF_PATTERN = /\[(\d+)\]/g;
+
+function findMathEnd(delimiter: string, text: string, startIndex: number): number {
+  let index = startIndex;
+  let braceLevel = 0;
+
+  while (index < text.length) {
+    const character = text[index];
+    if (braceLevel <= 0 && text.startsWith(delimiter, index)) {
+      return index;
+    }
+    if (character === '\\') {
+      index += 2;
+      continue;
+    }
+    if (character === '{') braceLevel += 1;
+    if (character === '}') braceLevel -= 1;
+    index += 1;
+  }
+
+  return -1;
+}
+
+function findInlineDollarEnd(text: string, startIndex: number): number {
+  const end = text.indexOf('$', startIndex);
+  if (end === -1) return -1;
+
+  const body = text.slice(startIndex, end);
+  if (!body || body.includes('\n')) return -1;
+  if (/[A-Za-z0-9]/.test(text[end + 1] ?? '')) return -1;
+
+  return end;
+}
+
+function splitMath(content: string): Array<Extract<MessageContentNode, { type: 'text' | 'math' }>> {
+  const nodes: Array<Extract<MessageContentNode, { type: 'text' | 'math' }>> = [];
+  let remaining = content;
+
+  while (remaining.length > 0) {
+    let nextIndex = -1;
+    let nextDelim: MathDelimiter | 'dollar' | null = null;
+
+    for (const delim of MATH_DELIMITERS) {
+      const index = remaining.indexOf(delim.left);
+      if (index !== -1 && (nextIndex === -1 || index < nextIndex)) {
+        nextIndex = index;
+        nextDelim = delim;
+      }
+    }
+
+    const dollarIndex = remaining.search(/(?<![A-Za-z0-9\\])\$(?!\d)/);
+    if (dollarIndex !== -1 && (nextIndex === -1 || dollarIndex < nextIndex)) {
+      nextIndex = dollarIndex;
+      nextDelim = 'dollar';
+    }
+
+    if (nextIndex === -1 || nextDelim === null) {
+      nodes.push({ type: 'text', value: remaining });
+      break;
+    }
+
+    if (nextIndex > 0) {
+      nodes.push({ type: 'text', value: remaining.slice(0, nextIndex) });
+      remaining = remaining.slice(nextIndex);
+    }
+
+    if (nextDelim === 'dollar') {
+      const end = findInlineDollarEnd(remaining, 1);
+      if (end === -1) {
+        nodes.push({ type: 'text', value: remaining });
+        break;
+      }
+      nodes.push({ type: 'math', value: remaining.slice(1, end), display: false });
+      remaining = remaining.slice(end + 1);
+      continue;
+    }
+
+    const end = findMathEnd(nextDelim.right, remaining, nextDelim.left.length);
+    if (end === -1) {
+      nodes.push({ type: 'text', value: remaining });
+      break;
+    }
+
+    nodes.push({
+      type: 'math',
+      value: remaining.slice(nextDelim.left.length, end),
+      display: nextDelim.display,
+    });
+    remaining = remaining.slice(end + nextDelim.right.length);
+  }
+
+  return nodes;
+}
+
+function splitRefs(value: string): Array<Extract<MessageContentNode, { type: 'text' | 'ref' }>> {
+  const nodes: Array<Extract<MessageContentNode, { type: 'text' | 'ref' }>> = [];
+  let lastIndex = 0;
+
+  for (const match of value.matchAll(REF_PATTERN)) {
+    const id = Number(match[1]);
+    const start = match.index ?? 0;
+    if (start > lastIndex) {
+      nodes.push({ type: 'text', value: value.slice(lastIndex, start) });
+    }
+    nodes.push({ type: 'ref', id });
+    lastIndex = start + match[0].length;
+  }
+
+  if (lastIndex < value.length) {
+    nodes.push({ type: 'text', value: value.slice(lastIndex) });
+  }
+
+  return nodes;
+}
+
+function mergeAdjacentText(nodes: MessageContentNode[]): MessageContentNode[] {
+  const merged: MessageContentNode[] = [];
+  for (const node of nodes) {
+    const last = merged[merged.length - 1];
+    if (node.type === 'text' && last?.type === 'text') {
+      last.value += node.value;
+      continue;
+    }
+    merged.push(node);
+  }
+  return merged;
+}
+
+export function parseMessageContent(content: string): MessageContentNode[] {
+  return mergeAdjacentText(
+    splitMath(content).flatMap((node): MessageContentNode[] =>
+      node.type === 'text' ? splitRefs(node.value) : [node],
+    ),
+  );
+}

--- a/frontend/src/lib/chat/parseMessageContent.ts
+++ b/frontend/src/lib/chat/parseMessageContent.ts
@@ -44,6 +44,7 @@ function findInlineDollarEnd(text: string, startIndex: number): number {
 
   const body = text.slice(startIndex, end);
   if (!body || body.includes('\n')) return -1;
+  if (text[end + 1] === '$') return -1;
   if (/[A-Za-z0-9]/.test(text[end + 1] ?? '')) return -1;
 
   return end;
@@ -84,8 +85,9 @@ function splitMath(content: string): Array<Extract<MessageContentNode, { type: '
     if (nextDelim === 'dollar') {
       const end = findInlineDollarEnd(remaining, 1);
       if (end === -1) {
-        nodes.push({ type: 'text', value: remaining });
-        break;
+        nodes.push({ type: 'text', value: remaining.slice(0, 1) });
+        remaining = remaining.slice(1);
+        continue;
       }
       nodes.push({ type: 'math', value: remaining.slice(1, end), display: false });
       remaining = remaining.slice(end + 1);
@@ -94,8 +96,9 @@ function splitMath(content: string): Array<Extract<MessageContentNode, { type: '
 
     const end = findMathEnd(nextDelim.right, remaining, nextDelim.left.length);
     if (end === -1) {
-      nodes.push({ type: 'text', value: remaining });
-      break;
+      nodes.push({ type: 'text', value: remaining.slice(0, nextDelim.left.length) });
+      remaining = remaining.slice(nextDelim.left.length);
+      continue;
     }
 
     nodes.push({


### PR DESCRIPTION
## Summary
- Chat answers now render TeX/LaTeX (for example `\[ pmatrix \]`) with KaTeX instead of showing raw source.
- Citation markers such as `[1]` still become seekable time ranges after the formula.
- Incomplete math during streaming stays visible as text until the closing delimiter arrives.

## Test plan
- [ ] Ask a course chat question that produces a display matrix (`\[ \begin{pmatrix} ... \end{pmatrix} \]`) and confirm it renders as a formula, not TeX source.
- [ ] Confirm inline math (`\(a\)` / `$x$`) stays in the sentence, and `$100` is not treated as math.
- [ ] Confirm citation chips after a formula still jump to the cited scene.
- [ ] Confirm a streaming reply with an unclosed `\[` stays readable until the closer arrives.


Made with [Cursor](https://cursor.com)