### PR TITLE
fix(trpc): 出力の実行時検証とタグ色の型制約を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           npm ci
           npm run cf-typegen:check --workspace @videoq/api
+          npm run typecheck --workspace @videoq/trpc
           npm run typecheck --workspace @videoq/api
           npm run db:check --workspace @videoq/api
           npm run db:verify --workspace @videoq/api

--- a/apps/api/test/trpc.test.ts
+++ b/apps/api/test/trpc.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TEST_USER_ID, testAuthHeaders } from "./helpers/auth";
+import { TAG_COLORS } from "@videoq/trpc/schema";
 
 const tagService = vi.hoisted(() => ({
   listTags: vi.fn(),
@@ -104,6 +105,110 @@ describe("tRPC Hono adapter", () => {
     expect(response.status).toBe(400);
     expect(errorLog).not.toHaveBeenCalled();
   });
+
+  it.each(["tags.create", "tags.update", "tags.replace"])(
+    "rejects colors outside the shared palette before calling the service: %s",
+    async (procedure) => {
+      for (const color of ["not-a-color", "#3b82f6", ""]) {
+        const response = await createApp().request(`/api/trpc/${procedure}`, {
+          method: "POST",
+          headers: { ...testAuthHeaders(), "content-type": "application/json" },
+          body: JSON.stringify({ id: 3, name: "Lecture", color }),
+        }, ENV);
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toMatchObject({
+          error: { data: {
+            code: "BAD_REQUEST",
+            applicationCode: "VALIDATION_ERROR",
+            details: { color: [expect.any(String)] },
+          } },
+        });
+      }
+      expect(tagService.createUserTag).not.toHaveBeenCalled();
+      expect(tagService.updateUserTag).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(TAG_COLORS)("accepts the shared palette color %s", async (color) => {
+    tagService.createUserTag.mockResolvedValue({ tag: { ...sampleTag, color } });
+    const response = await createApp().request("/api/trpc/tags.create", {
+      method: "POST",
+      headers: { ...testAuthHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({ name: "Lecture", color }),
+    }, ENV);
+
+    expect(response.status).toBe(200);
+    expect(tagService.createUserTag).toHaveBeenCalledWith(ENV, TEST_USER_ID, "Lecture", color);
+  });
+
+  it("allows a name-only update of a tag with a legacy hex color", async () => {
+    const tag = { ...sampleTag, name: "Updated", color: "#3b82f6" };
+    tagService.updateUserTag.mockResolvedValue({ tag });
+    const response = await createApp().request("/api/trpc/tags.update", {
+      method: "POST",
+      headers: { ...testAuthHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({ id: tag.id, name: tag.name }),
+    }, ENV);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ result: { data: tag } });
+    expect(tagService.updateUserTag).toHaveBeenCalledWith(ENV, tag.id, TEST_USER_ID, {
+      name: tag.name, color: undefined,
+    });
+  });
+
+  it("returns only declared output fields, including in nested lists", async () => {
+    tagService.listTags.mockResolvedValue({
+      count: 1,
+      results: [{ ...sampleTag, internal_secret: "private-service-value" }],
+    });
+    const response = await createApp().request("/api/trpc/tags.list", {
+      headers: testAuthHeaders(),
+    }, ENV);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ result: { data: {
+      data: [sampleTag],
+      meta: { total: 1, limit: 100, offset: 0 },
+    } } });
+  });
+
+  it.each(["query", "mutation"])(
+    "reports malformed %s outputs as internal errors without exposing validation details",
+    async (kind) => {
+      const privateValue = "private-user@example.test";
+      const invalidTag = { ...sampleTag, video_count: privateValue };
+      tagService.listTags.mockResolvedValue({ count: 1, results: [invalidTag] });
+      tagService.createUserTag.mockResolvedValue({ tag: invalidTag });
+      const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const response = await createApp().request(
+        `/api/trpc/${kind === "query" ? "tags.list" : "tags.create"}`,
+        kind === "query"
+          ? { headers: testAuthHeaders() }
+          : {
+              method: "POST",
+              headers: { ...testAuthHeaders(), "content-type": "application/json" },
+              body: JSON.stringify({ name: "Lecture" }),
+            },
+        ENV,
+      );
+
+      expect(response.status).toBe(500);
+      const payload = await response.json();
+      expect(payload).toMatchObject({ error: {
+        message: "An internal server error occurred.",
+        data: { code: "INTERNAL_SERVER_ERROR" },
+      } });
+      const serialized = JSON.stringify(payload);
+      expect(serialized).not.toContain("VALIDATION_ERROR");
+      expect(serialized).not.toContain('"details"');
+      expect(serialized).not.toContain("video_count");
+      expect(serialized).not.toContain(privateValue);
+      expect(errorLog).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(errorLog.mock.calls)).not.toContain(privateValue);
+    },
+  );
 
   it("serves a typed tag query through /api/trpc", async () => {
     tagService.listTags.mockResolvedValue({

--- a/docs/architecture/trpc-api.md
+++ b/docs/architecture/trpc-api.md
@@ -23,10 +23,12 @@ flowchart LR
 packages/trpc/
 ├── src/init.ts          tRPC 初期化、認証・権限 middleware、error formatter
 ├── src/inputs/          Zod input（validation と handler 入力型の定義元）
+├── src/outputs.ts       Zod output（validation と handler 出力型の定義元）
+├── src/model-schemas.ts 共有 DTO の出力検証スキーマ
 ├── src/routers/         domain router と procedure の接続
 ├── src/router.ts        AppRouter の合成
-├── src/contracts.ts     Zod から導出する入力 map と handler の出力契約
-├── src/models.ts        API / SPA 共有 DTO
+├── src/contracts.ts     Zod から導出する入出力 map と handler 契約
+├── src/models.ts        出力スキーマから導出する API / SPA 共有 DTO
 ├── src/context.ts       framework 非依存の request context
 └── src/schema.ts        runtime 共有定数
 
@@ -46,6 +48,12 @@ apps/web/src/lib/
 入力スキーマは `src/inputs/` に一度だけ定義します。procedure の `.input()` と
 `RpcInputMap` が同じスキーマを参照し、handler には `z.output` で default / transform
 適用後の型を渡します。SPA の呼び出し側の型は引き続き `AppRouter` から推論します。
+
+出力スキーマは `src/outputs.ts` に全 procedure 分を定義します。`.output()` と
+`RpcOutputMap` が同じスキーマを使い、共有 DTO も `src/model-schemas.ts` と
+`src/schema.ts` から導出します。出力検証では必須項目・型を確認し、未定義フィールドを
+除去します。タグの書き込みは `tagColorSchema` でパレット名に制限しますが、出力では
+旧 hex 色の保存データも受け入れます。
 
 ## React とキャッシュ
 
@@ -80,13 +88,17 @@ HTTP protocol または payload transport 自体に意味があるものだけ r
 - chat history CSV export
 
 新しい通常 JSON 操作は `packages/trpc/src/inputs` に入力スキーマを定義し、
-`packages/trpc/src/routers` と `apps/api/src/trpc/handlers` に procedure を追加します。
+`packages/trpc/src/outputs.ts` に出力スキーマを定義します。
+`packages/trpc/src/routers` で `.input()` / `.output()` を接続し、
+`apps/api/src/trpc/handlers` に実装を追加します。
 
 ## Error contract
 
 tRPC の標準 error code / HTTP status に加え、既存 UI が判断に使う
 `applicationCode` と field validation の `details` を error data に保持します。
 内部エラーの message は公開時に固定文へ置き換えます。
+出力検証の失敗も `INTERNAL_SERVER_ERROR` とし、入力の `VALIDATION_ERROR` と区別します。
+出力検証エラーには `applicationCode` や検証の `details` を付けません。
 
 SPA は tRPC 標準の `TRPCClientError` をそのまま受け取り、画面で application code や
 details が必要な場合は `getApiError()` を使います。認証切れは link で procedure ごとに

--- a/packages/trpc/README.md
+++ b/packages/trpc/README.md
@@ -6,10 +6,12 @@ Hono API と React SPA が共有する tRPC 契約です。通常の JSON API �
 
 - `src/init.ts`: tRPC の初期化、認証・権限 middleware、共通 error shape
 - `src/inputs/`: 機能単位の Zod input validation（入力型の定義元）
-- `src/routers/`: 入力スキーマ、認証・権限、query / mutation の接続
+- `src/outputs.ts`: 全 procedure の出力スキーマ（出力型の定義元）
+- `src/model-schemas.ts`: 共有 DTO の出力検証スキーマ
+- `src/routers/`: 入出力スキーマ、認証・権限、query / mutation の接続
 - `src/router.ts`: 各 feature router を束ねる app router
 - `src/contracts.ts`: API adapter が実装する procedure の入出力契約
-- `src/models.ts`: API と SPA で共有する DTO 型
+- `src/models.ts`: 出力スキーマから導出する API / SPA 共有 DTO 型
 - `src/context.ts`: Hono adapter から注入する request context
 - `src/schema.ts`: UI でも利用する runtime 定数
 
@@ -19,6 +21,14 @@ bundle しません。
 
 `RpcInputMap` は入力スキーマの `z.output` から導出し、handler は default / transform
 適用後の値を受け取ります。入力構造を別の interface に再定義しません。
+
+`RpcOutputMap` と共有 DTO も出力スキーマから導出します。全 procedure の `.output()`
+で戻り値を検証し、未定義フィールドを除去します。出力検証の失敗は固定メッセージの
+`INTERNAL_SERVER_ERROR` とし、入力検証エラーの詳細としてクライアントに公開しません。
+
+タグの作成・更新・置換は共通の `tagColorSchema` でパレット名を検証します。
+出力の色は保存済みの旧 hex 形式も読み取れるよう `string` としています。
+`npm run typecheck` は `type-tests/` の入力型・handler 出力型の回帰チェックも実行します。
 
 React の通常の JSON query / mutation は `@trpc/tanstack-react-query` の
 `trpc.*.queryOptions()` / `mutationOptions()` と TanStack Query の hooks を利用します。

--- a/packages/trpc/src/contracts.ts
+++ b/packages/trpc/src/contracts.ts
@@ -1,127 +1,18 @@
 import type { z } from "zod";
 import type { inputSchemas } from "./inputs";
-import type {
-  AdminUser,
-  BillingPlan,
-  ChatAnalytics,
-  ChatHistoryItem,
-  ChatLogEvaluation,
-  ChatMessage,
-  Course,
-  CourseListItem,
-  CourseInvitationDeliveryStatus,
-  CourseInvitationPreview,
-  CourseInviteRecipientResult,
-  CoursePage,
-  CourseParticipants,
-  EvaluationSummary,
-  Page,
-  PlogConcept,
-  PlogEdge,
-  PlogGraph,
-  PlogLearnerState,
-  Tag,
-  TagDetail,
-  TagPage,
-  UploadRequestResponse,
-  User,
-  Video,
-  VideoListItem,
-  VideoStatusCounts,
-} from "./models";
+import type { outputSchemas, successSchema } from "./outputs";
 
-export type Success = { success: true };
+export type Success = z.output<typeof successSchema>;
 
 /** Handlers receive validated inputs, including Zod defaults and transforms. */
 export type RpcInputMap = {
   [Name in keyof typeof inputSchemas]: z.output<(typeof inputSchemas)[Name]>;
 };
 
-export interface RpcOutputMap {
-  "account.me": User;
-  "account.searchApiKeyStatus": { has_api_key: boolean };
-  "account.saveSearchApiKey": Success;
-  "account.deleteSearchApiKey": Success;
-
-  "admin.listUsers": Page<AdminUser>;
-  "admin.getUser": AdminUser;
-  "admin.patchQuota": AdminUser;
-  "admin.patchUsage": AdminUser;
-  "admin.patchFlags": AdminUser;
-  "admin.deleteUser": { job_id: string };
-  "admin.reindexAll": { job_id: string };
-
-  "billing.plans": BillingPlan[];
-  "billing.checkout": { url: string };
-  "billing.portal": { url: string };
-
-  "chat.send": ChatMessage;
-  "chat.feedback": { chat_log_id: number; feedback: "good" | "bad" | null };
-  "chat.history": Page<ChatHistoryItem>;
-  "chat.resetHistory": Success;
-  "chat.analytics": ChatAnalytics;
-
-  "evaluation.summary": EvaluationSummary;
-  "evaluation.logs": Page<ChatLogEvaluation>;
-
-  "videos.list": Page<VideoListItem>;
-  "videos.statusCounts": VideoStatusCounts;
-  "videos.get": Video;
-  "videos.requestUpload": UploadRequestResponse;
-  "videos.confirmUpload": Video;
-  "videos.createYoutube": Video;
-  "videos.update": Video;
-  "videos.replace": Video;
-  "videos.delete": Success;
-
-  "courses.list": CoursePage;
-  "courses.get": Course;
-  "courses.shared": Course;
-  "courses.create": CourseListItem;
-  "courses.update": Course;
-  "courses.replace": Course;
-  "courses.delete": Success;
-  "courses.reorder": { courseIds: number[] };
-  "courses.createShare": { message: string; share_slug: string };
-  "courses.deleteShare": Success;
-
-  "courseMemberships.invite": { results: CourseInviteRecipientResult[] };
-  "courseMemberships.participants": CourseParticipants;
-  "courseMemberships.preview": CourseInvitationPreview;
-  "courseMemberships.accept": { course_id: number; status: "accepted" };
-  "courseMemberships.decline": { status: "declined" };
-  "courseMemberships.resend": { delivery_status: CourseInvitationDeliveryStatus };
-  "courseMemberships.revoke": Success;
-  "courseMemberships.removeMember": Success;
-  "courseMemberships.leave": Success;
-
-  "memberships.addTags": { message: string; added_count: number; skipped_count: number };
-  "memberships.removeTag": { message: string };
-  "memberships.reorderVideos": { message: string };
-  "memberships.addVideos": { message: string; added_count: number; skipped_count: number };
-  "memberships.addVideo": { message: string; id: number; reused: boolean };
-  "memberships.removeVideo": Success;
-
-  "tags.list": TagPage;
-  "tags.get": TagDetail;
-  "tags.create": Tag;
-  "tags.update": Tag;
-  "tags.replace": Tag;
-  "tags.delete": Success;
-
-  "plog.graph": PlogGraph;
-  "plog.learnerState": { states: PlogLearnerState[] };
-  "plog.resetLearnerState": { deleted: number };
-  "plog.rebuild": { video_id: number; status: string; job_id: number };
-  "plog.createConcept": PlogConcept;
-  "plog.updateConcept": PlogConcept;
-  "plog.deleteConcept": { deleted: true; id: number };
-  "plog.mergeConcepts": PlogConcept;
-  "plog.updateLearningObject": PlogConcept;
-  "plog.createEdge": PlogEdge;
-  "plog.updateEdge": PlogEdge;
-  "plog.deleteEdge": { deleted: true; id: number };
-}
+/** Handler outputs and router validation use the same schema map. */
+export type RpcOutputMap = {
+  [Name in keyof typeof outputSchemas]: z.output<(typeof outputSchemas)[Name]>;
+};
 
 export type ProcedureName = keyof RpcInputMap;
 

--- a/packages/trpc/src/index.ts
+++ b/packages/trpc/src/index.ts
@@ -9,6 +9,7 @@ export {
   VIDEO_STATUSES,
   chatMessageSchema,
   chatMessagesSchema,
+  tagColorSchema,
   videoListItemSchema,
   videoSchema,
   videoSourceTypeSchema,

--- a/packages/trpc/src/init.ts
+++ b/packages/trpc/src/init.ts
@@ -10,15 +10,21 @@ type ApplicationErrorCause = {
 
 export const t = initTRPC.context<TrpcContext>().create({
   errorFormatter({ shape, error }) {
-    const cause = error.cause as ApplicationErrorCause | undefined;
+    const internalError = error.code === "INTERNAL_SERVER_ERROR";
+    // Output validation is a server failure, never a client field error.
+    const outputValidationError = internalError && error.cause instanceof ZodError;
+    const cause = outputValidationError ? undefined : error.cause as ApplicationErrorCause | undefined;
+    const inputValidationError = error.code === "BAD_REQUEST" && error.cause instanceof ZodError
+      ? error.cause
+      : undefined;
     const validationDetails: Record<string, string[]> = {};
-    if (error.cause instanceof ZodError) {
-      for (const issue of error.cause.issues) {
+    if (inputValidationError) {
+      for (const issue of inputValidationError.issues) {
         const field = String(issue.path[0] ?? "input");
         (validationDetails[field] ??= []).push(issue.message);
       }
     }
-    const applicationCode = error.cause instanceof ZodError
+    const applicationCode = inputValidationError
       ? "VALIDATION_ERROR"
       : typeof cause?.appCode === "string"
         ? cause.appCode
@@ -31,10 +37,10 @@ export const t = initTRPC.context<TrpcContext>().create({
 
     return {
       ...shape,
-      message: error.cause instanceof ZodError
-        ? (error.cause.issues[0]?.message ?? "Invalid input")
-        : error.code === "INTERNAL_SERVER_ERROR"
-          ? "An internal server error occurred."
+      message: internalError
+        ? "An internal server error occurred."
+        : inputValidationError
+          ? (inputValidationError.issues[0]?.message ?? "Invalid input")
           : shape.message,
       data: {
         ...shape.data,

--- a/packages/trpc/src/inputs/tags.ts
+++ b/packages/trpc/src/inputs/tags.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { tagColorSchema } from "../schema";
 
 const id = z.number().int().positive();
 
@@ -8,12 +9,12 @@ export const tagsInputSchemas = {
     offset: z.number().int().nonnegative().default(0),
   }).default({ limit: 100, offset: 0 }),
   "tags.get": z.object({ id }),
-  "tags.create": z.object({ name: z.string().min(1).max(50), color: z.string().min(1).default("gray") }),
+  "tags.create": z.object({ name: z.string().min(1).max(50), color: tagColorSchema.default("gray") }),
   "tags.update": z.object({
     id,
     name: z.string().min(1).max(50).optional(),
-    color: z.string().min(1).optional(),
+    color: tagColorSchema.optional(),
   }),
-  "tags.replace": z.object({ id, name: z.string().min(1).max(50), color: z.string().min(1) }),
+  "tags.replace": z.object({ id, name: z.string().min(1).max(50), color: tagColorSchema }),
   "tags.delete": z.object({ id }),
 };

--- a/packages/trpc/src/model-schemas.ts
+++ b/packages/trpc/src/model-schemas.ts
@@ -1,0 +1,266 @@
+import { z } from "zod";
+import { videoListItemSchema, videoSchema } from "./schema";
+
+export const paginationMetaSchema = z.object({
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+});
+
+export function pageSchema<T extends z.ZodType>(item: T) {
+  return z.object({ data: z.array(item), meta: paginationMetaSchema });
+}
+
+export const userSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  email: z.string(),
+  is_superuser: z.boolean().optional(),
+  video_count: z.number(),
+  max_video_upload_size_mb: z.number(),
+  used_storage_bytes: z.number().optional(),
+  storage_limit_bytes: z.number().nullable().optional(),
+  used_processing_seconds: z.number().optional(),
+  processing_limit_seconds: z.number().nullable().optional(),
+  used_ai_answers: z.number().optional(),
+  ai_answers_limit: z.number().nullable().optional(),
+  is_over_quota: z.boolean().optional(),
+  plan_code: z.enum(["free", "basic", "pro"]).optional(),
+  subscription_status: z.string().nullable().optional(),
+  quota_source: z.enum(["plan", "admin"]).optional(),
+});
+
+export const adminUserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  email: z.string(),
+  is_active: z.boolean(),
+  is_staff: z.boolean(),
+  is_superuser: z.boolean(),
+  max_video_upload_size_mb: z.number(),
+  storage_limit_gb: z.number().nullable(),
+  processing_limit_minutes: z.number().nullable(),
+  ai_answers_limit: z.number().nullable(),
+  used_storage_bytes: z.number(),
+  used_processing_seconds: z.number(),
+  used_ai_answers: z.number(),
+  usage_period_start: z.string().nullable(),
+  is_over_quota: z.boolean(),
+  plan_code: z.string().optional(),
+  quota_source: z.enum(["plan", "admin"]).optional(),
+});
+
+export const billingPlanSchema = z.object({
+  code: z.enum(["free", "basic", "pro"]),
+  interval: z.enum(["month", "year"]).nullable(),
+  lookup_key: z.string().nullable(),
+  amount_yen: z.number(),
+  currency: z.literal("jpy"),
+  entitlements: z.object({
+    max_video_upload_size_mb: z.number(),
+    storage_limit_gb: z.number(),
+    processing_limit_minutes: z.number(),
+    ai_answers_limit: z.number(),
+  }),
+});
+
+export const citationSchema = z.object({
+  id: z.number(),
+  video_id: z.number(),
+  title: z.string(),
+  start_time: z.string().nullable(),
+  end_time: z.string().nullable(),
+});
+
+export const chatFeedbackSchema = z.enum(["good", "bad"]).nullable();
+
+export const chatMessageSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.string(),
+  citations: z.array(citationSchema).optional(),
+  chat_log_id: z.number().optional(),
+  feedback: chatFeedbackSchema.optional(),
+});
+
+export const chatLogEvaluationSchema = z.object({
+  chat_log_id: z.number(),
+  status: z.enum(["pending", "completed", "failed"]),
+  faithfulness: z.number().nullable(),
+  answer_relevancy: z.number().nullable(),
+  context_precision: z.number().nullable(),
+  error_message: z.string().nullable(),
+  evaluated_at: z.string().nullable(),
+});
+
+export const chatHistoryItemSchema = z.object({
+  id: z.number(),
+  course: z.number(),
+  asked_by: z.object({ user_id: z.string(), username: z.string(), email: z.string() }).nullable(),
+  question: z.string(),
+  answer: z.string(),
+  citations: z.array(citationSchema).optional(),
+  is_shared_origin: z.boolean(),
+  feedback: chatFeedbackSchema.optional(),
+  created_at: z.string(),
+  evaluation: chatLogEvaluationSchema.optional(),
+});
+
+export const chatAnalyticsSchema = z.object({
+  summary: z.object({
+    total_questions: z.number(),
+    date_range: z.object({
+      first: z.string().nullable().optional(),
+      last: z.string().nullable().optional(),
+    }),
+  }),
+  time_series: z.array(z.object({ date: z.string(), count: z.number() })),
+  feedback: z.object({ good: z.number(), bad: z.number(), none: z.number() }),
+});
+
+export const evaluationSummarySchema = z.object({
+  course_id: z.number(),
+  evaluated_count: z.number(),
+  avg_faithfulness: z.number().nullable(),
+  avg_answer_relevancy: z.number().nullable(),
+  avg_context_precision: z.number().nullable(),
+});
+
+export const videoStatusCountsSchema = z.object({
+  total: z.number(),
+  completed: z.number(),
+  pending: z.number(),
+  processing: z.number(),
+  indexing: z.number(),
+  error: z.number(),
+  uploading: z.number(),
+});
+
+export const uploadRequestResponseSchema = z.object({
+  video: videoSchema,
+  upload_url: z.string(),
+});
+
+export const videoInCourseSchema = videoListItemSchema.omit({ tags: true }).extend({ order: z.number() });
+
+export const courseListItemSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  description: z.string(),
+  display_order: z.number(),
+  created_at: z.string(),
+  video_count: z.number(),
+  access_role: z.enum(["owner", "member"]),
+});
+
+export const courseSchema = courseListItemSchema.extend({
+  updated_at: z.string().optional(),
+  videos: z.array(videoInCourseSchema).optional(),
+  share_slug: z.string().nullable().optional(),
+  access_role: z.enum(["owner", "member", "public"]).optional(),
+});
+
+export const courseInvitationStatusSchema = z.enum(["pending", "accepted", "declined", "expired", "revoked"]);
+export const courseInvitationDeliveryStatusSchema = z.enum(["queued", "sent", "failed"]);
+
+export const courseInviteRecipientResultSchema = z.object({
+  email: z.string(),
+  status: z.enum(["queued", "already_member", "already_invited", "invalid", "duplicate"]),
+  invitation_id: z.number().optional(),
+});
+
+export const courseInvitationListItemSchema = z.object({
+  id: z.number(),
+  email: z.string(),
+  status: courseInvitationStatusSchema,
+  delivery_status: courseInvitationDeliveryStatusSchema,
+  expires_at: z.string(),
+  created_at: z.string(),
+  last_sent_at: z.string().nullable(),
+  send_attempts: z.number(),
+});
+
+export const courseUserMemberSchema = z.object({
+  user_id: z.string(),
+  username: z.string(),
+  email: z.string(),
+  joined_at: z.string(),
+});
+
+export const courseParticipantsSchema = z.object({
+  invitations: z.array(courseInvitationListItemSchema),
+  members: z.array(courseUserMemberSchema),
+});
+
+export const courseInvitationPreviewSchema = z.object({
+  course_id: z.number(),
+  course_name: z.string(),
+  inviter_name: z.string(),
+  email_hint: z.string(),
+  status: courseInvitationStatusSchema,
+  expires_at: z.string(),
+});
+
+export const tagSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  // Existing tags may still use legacy hex colors; writes use tagColorSchema.
+  color: z.string(),
+  created_at: z.string(),
+  video_count: z.number(),
+});
+
+export const tagDetailSchema = tagSchema.extend({ videos: z.array(videoListItemSchema).optional() });
+
+export const plogWaypointSchema = z.object({
+  start_sec: z.number().optional(),
+  end_sec: z.number().optional(),
+  start_time: z.string().optional(),
+  end_time: z.string().optional(),
+  label: z.string().optional(),
+});
+
+export const plogConceptSchema = z.object({
+  id: z.number(),
+  label: z.string(),
+  node_type: z.string(),
+  intro_sec: z.number(),
+  source_quote: z.string(),
+  opening_question: z.string(),
+  hint_ladder: z.array(z.string()),
+  misconceptions: z.array(z.string()),
+  canonical_order: z.array(z.string()),
+  worked_examples: z.array(z.string()),
+  waypoints: z.array(plogWaypointSchema),
+  hint_count: z.number(),
+  waypoint_count: z.number(),
+});
+
+export const plogEdgeSchema = z.object({
+  id: z.number(),
+  source_id: z.number(),
+  source_label: z.string(),
+  target_id: z.number(),
+  target_label: z.string(),
+  edge_type: z.string(),
+  quote: z.string(),
+});
+
+export const plogGraphSchema = z.object({
+  video_id: z.number(),
+  build_status: z.string(),
+  input_tokens: z.number(),
+  output_tokens: z.number(),
+  error_message: z.string(),
+  summary_node_count: z.number(),
+  concepts: z.array(plogConceptSchema),
+  edges: z.array(plogEdgeSchema),
+});
+
+export const plogLearnerStateSchema = z.object({
+  concept_id: z.number(),
+  label: z.string(),
+  reached: z.boolean(),
+  hint_index: z.number(),
+  last_grade: z.string(),
+  active: z.boolean(),
+});

--- a/packages/trpc/src/models.ts
+++ b/packages/trpc/src/models.ts
@@ -1,271 +1,45 @@
+import type { z } from "zod";
+import type * as models from "./model-schemas";
+import type * as shared from "./schema";
+
+/** Public DTOs are inferred from the same schemas used for output validation. */
 export interface Page<T> {
   data: T[];
-  meta: { total: number; limit: number; offset: number };
+  meta: z.output<typeof models.paginationMetaSchema>;
 }
 
-export interface User {
-  id: string;
-  username: string;
-  email: string;
-  is_superuser?: boolean;
-  video_count: number;
-  max_video_upload_size_mb: number;
-  used_storage_bytes?: number;
-  storage_limit_bytes?: number | null;
-  used_processing_seconds?: number;
-  processing_limit_seconds?: number | null;
-  used_ai_answers?: number;
-  ai_answers_limit?: number | null;
-  is_over_quota?: boolean;
-  plan_code?: "free" | "basic" | "pro";
-  subscription_status?: string | null;
-  quota_source?: "plan" | "admin";
-}
-
-export interface AdminUser {
-  id: string;
-  username: string;
-  email: string;
-  is_active: boolean;
-  is_staff: boolean;
-  is_superuser: boolean;
-  max_video_upload_size_mb: number;
-  storage_limit_gb: number | null;
-  processing_limit_minutes: number | null;
-  ai_answers_limit: number | null;
-  used_storage_bytes: number;
-  used_processing_seconds: number;
-  used_ai_answers: number;
-  usage_period_start: string | null;
-  is_over_quota: boolean;
-  plan_code?: string;
-  quota_source?: "plan" | "admin";
-}
-
-export interface BillingPlan {
-  code: "free" | "basic" | "pro";
-  interval: "month" | "year" | null;
-  lookup_key: string | null;
-  amount_yen: number;
-  currency: "jpy";
-  entitlements: {
-    max_video_upload_size_mb: number;
-    storage_limit_gb: number;
-    processing_limit_minutes: number;
-    ai_answers_limit: number;
-  };
-}
-
-export interface Citation {
-  id: number;
-  video_id: number;
-  title: string;
-  start_time: string | null;
-  end_time: string | null;
-}
-
-export interface ChatMessage {
-  role: "user" | "assistant";
-  content: string;
-  citations?: Citation[];
-  chat_log_id?: number;
-  feedback?: "good" | "bad" | null;
-}
-
-export interface ChatHistoryItem {
-  id: number;
-  course: number;
-  asked_by: { user_id: string; username: string; email: string } | null;
-  question: string;
-  answer: string;
-  citations?: Citation[];
-  is_shared_origin: boolean;
-  feedback?: "good" | "bad" | null;
-  created_at: string;
-  evaluation?: ChatLogEvaluation;
-}
-
-export interface ChatAnalytics {
-  summary: {
-    total_questions: number;
-    date_range: { first?: string | null; last?: string | null };
-  };
-  time_series: { date: string; count: number }[];
-  feedback: { good: number; bad: number; none: number };
-}
-
-export interface EvaluationSummary {
-  course_id: number;
-  evaluated_count: number;
-  avg_faithfulness: number | null;
-  avg_answer_relevancy: number | null;
-  avg_context_precision: number | null;
-}
-
-export interface ChatLogEvaluation {
-  chat_log_id: number;
-  status: "pending" | "completed" | "failed";
-  faithfulness: number | null;
-  answer_relevancy: number | null;
-  context_precision: number | null;
-  error_message: string | null;
-  evaluated_at: string | null;
-}
-
-export type VideoStatus = z.infer<typeof videoStatusSchema>;
-export type VideoSourceType = z.infer<typeof videoSourceTypeSchema>;
-export type VideoTag = z.infer<typeof videoTagSchema>;
-export type VideoListItem = z.infer<typeof videoListItemSchema>;
-export type Video = z.infer<typeof videoSchema>;
-
-export interface VideoStatusCounts {
-  total: number;
-  completed: number;
-  pending: number;
-  processing: number;
-  indexing: number;
-  error: number;
-  uploading: number;
-}
-
-export interface UploadRequestResponse {
-  video: Video;
-  upload_url: string;
-}
-
-export type VideoInCourse = Omit<VideoListItem, "tags"> & { order: number };
-
-export interface CourseListItem {
-  id: number;
-  name: string;
-  description: string;
-  display_order: number;
-  created_at: string;
-  video_count: number;
-  access_role: "owner" | "member";
-}
-
-export interface Course extends Omit<CourseListItem, "access_role"> {
-  updated_at?: string;
-  videos?: VideoInCourse[];
-  share_slug?: string | null;
-  access_role?: "owner" | "member" | "public";
-}
-
-export type CourseInvitationStatus = "pending" | "accepted" | "declined" | "expired" | "revoked";
-export type CourseInvitationDeliveryStatus = "queued" | "sent" | "failed";
-
-export interface CourseInviteRecipientResult {
-  email: string;
-  status: "queued" | "already_member" | "already_invited" | "invalid" | "duplicate";
-  invitation_id?: number;
-}
-
-export interface CourseInvitationListItem {
-  id: number;
-  email: string;
-  status: CourseInvitationStatus;
-  delivery_status: CourseInvitationDeliveryStatus;
-  expires_at: string;
-  created_at: string;
-  last_sent_at: string | null;
-  send_attempts: number;
-}
-
-export interface CourseUserMember {
-  user_id: string;
-  username: string;
-  email: string;
-  joined_at: string;
-}
-
-export interface CourseParticipants {
-  invitations: CourseInvitationListItem[];
-  members: CourseUserMember[];
-}
-
-export interface CourseInvitationPreview {
-  course_id: number;
-  course_name: string;
-  inviter_name: string;
-  email_hint: string;
-  status: CourseInvitationStatus;
-  expires_at: string;
-}
-
-export interface Tag {
-  id: number;
-  name: string;
-  color: string;
-  created_at: string;
-  video_count: number;
-}
-
-export interface TagDetail extends Tag {
-  videos?: VideoListItem[];
-}
-
-export interface PlogWaypoint {
-  start_sec?: number;
-  end_sec?: number;
-  start_time?: string;
-  end_time?: string;
-  label?: string;
-}
-
-export interface PlogConcept {
-  id: number;
-  label: string;
-  node_type: string;
-  intro_sec: number;
-  source_quote: string;
-  opening_question: string;
-  hint_ladder: string[];
-  misconceptions: string[];
-  canonical_order: string[];
-  worked_examples: string[];
-  waypoints: PlogWaypoint[];
-  hint_count: number;
-  waypoint_count: number;
-}
-
-export interface PlogEdge {
-  id: number;
-  source_id: number;
-  source_label: string;
-  target_id: number;
-  target_label: string;
-  edge_type: string;
-  quote: string;
-}
-
-export interface PlogGraph {
-  video_id: number;
-  build_status: string;
-  input_tokens: number;
-  output_tokens: number;
-  error_message: string;
-  summary_node_count: number;
-  concepts: PlogConcept[];
-  edges: PlogEdge[];
-}
-
-export interface PlogLearnerState {
-  concept_id: number;
-  label: string;
-  reached: boolean;
-  hint_index: number;
-  last_grade: string;
-  active: boolean;
-}
-
+export type User = z.output<typeof models.userSchema>;
+export type AdminUser = z.output<typeof models.adminUserSchema>;
+export type BillingPlan = z.output<typeof models.billingPlanSchema>;
+export type Citation = z.output<typeof models.citationSchema>;
+export type ChatMessage = z.output<typeof models.chatMessageSchema>;
+export type ChatHistoryItem = z.output<typeof models.chatHistoryItemSchema>;
+export type ChatAnalytics = z.output<typeof models.chatAnalyticsSchema>;
+export type EvaluationSummary = z.output<typeof models.evaluationSummarySchema>;
+export type ChatLogEvaluation = z.output<typeof models.chatLogEvaluationSchema>;
+export type VideoStatus = z.output<typeof shared.videoStatusSchema>;
+export type VideoSourceType = z.output<typeof shared.videoSourceTypeSchema>;
+export type VideoTag = z.output<typeof shared.videoTagSchema>;
+export type VideoListItem = z.output<typeof shared.videoListItemSchema>;
+export type Video = z.output<typeof shared.videoSchema>;
+export type VideoStatusCounts = z.output<typeof models.videoStatusCountsSchema>;
+export type UploadRequestResponse = z.output<typeof models.uploadRequestResponseSchema>;
+export type VideoInCourse = z.output<typeof models.videoInCourseSchema>;
+export type CourseListItem = z.output<typeof models.courseListItemSchema>;
+export type Course = z.output<typeof models.courseSchema>;
+export type CourseInvitationStatus = z.output<typeof models.courseInvitationStatusSchema>;
+export type CourseInvitationDeliveryStatus = z.output<typeof models.courseInvitationDeliveryStatusSchema>;
+export type CourseInviteRecipientResult = z.output<typeof models.courseInviteRecipientResultSchema>;
+export type CourseInvitationListItem = z.output<typeof models.courseInvitationListItemSchema>;
+export type CourseUserMember = z.output<typeof models.courseUserMemberSchema>;
+export type CourseParticipants = z.output<typeof models.courseParticipantsSchema>;
+export type CourseInvitationPreview = z.output<typeof models.courseInvitationPreviewSchema>;
+export type Tag = z.output<typeof models.tagSchema>;
+export type TagDetail = z.output<typeof models.tagDetailSchema>;
+export type PlogWaypoint = z.output<typeof models.plogWaypointSchema>;
+export type PlogConcept = z.output<typeof models.plogConceptSchema>;
+export type PlogEdge = z.output<typeof models.plogEdgeSchema>;
+export type PlogGraph = z.output<typeof models.plogGraphSchema>;
+export type PlogLearnerState = z.output<typeof models.plogLearnerStateSchema>;
 export type TagPage = Page<Tag>;
 export type CoursePage = Page<CourseListItem>;
-import type { z } from "zod";
-import type {
-  videoListItemSchema,
-  videoSchema,
-  videoSourceTypeSchema,
-  videoStatusSchema,
-  videoTagSchema,
-} from "./schema";

--- a/packages/trpc/src/outputs.ts
+++ b/packages/trpc/src/outputs.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+import type { inputSchemas } from "./inputs";
+import * as models from "./model-schemas";
+import { videoListItemSchema, videoSchema } from "./schema";
+
+export const successSchema = z.object({ success: z.literal(true) });
+const jobSchema = z.object({ job_id: z.string() });
+const urlSchema = z.object({ url: z.string() });
+const messageSchema = z.object({ message: z.string() });
+const addedItemsSchema = messageSchema.extend({ added_count: z.number(), skipped_count: z.number() });
+const deletedItemSchema = z.object({ deleted: z.literal(true), id: z.number() });
+
+/** Runtime output validation and handler output types share this definition. */
+export const outputSchemas = {
+  "account.me": models.userSchema,
+  "account.searchApiKeyStatus": z.object({ has_api_key: z.boolean() }),
+  "account.saveSearchApiKey": successSchema,
+  "account.deleteSearchApiKey": successSchema,
+
+  "admin.listUsers": models.pageSchema(models.adminUserSchema),
+  "admin.getUser": models.adminUserSchema,
+  "admin.patchQuota": models.adminUserSchema,
+  "admin.patchUsage": models.adminUserSchema,
+  "admin.patchFlags": models.adminUserSchema,
+  "admin.deleteUser": jobSchema,
+  "admin.reindexAll": jobSchema,
+
+  "billing.plans": z.array(models.billingPlanSchema),
+  "billing.checkout": urlSchema,
+  "billing.portal": urlSchema,
+
+  "chat.send": models.chatMessageSchema,
+  "chat.feedback": z.object({ chat_log_id: z.number(), feedback: models.chatFeedbackSchema }),
+  "chat.history": models.pageSchema(models.chatHistoryItemSchema),
+  "chat.resetHistory": successSchema,
+  "chat.analytics": models.chatAnalyticsSchema,
+
+  "evaluation.summary": models.evaluationSummarySchema,
+  "evaluation.logs": models.pageSchema(models.chatLogEvaluationSchema),
+
+  "videos.list": models.pageSchema(videoListItemSchema),
+  "videos.statusCounts": models.videoStatusCountsSchema,
+  "videos.get": videoSchema,
+  "videos.requestUpload": models.uploadRequestResponseSchema,
+  "videos.confirmUpload": videoSchema,
+  "videos.createYoutube": videoSchema,
+  "videos.update": videoSchema,
+  "videos.replace": videoSchema,
+  "videos.delete": successSchema,
+
+  "courses.list": models.pageSchema(models.courseListItemSchema),
+  "courses.get": models.courseSchema,
+  "courses.shared": models.courseSchema,
+  "courses.create": models.courseListItemSchema,
+  "courses.update": models.courseSchema,
+  "courses.replace": models.courseSchema,
+  "courses.delete": successSchema,
+  "courses.reorder": z.object({ courseIds: z.array(z.number()) }),
+  "courses.createShare": messageSchema.extend({ share_slug: z.string() }),
+  "courses.deleteShare": successSchema,
+
+  "courseMemberships.invite": z.object({ results: z.array(models.courseInviteRecipientResultSchema) }),
+  "courseMemberships.participants": models.courseParticipantsSchema,
+  "courseMemberships.preview": models.courseInvitationPreviewSchema,
+  "courseMemberships.accept": z.object({ course_id: z.number(), status: z.literal("accepted") }),
+  "courseMemberships.decline": z.object({ status: z.literal("declined") }),
+  "courseMemberships.resend": z.object({ delivery_status: models.courseInvitationDeliveryStatusSchema }),
+  "courseMemberships.revoke": successSchema,
+  "courseMemberships.removeMember": successSchema,
+  "courseMemberships.leave": successSchema,
+
+  "memberships.addTags": addedItemsSchema,
+  "memberships.removeTag": messageSchema,
+  "memberships.reorderVideos": messageSchema,
+  "memberships.addVideos": addedItemsSchema,
+  "memberships.addVideo": messageSchema.extend({ id: z.number(), reused: z.boolean() }),
+  "memberships.removeVideo": successSchema,
+
+  "tags.list": models.pageSchema(models.tagSchema),
+  "tags.get": models.tagDetailSchema,
+  "tags.create": models.tagSchema,
+  "tags.update": models.tagSchema,
+  "tags.replace": models.tagSchema,
+  "tags.delete": successSchema,
+
+  "plog.graph": models.plogGraphSchema,
+  "plog.learnerState": z.object({ states: z.array(models.plogLearnerStateSchema) }),
+  "plog.resetLearnerState": z.object({ deleted: z.number() }),
+  "plog.rebuild": z.object({ video_id: z.number(), status: z.string(), job_id: z.number() }),
+  "plog.createConcept": models.plogConceptSchema,
+  "plog.updateConcept": models.plogConceptSchema,
+  "plog.deleteConcept": deletedItemSchema,
+  "plog.mergeConcepts": models.plogConceptSchema,
+  "plog.updateLearningObject": models.plogConceptSchema,
+  "plog.createEdge": models.plogEdgeSchema,
+  "plog.updateEdge": models.plogEdgeSchema,
+  "plog.deleteEdge": deletedItemSchema,
+} satisfies Record<keyof typeof inputSchemas, z.ZodType>;

--- a/packages/trpc/src/routers/account.ts
+++ b/packages/trpc/src/routers/account.ts
@@ -1,15 +1,19 @@
 import { protectedProcedure, t } from "../init";
 import { accountInputSchemas } from "../inputs/account";
+import { outputSchemas } from "../outputs";
 
 export const accountRouter = t.router({
-  me: protectedProcedure.query(({ ctx }) => ctx.call("account.me", undefined)),
-  searchApiKeyStatus: protectedProcedure.query(({ ctx }) =>
-    ctx.call("account.searchApiKeyStatus", undefined),
-  ),
+  me: protectedProcedure
+    .output(outputSchemas["account.me"])
+    .query(({ ctx }) => ctx.call("account.me", undefined)),
+  searchApiKeyStatus: protectedProcedure
+    .output(outputSchemas["account.searchApiKeyStatus"])
+    .query(({ ctx }) => ctx.call("account.searchApiKeyStatus", undefined)),
   saveSearchApiKey: protectedProcedure
     .input(accountInputSchemas["account.saveSearchApiKey"])
+    .output(outputSchemas["account.saveSearchApiKey"])
     .mutation(({ ctx, input }) => ctx.call("account.saveSearchApiKey", input)),
-  deleteSearchApiKey: protectedProcedure.mutation(({ ctx }) =>
-    ctx.call("account.deleteSearchApiKey", undefined),
-  ),
+  deleteSearchApiKey: protectedProcedure
+    .output(outputSchemas["account.deleteSearchApiKey"])
+    .mutation(({ ctx }) => ctx.call("account.deleteSearchApiKey", undefined)),
 });

--- a/packages/trpc/src/routers/admin.ts
+++ b/packages/trpc/src/routers/admin.ts
@@ -1,26 +1,33 @@
 import { adminProcedure, t } from "../init";
 import { adminInputSchemas } from "../inputs/admin";
+import { outputSchemas } from "../outputs";
 
 export const adminRouter = t.router({
   listUsers: adminProcedure
     .input(adminInputSchemas["admin.listUsers"])
+    .output(outputSchemas["admin.listUsers"])
     .query(({ ctx, input }) => ctx.call("admin.listUsers", input)),
-  getUser: adminProcedure.input(adminInputSchemas["admin.getUser"]).query(({ ctx, input }) =>
-    ctx.call("admin.getUser", input),
-  ),
+  getUser: adminProcedure
+    .input(adminInputSchemas["admin.getUser"])
+    .output(outputSchemas["admin.getUser"])
+    .query(({ ctx, input }) => ctx.call("admin.getUser", input)),
   patchQuota: adminProcedure
     .input(adminInputSchemas["admin.patchQuota"])
+    .output(outputSchemas["admin.patchQuota"])
     .mutation(({ ctx, input }) => ctx.call("admin.patchQuota", input)),
   patchUsage: adminProcedure
     .input(adminInputSchemas["admin.patchUsage"])
+    .output(outputSchemas["admin.patchUsage"])
     .mutation(({ ctx, input }) => ctx.call("admin.patchUsage", input)),
   patchFlags: adminProcedure
     .input(adminInputSchemas["admin.patchFlags"])
+    .output(outputSchemas["admin.patchFlags"])
     .mutation(({ ctx, input }) => ctx.call("admin.patchFlags", input)),
-  deleteUser: adminProcedure.input(adminInputSchemas["admin.deleteUser"]).mutation(({ ctx, input }) =>
-    ctx.call("admin.deleteUser", input),
-  ),
-  reindexAll: adminProcedure.mutation(({ ctx }) =>
-    ctx.call("admin.reindexAll", undefined),
-  ),
+  deleteUser: adminProcedure
+    .input(adminInputSchemas["admin.deleteUser"])
+    .output(outputSchemas["admin.deleteUser"])
+    .mutation(({ ctx, input }) => ctx.call("admin.deleteUser", input)),
+  reindexAll: adminProcedure
+    .output(outputSchemas["admin.reindexAll"])
+    .mutation(({ ctx }) => ctx.call("admin.reindexAll", undefined)),
 });

--- a/packages/trpc/src/routers/billing.ts
+++ b/packages/trpc/src/routers/billing.ts
@@ -1,12 +1,17 @@
 import { protectedProcedure, publicProcedure, t } from "../init";
 import { billingInputSchemas } from "../inputs/billing";
+import { outputSchemas } from "../outputs";
 
 export const billingRouter = t.router({
-  plans: publicProcedure.query(({ ctx }) => ctx.call("billing.plans", undefined)),
+  plans: publicProcedure
+    .output(outputSchemas["billing.plans"])
+    .query(({ ctx }) => ctx.call("billing.plans", undefined)),
   checkout: protectedProcedure
     .input(billingInputSchemas["billing.checkout"])
+    .output(outputSchemas["billing.checkout"])
     .mutation(({ ctx, input }) => ctx.call("billing.checkout", input)),
   portal: protectedProcedure
     .input(billingInputSchemas["billing.portal"])
+    .output(outputSchemas["billing.portal"])
     .mutation(({ ctx, input }) => ctx.call("billing.portal", input)),
 });

--- a/packages/trpc/src/routers/chat.ts
+++ b/packages/trpc/src/routers/chat.ts
@@ -1,29 +1,37 @@
 import { protectedProcedure, publicProcedure, t } from "../init";
 import { chatInputSchemas } from "../inputs/chat";
+import { outputSchemas } from "../outputs";
 
 export const chatRouter = t.router({
   send: publicProcedure
     .input(chatInputSchemas["chat.send"])
+    .output(outputSchemas["chat.send"])
     .mutation(({ ctx, input }) => ctx.call("chat.send", input)),
   feedback: publicProcedure
     .input(chatInputSchemas["chat.feedback"])
+    .output(outputSchemas["chat.feedback"])
     .mutation(({ ctx, input }) => ctx.call("chat.feedback", input)),
   history: protectedProcedure
     .input(chatInputSchemas["chat.history"])
+    .output(outputSchemas["chat.history"])
     .query(({ ctx, input }) => ctx.call("chat.history", input)),
   resetHistory: protectedProcedure
     .input(chatInputSchemas["chat.resetHistory"])
+    .output(outputSchemas["chat.resetHistory"])
     .mutation(({ ctx, input }) => ctx.call("chat.resetHistory", input)),
   analytics: protectedProcedure
     .input(chatInputSchemas["chat.analytics"])
+    .output(outputSchemas["chat.analytics"])
     .query(({ ctx, input }) => ctx.call("chat.analytics", input)),
 });
 
 export const evaluationRouter = t.router({
   summary: protectedProcedure
     .input(chatInputSchemas["evaluation.summary"])
+    .output(outputSchemas["evaluation.summary"])
     .query(({ ctx, input }) => ctx.call("evaluation.summary", input)),
   logs: protectedProcedure
     .input(chatInputSchemas["evaluation.logs"])
+    .output(outputSchemas["evaluation.logs"])
     .query(({ ctx, input }) => ctx.call("evaluation.logs", input)),
 });

--- a/packages/trpc/src/routers/courses.ts
+++ b/packages/trpc/src/routers/courses.ts
@@ -1,86 +1,112 @@
 import { protectedProcedure, publicProcedure, t } from "../init";
 import { coursesInputSchemas } from "../inputs/courses";
+import { outputSchemas } from "../outputs";
 
 export const coursesRouter = t.router({
   list: protectedProcedure
     .input(coursesInputSchemas["courses.list"])
+    .output(outputSchemas["courses.list"])
     .query(({ ctx, input }) => ctx.call("courses.list", input)),
-  get: protectedProcedure.input(coursesInputSchemas["courses.get"]).query(({ ctx, input }) =>
-    ctx.call("courses.get", input),
-  ),
+  get: protectedProcedure
+    .input(coursesInputSchemas["courses.get"])
+    .output(outputSchemas["courses.get"])
+    .query(({ ctx, input }) => ctx.call("courses.get", input)),
   shared: publicProcedure
     .input(coursesInputSchemas["courses.shared"])
+    .output(outputSchemas["courses.shared"])
     .query(({ ctx, input }) => ctx.call("courses.shared", input)),
   create: protectedProcedure
     .input(coursesInputSchemas["courses.create"])
+    .output(outputSchemas["courses.create"])
     .mutation(({ ctx, input }) => ctx.call("courses.create", input)),
   update: protectedProcedure
     .input(coursesInputSchemas["courses.update"])
+    .output(outputSchemas["courses.update"])
     .mutation(({ ctx, input }) => ctx.call("courses.update", input)),
   replace: protectedProcedure
     .input(coursesInputSchemas["courses.replace"])
+    .output(outputSchemas["courses.replace"])
     .mutation(({ ctx, input }) => ctx.call("courses.replace", input)),
-  delete: protectedProcedure.input(coursesInputSchemas["courses.delete"]).mutation(({ ctx, input }) =>
-    ctx.call("courses.delete", input),
-  ),
+  delete: protectedProcedure
+    .input(coursesInputSchemas["courses.delete"])
+    .output(outputSchemas["courses.delete"])
+    .mutation(({ ctx, input }) => ctx.call("courses.delete", input)),
   reorder: protectedProcedure
     .input(coursesInputSchemas["courses.reorder"])
+    .output(outputSchemas["courses.reorder"])
     .mutation(({ ctx, input }) => ctx.call("courses.reorder", input)),
   createShare: protectedProcedure
     .input(coursesInputSchemas["courses.createShare"])
+    .output(outputSchemas["courses.createShare"])
     .mutation(({ ctx, input }) => ctx.call("courses.createShare", input)),
-  deleteShare: protectedProcedure.input(coursesInputSchemas["courses.deleteShare"]).mutation(({ ctx, input }) =>
-    ctx.call("courses.deleteShare", input),
-  ),
+  deleteShare: protectedProcedure
+    .input(coursesInputSchemas["courses.deleteShare"])
+    .output(outputSchemas["courses.deleteShare"])
+    .mutation(({ ctx, input }) => ctx.call("courses.deleteShare", input)),
 });
 
 export const courseMembershipsRouter = t.router({
   invite: protectedProcedure
     .input(coursesInputSchemas["courseMemberships.invite"])
+    .output(outputSchemas["courseMemberships.invite"])
     .mutation(({ ctx, input }) => ctx.call("courseMemberships.invite", input)),
   participants: protectedProcedure
     .input(coursesInputSchemas["courseMemberships.participants"])
+    .output(outputSchemas["courseMemberships.participants"])
     .query(({ ctx, input }) => ctx.call("courseMemberships.participants", input)),
   preview: publicProcedure
     .input(coursesInputSchemas["courseMemberships.preview"])
+    .output(outputSchemas["courseMemberships.preview"])
     .query(({ ctx, input }) => ctx.call("courseMemberships.preview", input)),
   accept: protectedProcedure
     .input(coursesInputSchemas["courseMemberships.accept"])
+    .output(outputSchemas["courseMemberships.accept"])
     .mutation(({ ctx, input }) => ctx.call("courseMemberships.accept", input)),
   decline: protectedProcedure
     .input(coursesInputSchemas["courseMemberships.decline"])
+    .output(outputSchemas["courseMemberships.decline"])
     .mutation(({ ctx, input }) => ctx.call("courseMemberships.decline", input)),
   resend: protectedProcedure
     .input(coursesInputSchemas["courseMemberships.resend"])
+    .output(outputSchemas["courseMemberships.resend"])
     .mutation(({ ctx, input }) => ctx.call("courseMemberships.resend", input)),
   revoke: protectedProcedure
     .input(coursesInputSchemas["courseMemberships.revoke"])
+    .output(outputSchemas["courseMemberships.revoke"])
     .mutation(({ ctx, input }) => ctx.call("courseMemberships.revoke", input)),
   removeMember: protectedProcedure
     .input(coursesInputSchemas["courseMemberships.removeMember"])
+    .output(outputSchemas["courseMemberships.removeMember"])
     .mutation(({ ctx, input }) => ctx.call("courseMemberships.removeMember", input)),
-  leave: protectedProcedure.input(coursesInputSchemas["courseMemberships.leave"]).mutation(({ ctx, input }) =>
-    ctx.call("courseMemberships.leave", input),
-  ),
+  leave: protectedProcedure
+    .input(coursesInputSchemas["courseMemberships.leave"])
+    .output(outputSchemas["courseMemberships.leave"])
+    .mutation(({ ctx, input }) => ctx.call("courseMemberships.leave", input)),
 });
 
 export const membershipsRouter = t.router({
   addTags: protectedProcedure
     .input(coursesInputSchemas["memberships.addTags"])
+    .output(outputSchemas["memberships.addTags"])
     .mutation(({ ctx, input }) => ctx.call("memberships.addTags", input)),
   removeTag: protectedProcedure
     .input(coursesInputSchemas["memberships.removeTag"])
+    .output(outputSchemas["memberships.removeTag"])
     .mutation(({ ctx, input }) => ctx.call("memberships.removeTag", input)),
   reorderVideos: protectedProcedure
     .input(coursesInputSchemas["memberships.reorderVideos"])
+    .output(outputSchemas["memberships.reorderVideos"])
     .mutation(({ ctx, input }) => ctx.call("memberships.reorderVideos", input)),
   addVideos: protectedProcedure
     .input(coursesInputSchemas["memberships.addVideos"])
+    .output(outputSchemas["memberships.addVideos"])
     .mutation(({ ctx, input }) => ctx.call("memberships.addVideos", input)),
   addVideo: protectedProcedure
     .input(coursesInputSchemas["memberships.addVideo"])
+    .output(outputSchemas["memberships.addVideo"])
     .mutation(({ ctx, input }) => ctx.call("memberships.addVideo", input)),
   removeVideo: protectedProcedure
     .input(coursesInputSchemas["memberships.removeVideo"])
+    .output(outputSchemas["memberships.removeVideo"])
     .mutation(({ ctx, input }) => ctx.call("memberships.removeVideo", input)),
 });

--- a/packages/trpc/src/routers/plog.ts
+++ b/packages/trpc/src/routers/plog.ts
@@ -1,41 +1,54 @@
 import { protectedProcedure, t } from "../init";
 import { plogInputSchemas } from "../inputs/plog";
+import { outputSchemas } from "../outputs";
 
 export const plogRouter = t.router({
-  graph: protectedProcedure.input(plogInputSchemas["plog.graph"]).query(({ ctx, input }) =>
-    ctx.call("plog.graph", input),
-  ),
-  learnerState: protectedProcedure.input(plogInputSchemas["plog.learnerState"]).query(({ ctx, input }) =>
-    ctx.call("plog.learnerState", input),
-  ),
-  resetLearnerState: protectedProcedure.input(plogInputSchemas["plog.resetLearnerState"]).mutation(({ ctx, input }) =>
-    ctx.call("plog.resetLearnerState", input),
-  ),
-  rebuild: protectedProcedure.input(plogInputSchemas["plog.rebuild"]).mutation(({ ctx, input }) =>
-    ctx.call("plog.rebuild", input),
-  ),
+  graph: protectedProcedure
+    .input(plogInputSchemas["plog.graph"])
+    .output(outputSchemas["plog.graph"])
+    .query(({ ctx, input }) => ctx.call("plog.graph", input)),
+  learnerState: protectedProcedure
+    .input(plogInputSchemas["plog.learnerState"])
+    .output(outputSchemas["plog.learnerState"])
+    .query(({ ctx, input }) => ctx.call("plog.learnerState", input)),
+  resetLearnerState: protectedProcedure
+    .input(plogInputSchemas["plog.resetLearnerState"])
+    .output(outputSchemas["plog.resetLearnerState"])
+    .mutation(({ ctx, input }) => ctx.call("plog.resetLearnerState", input)),
+  rebuild: protectedProcedure
+    .input(plogInputSchemas["plog.rebuild"])
+    .output(outputSchemas["plog.rebuild"])
+    .mutation(({ ctx, input }) => ctx.call("plog.rebuild", input)),
   createConcept: protectedProcedure
     .input(plogInputSchemas["plog.createConcept"])
+    .output(outputSchemas["plog.createConcept"])
     .mutation(({ ctx, input }) => ctx.call("plog.createConcept", input)),
   updateConcept: protectedProcedure
     .input(plogInputSchemas["plog.updateConcept"])
+    .output(outputSchemas["plog.updateConcept"])
     .mutation(({ ctx, input }) => ctx.call("plog.updateConcept", input)),
-  deleteConcept: protectedProcedure.input(plogInputSchemas["plog.deleteConcept"]).mutation(({ ctx, input }) =>
-    ctx.call("plog.deleteConcept", input),
-  ),
+  deleteConcept: protectedProcedure
+    .input(plogInputSchemas["plog.deleteConcept"])
+    .output(outputSchemas["plog.deleteConcept"])
+    .mutation(({ ctx, input }) => ctx.call("plog.deleteConcept", input)),
   mergeConcepts: protectedProcedure
     .input(plogInputSchemas["plog.mergeConcepts"])
+    .output(outputSchemas["plog.mergeConcepts"])
     .mutation(({ ctx, input }) => ctx.call("plog.mergeConcepts", input)),
   updateLearningObject: protectedProcedure
     .input(plogInputSchemas["plog.updateLearningObject"])
+    .output(outputSchemas["plog.updateLearningObject"])
     .mutation(({ ctx, input }) => ctx.call("plog.updateLearningObject", input)),
   createEdge: protectedProcedure
     .input(plogInputSchemas["plog.createEdge"])
+    .output(outputSchemas["plog.createEdge"])
     .mutation(({ ctx, input }) => ctx.call("plog.createEdge", input)),
   updateEdge: protectedProcedure
     .input(plogInputSchemas["plog.updateEdge"])
+    .output(outputSchemas["plog.updateEdge"])
     .mutation(({ ctx, input }) => ctx.call("plog.updateEdge", input)),
-  deleteEdge: protectedProcedure.input(plogInputSchemas["plog.deleteEdge"]).mutation(({ ctx, input }) =>
-    ctx.call("plog.deleteEdge", input),
-  ),
+  deleteEdge: protectedProcedure
+    .input(plogInputSchemas["plog.deleteEdge"])
+    .output(outputSchemas["plog.deleteEdge"])
+    .mutation(({ ctx, input }) => ctx.call("plog.deleteEdge", input)),
 });

--- a/packages/trpc/src/routers/tags.ts
+++ b/packages/trpc/src/routers/tags.ts
@@ -1,23 +1,30 @@
 import { protectedProcedure, t } from "../init";
 import { tagsInputSchemas } from "../inputs/tags";
+import { outputSchemas } from "../outputs";
 
 export const tagsRouter = t.router({
   list: protectedProcedure
     .input(tagsInputSchemas["tags.list"])
+    .output(outputSchemas["tags.list"])
     .query(({ ctx, input }) => ctx.call("tags.list", input)),
-  get: protectedProcedure.input(tagsInputSchemas["tags.get"]).query(({ ctx, input }) =>
-    ctx.call("tags.get", input),
-  ),
+  get: protectedProcedure
+    .input(tagsInputSchemas["tags.get"])
+    .output(outputSchemas["tags.get"])
+    .query(({ ctx, input }) => ctx.call("tags.get", input)),
   create: protectedProcedure
     .input(tagsInputSchemas["tags.create"])
+    .output(outputSchemas["tags.create"])
     .mutation(({ ctx, input }) => ctx.call("tags.create", input)),
   update: protectedProcedure
     .input(tagsInputSchemas["tags.update"])
+    .output(outputSchemas["tags.update"])
     .mutation(({ ctx, input }) => ctx.call("tags.update", input)),
   replace: protectedProcedure
     .input(tagsInputSchemas["tags.replace"])
+    .output(outputSchemas["tags.replace"])
     .mutation(({ ctx, input }) => ctx.call("tags.replace", input)),
-  delete: protectedProcedure.input(tagsInputSchemas["tags.delete"]).mutation(({ ctx, input }) =>
-    ctx.call("tags.delete", input),
-  ),
+  delete: protectedProcedure
+    .input(tagsInputSchemas["tags.delete"])
+    .output(outputSchemas["tags.delete"])
+    .mutation(({ ctx, input }) => ctx.call("tags.delete", input)),
 });

--- a/packages/trpc/src/routers/videos.ts
+++ b/packages/trpc/src/routers/videos.ts
@@ -1,32 +1,41 @@
 import { protectedProcedure, t } from "../init";
 import { videosInputSchemas } from "../inputs/videos";
+import { outputSchemas } from "../outputs";
 
 export const videosRouter = t.router({
   list: protectedProcedure
     .input(videosInputSchemas["videos.list"])
+    .output(outputSchemas["videos.list"])
     .query(({ ctx, input }) => ctx.call("videos.list", input)),
-  statusCounts: protectedProcedure.query(({ ctx }) =>
-    ctx.call("videos.statusCounts", undefined),
-  ),
-  get: protectedProcedure.input(videosInputSchemas["videos.get"]).query(({ ctx, input }) =>
-    ctx.call("videos.get", input),
-  ),
+  statusCounts: protectedProcedure
+    .output(outputSchemas["videos.statusCounts"])
+    .query(({ ctx }) => ctx.call("videos.statusCounts", undefined)),
+  get: protectedProcedure
+    .input(videosInputSchemas["videos.get"])
+    .output(outputSchemas["videos.get"])
+    .query(({ ctx, input }) => ctx.call("videos.get", input)),
   requestUpload: protectedProcedure
     .input(videosInputSchemas["videos.requestUpload"])
+    .output(outputSchemas["videos.requestUpload"])
     .mutation(({ ctx, input }) => ctx.call("videos.requestUpload", input)),
-  confirmUpload: protectedProcedure.input(videosInputSchemas["videos.confirmUpload"]).mutation(({ ctx, input }) =>
-    ctx.call("videos.confirmUpload", input),
-  ),
+  confirmUpload: protectedProcedure
+    .input(videosInputSchemas["videos.confirmUpload"])
+    .output(outputSchemas["videos.confirmUpload"])
+    .mutation(({ ctx, input }) => ctx.call("videos.confirmUpload", input)),
   createYoutube: protectedProcedure
     .input(videosInputSchemas["videos.createYoutube"])
+    .output(outputSchemas["videos.createYoutube"])
     .mutation(({ ctx, input }) => ctx.call("videos.createYoutube", input)),
   update: protectedProcedure
     .input(videosInputSchemas["videos.update"])
+    .output(outputSchemas["videos.update"])
     .mutation(({ ctx, input }) => ctx.call("videos.update", input)),
   replace: protectedProcedure
     .input(videosInputSchemas["videos.replace"])
+    .output(outputSchemas["videos.replace"])
     .mutation(({ ctx, input }) => ctx.call("videos.replace", input)),
-  delete: protectedProcedure.input(videosInputSchemas["videos.delete"]).mutation(({ ctx, input }) =>
-    ctx.call("videos.delete", input),
-  ),
+  delete: protectedProcedure
+    .input(videosInputSchemas["videos.delete"])
+    .output(outputSchemas["videos.delete"])
+    .mutation(({ ctx, input }) => ctx.call("videos.delete", input)),
 });

--- a/packages/trpc/src/schema.ts
+++ b/packages/trpc/src/schema.ts
@@ -48,7 +48,8 @@ export const TAG_COLORS = [
   "purple",
 ] as const;
 
-export type TagColor = (typeof TAG_COLORS)[number];
+export const tagColorSchema = z.enum(TAG_COLORS);
+export type TagColor = z.infer<typeof tagColorSchema>;
 
 export const VIDEO_STATUSES = [
   "uploading",

--- a/packages/trpc/tsconfig.json
+++ b/packages/trpc/tsconfig.json
@@ -7,5 +7,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "type-tests/**/*.ts"]
 }

--- a/packages/trpc/type-tests/contracts.ts
+++ b/packages/trpc/type-tests/contracts.ts
@@ -1,0 +1,30 @@
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
+import type { ProcedureHandlers, RpcInputMap } from "../src/contracts";
+import type { Tag, TagPage } from "../src/models";
+import type { AppRouter } from "../src/router";
+import type { TagColor } from "../src/schema";
+
+type Inputs = inferRouterInputs<AppRouter>;
+type Outputs = inferRouterOutputs<AppRouter>;
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+export type ContractAssertions = [
+  Assert<Equal<Inputs["tags"]["create"]["color"], TagColor | undefined>>,
+  Assert<Equal<Inputs["tags"]["update"]["color"], TagColor | undefined>>,
+  Assert<Equal<Inputs["tags"]["replace"]["color"], TagColor>>,
+  Assert<Equal<RpcInputMap["tags.create"]["color"], TagColor>>,
+  Assert<Equal<Outputs["tags"]["create"], Tag>>,
+  Assert<Equal<Outputs["tags"]["list"], TagPage>>,
+];
+
+declare const createTag: (input: Inputs["tags"]["create"]) => void;
+createTag({ name: "Lecture" });
+createTag({ name: "Lecture", color: "light-blue" });
+// @ts-expect-error Arbitrary colors must not be accepted by the client contract.
+createTag({ name: "Lecture", color: "not-a-color" });
+
+declare const registerHandler: (handler: ProcedureHandlers["tags.create"]) => void;
+// @ts-expect-error A handler cannot return a tag with missing required fields.
+registerHandler(async () => ({ id: 1, name: "Lecture", color: "blue" }));


### PR DESCRIPTION
tRPC の戻り値は共有型によるコンパイル時のチェックだけだったため、全73操作に `.output()` を追加し、実行時にもレスポンスを検証します。共有DTOと `RpcOutputMap` は同じZodスキーマから導出し、型と検証ルールの二重管理を解消します。未定義フィールドはレスポンスから除去します。

タグの作成・更新・置換では、`string` だった色を共通パレットの列挙型に変更します。不正な色は型チェックとサービス到達前の入力検証で検出し、色の省略時の既定値と保存済みの旧hex色の読み取りは維持します。

出力検証の失敗は固定メッセージの `INTERNAL_SERVER_ERROR` とし、検証詳細をクライアントへ公開しません。既存のアプリケーションエラーコードは維持します。回帰テスト、CIの共有パッケージ型チェック、設計ドキュメントも更新しています。

検証結果:

- `npm run typecheck`: 3パッケージ成功。入力型とhandler出力型の回帰チェックを含む。
- `npm run test:unit --workspace @videoq/api`: 371件成功、9件スキップ。
- `npm run test:workers --workspace @videoq/api`: 5件成功。
- `npm run test --workspace @videoq/web`: 643件成功。
- 全73操作について、入出力契約のキーと出力検証の接続を確認。

実DBを使う9件は `QUOTA_TEST_DATABASE_URL` 未設定のためローカルでは未実行です。
