### PR TITLE
統合テストのpg.PoolにerrorリスナーをアタッチしてCIクラッシュを修正

### DIFF
--- a/apps/api/test/better-auth-1-7-migration.integration.test.ts
+++ b/apps/api/test/better-auth-1-7-migration.integration.test.ts
@@ -63,6 +63,11 @@ migrationDescribe("Better Auth 1.7 Drizzle migration", () => {
   it("invalidates old clients and accepts Better Auth DCR resource identifiers", async () => {
     const databaseName = `videoq_ba17_${crypto.randomUUID().replaceAll("-", "")}`;
     const adminPool = new Pool({ connectionString: databaseUrl });
+    // node-postgres requires a Pool error listener; without one, a background
+    // error on an idle client crashes the process instead of just being ignored.
+    // `DROP DATABASE ... WITH (FORCE)` in the `finally` block below races with our
+    // own `pool.end()` above it and can surface exactly such an error here.
+    adminPool.on("error", () => {});
     const adminDb = drizzle(adminPool);
     const targetUrl = new URL(databaseUrl!);
     targetUrl.pathname = `/${databaseName}`;
@@ -72,6 +77,7 @@ migrationDescribe("Better Auth 1.7 Drizzle migration", () => {
     try {
       await adminDb.execute(sql.raw(`CREATE DATABASE "${databaseName}"`));
       targetPool = new Pool({ connectionString: targetUrl.toString(), max: 1 });
+      targetPool.on("error", () => {});
       const db = drizzle(targetPool);
 
       // Minimal Better Auth 1.6 schema touched by migrations 0017-0020.

--- a/apps/api/test/drizzle-migration-chain.integration.test.ts
+++ b/apps/api/test/drizzle-migration-chain.integration.test.ts
@@ -19,6 +19,11 @@ migrationDescribe("Drizzle greenfield migration chain", () => {
   it("applies every migration to an empty PostgreSQL database", async () => {
     const databaseName = `videoq_drizzle_${crypto.randomUUID().replaceAll("-", "")}`;
     const adminPool = new Pool({ connectionString: databaseUrl });
+    // node-postgres requires a Pool error listener; without one, a background
+    // error on an idle client crashes the process instead of just being ignored.
+    // `DROP DATABASE ... WITH (FORCE)` in the `finally` block below races with our
+    // own `pool.end()` above it and can surface exactly such an error here.
+    adminPool.on("error", () => {});
     const adminDb = drizzle(adminPool);
     const targetUrl = new URL(databaseUrl!);
     targetUrl.pathname = `/${databaseName}`;
@@ -27,6 +32,7 @@ migrationDescribe("Drizzle greenfield migration chain", () => {
     try {
       await adminDb.execute(sql.raw(`CREATE DATABASE "${databaseName}"`));
       targetPool = new Pool({ connectionString: targetUrl.toString(), max: 1 });
+      targetPool.on("error", () => {});
       const db = drizzle(targetPool);
 
       await migrate(db, { migrationsFolder: migrationDirectory });


### PR DESCRIPTION
## Summary
- `better-auth-1-7-migration.integration.test.ts` / `drizzle-migration-chain.integration.test.ts` は per-test DB を作成し、`finally` で `pool.end()` → `DROP DATABASE ... WITH (FORCE)` の順に後始末している
- `pool.end()` と `DROP DATABASE ... WITH (FORCE)` の間でレースが起き、Postgres側からの切断エラーが `Pool` の `error` リスナー未設定のまま届くと、Vitestプロセス全体が `Uncaught Exception` でクラッシュする(全テストはpassしているのに落ちる)
- 両ファイルの `adminPool` / `targetPool` に `.on("error", () => {})` を追加してこの既知のnode-postgres挙動に対処

## Context
main CI (push) が2回、同一シグネチャ(`68 passed (68)` + `Uncaught Exception: terminating connection due to administrator command`)で断続的に失敗していた:
- https://github.com/yukiharada1228/videoq/actions/runs/34165866453 (PR #874)
- https://github.com/yukiharada1228/videoq/actions/runs/34697028953 (PR #875)

いずれもPR本体の変更とは無関係で、テストのDB後始末に起因する既存のフレークと判断。

## Test plan
- [x] `npm run typecheck --workspace @videoq/api`
- [ ] CIの `Hono (apps/api)` ジョブが `Unhandled Errors` なしで通ることを確認(ローカルにDockerが無く実DBでの再現ができないため、CIでの確認が必要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123vD16TtUYotPJ7accc8Jq