### PR TITLE
Import existing Lambda log group with Terraform

### DIFF
--- a/infra/DEPLOY.md
+++ b/infra/DEPLOY.md
@@ -195,12 +195,8 @@ GitHub Actionsは固定AWS access keyではなく、plan / deployを分離した
 `AWS_GITHUB_ACTIONS_DEPLOY_ROLE_ARN`）は[`iam/README.md`](iam/README.md)を参照してください。
 
 既存Lambdaが一度でも動作済みなら、CloudWatch Logs groupはAWSが先に作成しています。
-最初のmonitoring apply前に一度だけstateへimportします。
-
-```bash
-cd infra
-terraform import aws_cloudwatch_log_group.worker /aws/lambda/videoq-worker-prod
-```
+`monitoring.tf`の宣言的な`import`ブロックが最初のapplyで既存groupをstateへ取り込み、
+以後は通常のTerraformリソースとして管理します。
 
 `operations_alert_email`を設定すると、Lambda error / throttle / 長時間実行、SQS滞留、
 DLQ到達をSNS emailで通知します。apply後にAWSから届くsubscription確認メールを承認して

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -10,8 +10,13 @@ resource "aws_sns_topic_subscription" "operations_email" {
   endpoint  = var.operations_alert_email
 }
 
-# Lambda creates this group implicitly on first invocation. Existing production
-# installations must import it once before the first apply; see DEPLOY.md.
+# Lambda creates this group implicitly on first invocation. Declarative import
+# adopts an existing group on the first apply and is a no-op once it is managed.
+import {
+  to = aws_cloudwatch_log_group.worker
+  id = "/aws/lambda/${local.names.worker}"
+}
+
 resource "aws_cloudwatch_log_group" "worker" {
   name              = "/aws/lambda/${local.names.worker}"
   retention_in_days = var.lambda_log_retention_days


### PR DESCRIPTION
## Summary

- declaratively import the Lambda-created CloudWatch Log Group on the first apply
- keep the import ID environment-aware through `local.names.worker`
- update the deployment guide to match the automated migration

## Why

Terraform Apply #18 failed because `/aws/lambda/videoq-worker-prod` already exists outside state. The import block adopts it before Terraform manages retention and alarms.

## Verification

- `terraform fmt -check`
- `terraform validate`
- `git diff --check`