### PR TITLE
Allow CloudWatch log group tag discovery

### DIFF
--- a/infra/iam/videoq-terraform-deploy.json
+++ b/infra/iam/videoq-terraform-deploy.json
@@ -164,7 +164,10 @@
         "logs:TagResource",
         "logs:UntagResource"
       ],
-      "Resource": "arn:aws:logs:ap-northeast-1:<ACCOUNT_ID>:log-group:/aws/lambda/videoq-worker-prod:*"
+      "Resource": [
+        "arn:aws:logs:ap-northeast-1:<ACCOUNT_ID>:log-group:/aws/lambda/videoq-worker-prod",
+        "arn:aws:logs:ap-northeast-1:<ACCOUNT_ID>:log-group:/aws/lambda/videoq-worker-prod:*"
+      ]
     },
     {
       "Sid": "OperationsTopicManage",


### PR DESCRIPTION
## Summary

- allow CloudWatch Logs management against both the Log Group ARN and its child ARN form
- keep the repository policy identical to the active AWS policy

## Why

Terraform needs the base Log Group ARN for `logs:ListTagsForResource`. The previous wildcard-only resource matched streams but not the group itself.

## Verification

- policy JSON parses with `jq`
- account-rendered repository policy matches the active policy document
- Terraform Apply #19 rerun succeeded with the updated policy