### PR TITLE
Fix course reorder matching PATCH /courses/{id} as id=order

### DIFF
--- a/apps/api/src/features/courses/routes.ts
+++ b/apps/api/src/features/courses/routes.ts
@@ -148,6 +148,36 @@ courseRoutes.openapi(createCourseRoute, async (c) => {
   return c.json(course, 201);
 });
 
+// Static `/courses/order` must be registered before `/courses/{id}` so
+// PATCH .../order is not coerced as id="order" → NaN.
+const reorderRoute = createRoute({
+  method: "patch",
+  path: "/courses/order",
+  tags: ["Courses"],
+  summary: "Reorder courses",
+  middleware: [...courseWriteGuards] as const,
+  request: {
+    body: {
+      content: { "application/json": { schema: reorderCoursesSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: jsonResponse(z.object({ message: z.string() })),
+    400: errorResponse("Bad request"),
+  },
+});
+
+courseRoutes.openapi(reorderRoute, async (c) => {
+  const userId = c.var.userId!;
+  const { course_ids } = c.req.valid("json");
+  const res = await courseService.reorderUserCourses(c.env, userId, course_ids);
+  if ("mismatch" in res) {
+    throw apiBadRequest("Specified course IDs do not match user courses");
+  }
+  return c.json({ message: "Course order updated" }, 200);
+});
+
 const patchCourseRoute = createRoute({
   method: "patch",
   path: "/courses/{id}",
@@ -226,34 +256,6 @@ courseRoutes.openapi(deleteCourseRoute, async (c) => {
   const res = await courseService.removeCourse(c.env, id, userId);
   if ("notFound" in res) throw apiNotFound("Course not found");
   return c.body(null, 204);
-});
-
-const reorderRoute = createRoute({
-  method: "patch",
-  path: "/courses/order",
-  tags: ["Courses"],
-  summary: "Reorder courses",
-  middleware: [...courseWriteGuards] as const,
-  request: {
-    body: {
-      content: { "application/json": { schema: reorderCoursesSchema } },
-      required: true,
-    },
-  },
-  responses: {
-    200: jsonResponse(z.object({ message: z.string() })),
-    400: errorResponse("Bad request"),
-  },
-});
-
-courseRoutes.openapi(reorderRoute, async (c) => {
-  const userId = c.var.userId!;
-  const { course_ids } = c.req.valid("json");
-  const res = await courseService.reorderUserCourses(c.env, userId, course_ids);
-  if ("mismatch" in res) {
-    throw apiBadRequest("Specified course IDs do not match user courses");
-  }
-  return c.json({ message: "Course order updated" }, 200);
 });
 
 const createShareRoute = createRoute({

--- a/apps/api/test/videos-route-order.test.ts
+++ b/apps/api/test/videos-route-order.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../src/app";
-import { signAccessToken } from "./helpers/auth";
+import { TEST_USER_ID, signAccessToken, testAuthHeaders } from "./helpers/auth";
+import * as courseService from "../src/features/courses/service";
 
 const SECRET = "route-order-secret";
 
@@ -16,6 +17,7 @@ vi.mock("../src/repositories/auth-repository", () => ({
 
 vi.mock("../src/features/courses/service", () => ({
   listCourses: vi.fn(async () => ({ count: 0, results: [] })),
+  reorderUserCourses: vi.fn(async () => ({ ok: true })),
 }));
 
 describe("GET /api/videos/courses route order", () => {
@@ -40,5 +42,35 @@ describe("GET /api/videos/courses route order", () => {
       data: [],
       meta: { total: 0 },
     });
+  });
+});
+
+describe("PATCH /api/videos/courses/order route order", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not treat 'order' as a course id (NaN validation)", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/api/videos/courses/order",
+      {
+        method: "PATCH",
+        headers: {
+          ...testAuthHeaders(),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ course_ids: [2, 1] }),
+      },
+      ENV,
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ message: "Course order updated" });
+    expect(courseService.reorderUserCourses).toHaveBeenCalledWith(
+      ENV,
+      TEST_USER_ID,
+      [2, 1],
+    );
   });
 });


### PR DESCRIPTION
## Summary
- `PATCH /api/videos/courses/order` was matching `PATCH /courses/{id}` with `id="order"`, so `z.coerce.number()` produced NaN and reordering failed.
- Register the static `/courses/order` route before `/courses/{id}`.
- Add a regression test that the reorder handler runs and `reorderUserCourses` receives the submitted ids.

Split from #863 so this PR contains only the reorder fix. Chat TeX rendering is already on main via #862.

## Test plan
- [ ] Own two or more courses, drag or use the up/down buttons, and confirm the new order saves without `Invalid input: expected number, received NaN`.
- [ ] Confirm `PATCH /api/videos/courses/:id` still updates a course name/description.
- [ ] Run `npm test -- test/videos-route-order.test.ts` in `apps/api`.


Made with [Cursor](https://cursor.com)